### PR TITLE
Fix UI test blockers: splitMode, config cache, and fast-fail health c…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 - `BaseUiTest` needs a fast-fail health check instead of a 2-minute blind timeout
 - CI/CD pipeline is not yet configured
 
+## Working with the Build
+
+When investigating Gradle plugin APIs or build tooling, prefer reading project docs and running `./gradlew` commands (`help --task`, `dependencies`, `buildEnvironment`, etc.) over exploring files outside the project directory (e.g., `.gradle/caches/`, `.intellijPlatform/`). Stay within the project boundary.
+
 ## Common Pitfalls
 
 - **JCEF not rendering:** Confirm `JBCefApp.isSupported()` returns true. Test with `about:blank` first.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 import org.jetbrains.intellij.platform.gradle.tasks.RunIdeTask
+import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware.SplitModeTarget
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "2.1.0"
@@ -107,6 +108,10 @@ tasks {
      */
     register<RunIdeTask>("runIdeForUiTests") {
         dependsOn(extractRobotPlugin)
+        notCompatibleWithConfigurationCache("dynamic plugin path resolution in doFirst")
+
+        splitMode.set(false)
+        splitModeTarget.set(SplitModeTarget.BACKEND)
 
         systemProperty("robot-server.port", "8082")
         systemProperty("ide.mac.message.dialogs.as.sheets", "false")
@@ -120,13 +125,14 @@ tasks {
         // the Welcome screen — IntelliJ accepts a project path as a program argument.
         args(rootDir.resolve("test-project").absolutePath)
 
+        // Resolve at configuration time to avoid capturing Gradle objects in doFirst
+        val robotPluginDir = layout.buildDirectory.dir("robot-server-plugin").map { dir ->
+            val base = dir.asFile
+            base.listFiles()?.firstOrNull { it.isDirectory } ?: base
+        }
+
         doFirst {
-            // Locate the extracted plugin directory (one subdir inside the zip root)
-            // and add it via -Dplugin.path so IntelliJ loads it alongside sandbox plugins.
-            val pluginBase = layout.buildDirectory.dir("robot-server-plugin").get().asFile
-            val pluginDir = pluginBase.listFiles()?.firstOrNull { it.isDirectory }
-                ?: pluginBase  // fallback: point to the base if structure is flat
-            jvmArgs("-Dplugin.path=${pluginDir.absolutePath}")
+            jvmArgs("-Dplugin.path=${robotPluginDir.get().absolutePath}")
         }
     }
 

--- a/docs/UI_tests/resolution-report.md
+++ b/docs/UI_tests/resolution-report.md
@@ -1,0 +1,91 @@
+# UI Tests — Resolution Report
+
+**Date:** 2026-03-25
+**Status:** RESOLVED — all three blockers from `diagnostic-report.md` are fixed
+
+## Fixes Applied
+
+### Blocker 1 (P0): `splitMode` property not configured
+
+**File:** `build.gradle.kts:113-114`
+
+IPG 2.13.1 requires `splitMode` and `splitModeTarget` on every `RunIdeTask`. The built-in `runIde` task gets these automatically, but our custom `runIdeForUiTests` did not.
+
+**Change:** Added both properties inside the task registration block:
+
+```kotlin
+import org.jetbrains.intellij.platform.gradle.tasks.aware.SplitModeAware.SplitModeTarget
+
+register<RunIdeTask>("runIdeForUiTests") {
+    splitMode.set(false)
+    splitModeTarget.set(SplitModeTarget.BACKEND)
+    // ...
+}
+```
+
+---
+
+### Blocker 2 (P0): Configuration cache incompatibility
+
+**File:** `build.gradle.kts:111, 128-136`
+
+Two changes were needed:
+
+1. **Marked the task as config-cache-incompatible** so Gradle doesn't fail the build:
+
+```kotlin
+notCompatibleWithConfigurationCache("dynamic plugin path resolution in doFirst")
+```
+
+2. **Moved `layout.buildDirectory` resolution out of `doFirst`** into a configuration-time `Provider`, preventing serialization of Gradle script objects:
+
+```kotlin
+// Before (broken — captures layout.buildDirectory in doFirst closure)
+doFirst {
+    val pluginBase = layout.buildDirectory.dir("robot-server-plugin").get().asFile
+    val pluginDir = pluginBase.listFiles()?.firstOrNull { it.isDirectory } ?: pluginBase
+    jvmArgs("-Dplugin.path=${pluginDir.absolutePath}")
+}
+
+// After (fixed — resolved at configuration time via Provider)
+val robotPluginDir = layout.buildDirectory.dir("robot-server-plugin").map { dir ->
+    val base = dir.asFile
+    base.listFiles()?.firstOrNull { it.isDirectory } ?: base
+}
+doFirst {
+    jvmArgs("-Dplugin.path=${robotPluginDir.get().absolutePath}")
+}
+```
+
+---
+
+### Issue 3 (P1): No fast-fail when IDE is not running
+
+**File:** `src/uiTest/kotlin/.../BaseUiTest.kt:44-67`
+
+Previously, each test class would block for its full 2-minute `@BeforeAll` timeout when the robot server was unreachable (8 classes = ~16 minutes of hanging).
+
+**Change:** Added `ensureRobotServerReachable()` as the first step of `waitForIde()`. It pings the robot server URL via `HttpURLConnection` up to 5 times with 2-second intervals (~10 seconds total). If all attempts fail, the test class is aborted immediately via `Assumptions.abort()` with a clear message:
+
+```
+Robot server not reachable at http://localhost:8082 after 5 attempts.
+Is ./gradlew runIdeForUiTests running?
+```
+
+Using `Assumptions.abort()` marks tests as **skipped** (not failed), which correctly signals that the precondition was not met rather than the test logic being broken.
+
+---
+
+## Verification
+
+| Check | Result |
+|-------|--------|
+| `./gradlew compileKotlin` | PASS |
+| `./gradlew compileUiTestKotlin` | PASS |
+| `./gradlew help --task runIdeForUiTests` | PASS — task recognized |
+| Configuration cache | Stored successfully |
+
+## Remaining Work
+
+- **CI/CD pipeline** is not yet configured (manual two-terminal execution only)
+- **End-to-end validation** requires running `./gradlew runIdeForUiTests` + `./gradlew uiTest` with a display available (not possible in headless-only environments without Xvfb)

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/BaseUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/BaseUiTest.kt
@@ -5,9 +5,12 @@ import com.intellij.remoterobot.fixtures.CommonContainerFixture
 import com.intellij.remoterobot.search.locators.byXpath
 import com.intellij.remoterobot.utils.keyboard
 import com.intellij.remoterobot.utils.waitFor
+import org.junit.jupiter.api.Assumptions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 import java.awt.event.KeyEvent
+import java.net.HttpURLConnection
+import java.net.URI
 import java.nio.file.Path
 import java.time.Duration
 
@@ -22,14 +25,19 @@ import java.time.Duration
 abstract class BaseUiTest {
 
     protected val robot: RemoteRobot by lazy {
-        RemoteRobot(System.getProperty("robot-server.url", "http://localhost:8082"))
+        RemoteRobot(robotUrl)
     }
 
     protected val testProjectDir: Path =
         Path.of(System.getProperty("ui.test.project.dir", "test-project")).toAbsolutePath()
 
+    private val robotUrl: String =
+        System.getProperty("robot-server.url", "http://localhost:8082")
+
     @BeforeAll
     fun waitForIde() {
+        ensureRobotServerReachable()
+
         // Wait until the main IDE frame is visible (project was passed on startup)
         waitFor(Duration.ofMinutes(2)) {
             try {
@@ -40,6 +48,31 @@ abstract class BaseUiTest {
         }
         // Give the IDE a moment to finish indexing
         Thread.sleep(3_000)
+    }
+
+    private fun ensureRobotServerReachable() {
+        val maxAttempts = 5
+        val delayMs = 2_000L
+        for (attempt in 1..maxAttempts) {
+            try {
+                val connection = URI(robotUrl).toURL()
+                    .openConnection() as HttpURLConnection
+                connection.connectTimeout = 2_000
+                connection.readTimeout = 2_000
+                connection.requestMethod = "GET"
+                connection.responseCode
+                connection.disconnect()
+                return
+            } catch (_: Exception) {
+                if (attempt == maxAttempts) {
+                    Assumptions.abort<Unit>(
+                        "Robot server not reachable at $robotUrl after $maxAttempts attempts. " +
+                            "Is ./gradlew runIdeForUiTests running?"
+                    )
+                }
+                Thread.sleep(delayMs)
+            }
+        }
     }
 
     // ── Component helpers ─────────────────────────────────────────────────────


### PR DESCRIPTION
…heck

- Add splitMode/splitModeTarget to runIdeForUiTests task (IPG 2.13.1 requirement)
- Mark task as config-cache-incompatible and move plugin path resolution to config time
- Add HTTP health check to BaseUiTest that fails fast (~10s) instead of 2-min blind timeout
- Add resolution report documenting all fixes