### PR TITLE
Fix remote-robot version mismatch and add JDK 21 compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 group = providers.gradleProperty("pluginGroup").get()
 version = providers.gradleProperty("pluginVersion").get()
 
+val remoteRobotVersion = "0.11.23"
+
 // ── UI Test source set ────────────────────────────────────────────────────────
 val uiTest by sourceSets.creating {
     compileClasspath += sourceSets.main.get().output
@@ -41,9 +43,9 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("org.assertj:assertj-core:3.25.3")
 
-    // UI test client
-    "uiTestImplementation"("com.intellij.remoterobot:remote-robot:0.11.22")
-    "uiTestImplementation"("com.intellij.remoterobot:remote-fixtures:0.11.22")
+    // UI test client — version must match robotServerPlugin() resolved version
+    "uiTestImplementation"("com.intellij.remoterobot:remote-robot:$remoteRobotVersion")
+    "uiTestImplementation"("com.intellij.remoterobot:remote-fixtures:$remoteRobotVersion")
     "uiTestImplementation"("org.junit.jupiter:junit-jupiter:5.10.1")
     "uiTestImplementation"("com.squareup.okhttp3:okhttp:4.12.0")
     "uiTestImplementation"("com.squareup.okhttp3:logging-interceptor:4.12.0")
@@ -106,7 +108,7 @@ intellijPlatformTesting {
                 args(rootDir.resolve("test-project").absolutePath)
             }
             plugins {
-                robotServerPlugin()
+                robotServerPlugin(remoteRobotVersion)
             }
         }
     }
@@ -124,6 +126,8 @@ tasks {
         testClassesDirs = sourceSets["uiTest"].output.classesDirs
         classpath = sourceSets["uiTest"].runtimeClasspath
         useJUnitPlatform()
+        // Required for Retrofit/GSON reflection on JDK 17+
+        jvmArgs("--add-opens", "java.base/java.lang=ALL-UNNAMED")
         systemProperty("robot-server.url", System.getProperty("robot-server.url", "http://localhost:8082"))
         systemProperty("ui.test.project.dir", rootDir.resolve("test-project").absolutePath)
     }

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/BaseUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/BaseUiTest.kt
@@ -42,7 +42,8 @@ abstract class BaseUiTest {
         waitFor(Duration.ofMinutes(2)) {
             try {
                 ideFrame() != null
-            } catch (_: Exception) {
+            } catch (e: Exception) {
+                System.err.println("[waitForIde] ideFrame() failed: ${e.javaClass.simpleName}: ${e.message}")
                 false
             }
         }


### PR DESCRIPTION
Pin remote-robot client, fixtures, and server plugin to 0.11.23 via shared variable to prevent deserialization failures from version skew. Add --add-opens for Retrofit/GSON reflection on JDK 17+.