### PR TITLE
Add comprehensive roadmap and task documentation for plugin expansion

### DIFF
--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -1,0 +1,67 @@
+# PageObjectPlugin Roadmap
+
+## Context
+
+Tasks 0–12 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, and the settings UI has been migrated to Kotlin UI DSL v2. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). UI tests are blocked on a `splitMode` Gradle config issue (see `docs/UI_tests/diagnostic-report.md`), and CI test reporting isn't optimized for Claude Code to autonomously iterate (run → read report → fix → re-run).
+
+This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
+
+---
+
+## Track A — Language Support
+
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+
+- **A1. Python Playwright support** — `task-16-python-playwright-support.md`
+- **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
+
+Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implementation so the three language savers (TS/Python/JVM) stay in lockstep.
+
+---
+
+## Track B — Snapshot Saver Consolidation & Multi-Framework
+
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
+- **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
+
+B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+
+---
+
+## Track C — Repo / Inner Loop Improvements
+
+- **C1. UI test framework** — split into four subtasks:
+  - `task-13a-ui-tests-unblock.md` — fix `splitMode` + fast-fail health check
+  - `task-13b-ui-tests-reliability.md` — polling helpers, retry-once, `@Quarantine`
+  - `task-13c-ui-tests-diagnostics.md` — per-test trace bundle (feeds C3)
+  - `task-13d-ui-tests-page-object-refactor.md` — locators/pages/flows layering
+- **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md`
+- **C3. Feature demo reporting (Playwright-style trace viewer)** — `task-19-feature-demo-trace-viewer.md`
+
+---
+
+## Suggested Execution Order
+
+1. **C1a** — unblock UI tests (everything else benefits).
+2. **C1b–d** — reliability, diagnostics, page-object refactor.
+3. **C2** — get the Claude inner loop solid before adding scope.
+4. **B1** — refactor snapshot core (low risk, enables B2/B3).
+5. **A1** — Python Playwright (highest user demand for language expansion).
+6. **B2** — Selenium/Cypress adapters.
+7. **A2** — Java/Kotlin Playwright.
+8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+9. **B3** — mobile/Appium (largest unknowns).
+
+---
+
+## High-Level Verification
+
+- **A1/A2**: new unit tests in `src/test/kotlin/.../locators/` pass; open a `.py`/`.java` file with locators and confirm gutter badges and caret-driven highlight in the tool window.
+- **B1**: `npm test` in both `snapshot-core` and `playwright-snapshot-saver` passes; no regression in `test-project/` snapshots.
+- **B2/B3**: each new package has its own integration test target green in CI.
+- **C1**: `./gradlew runIdeForUiTests` boots; all 30 existing UI scenarios run; failing tests produce trace bundles; refactored tests contain zero literal XPaths.
+- **C2**: `./gradlew testReport` produces `build/reports/claude-summary.{json,md}`; CI uploads them as artifacts.
+- **C3**: `./gradlew demoReport -PfeatureName=<tag>` produces a self-contained trace viewer; PR with `demo` label auto-comments a link.
+
+See each task doc for its own detailed verification.

--- a/docs/snapshot-bundle-spec.md
+++ b/docs/snapshot-bundle-spec.md
@@ -1,0 +1,56 @@
+# Snapshot Bundle Spec (v1)
+
+> **Status:** Source of truth for the on-disk `.snapshots/<name>/` bundle format consumed by the PageObjectPlugin tool window and produced by all language-specific snapshot savers (TS / Python / JVM / Selenium / Cypress / Appium).
+>
+> This document promotes the format currently described in `CLAUDE.md` §"Snapshot Bundle Format" to a formal spec. Any change to the format MUST be accompanied by a version bump in `manifest.json.version` and a migration note below.
+
+---
+
+## Directory Layout
+
+```
+<snapshot-name>/
+  index.html        # REQUIRED — sanitized DOM with CSS inlined
+  screenshot.webp   # OPTIONAL — visual reference (PNG also accepted)
+  manifest.json     # OPTIONAL but STRONGLY RECOMMENDED
+```
+
+The directory name is the snapshot identifier surfaced in the tool window dropdown.
+
+## `index.html` requirements
+
+- Self-contained: no external `<link rel="stylesheet">` or `<script src>`. All CSS inlined in `<style>` blocks or element `style` attributes.
+- Scripts stripped or neutralized — the plugin renders this in a `srcdoc` iframe and does not execute arbitrary JS from snapshots.
+- UTF-8 encoded.
+- Preserves original element attributes so locators (`data-testid`, `role`, `aria-*`, `id`, `name`, classes) resolve identically to the live page.
+
+## `manifest.json` schema (v1)
+
+```json
+{
+  "version": 1,
+  "url": "https://example.com/login",
+  "viewport": { "width": 1280, "height": 720 },
+  "timestamp": "2025-01-15T10:30:00Z",
+  "playwright": "1.48.0",
+  "userAgent": "Mozilla/5.0 ..."
+}
+```
+
+Fields:
+- `version` (int, required) — schema version. Current: `1`.
+- `url` (string, required) — the page URL at capture time.
+- `viewport` (object, required) — `{width, height}` in CSS pixels. Mobile adapters (B3) MAY add `{platform, deviceName}`.
+- `timestamp` (string, required) — ISO-8601 UTC.
+- `playwright` / `selenium` / `cypress` / `appium` (string, optional) — driver version that captured the snapshot. Exactly one SHOULD be present.
+- `userAgent` (string, optional).
+
+## Versioning
+
+- The plugin reads `manifest.version` and refuses to render unknown future versions with a user-visible error.
+- Breaking changes bump the integer. Additive changes (new optional fields) do NOT bump the version.
+
+## Compatibility Notes
+
+- Older `test-project/.snapshots/` bundles produced before this spec may omit `manifest.json`; the plugin treats them as v1 with unknown metadata.
+- All language savers (`packages/playwright-snapshot-saver`, `packages/playwright-snapshot-saver-python`, `packages/playwright-snapshot-saver-jvm`, and future adapters) MUST emit bundles conforming to this spec. Any divergence is a bug.

--- a/docs/tasks/task-13a-ui-tests-unblock.md
+++ b/docs/tasks/task-13a-ui-tests-unblock.md
@@ -1,0 +1,40 @@
+# Task 13a: UI Tests — Unblock Runner
+
+> **Goal:** Restore the ability to run `./gradlew runIdeForUiTests` so the existing 30 UI scenarios execute again.
+> **Depends on:** nothing (prerequisite for 13b–d, 14, 19)
+> **Output:** Updated `build.gradle.kts` and `BaseUiTest.kt`; all existing UI scenarios runnable.
+
+## Motivation
+
+The UI test suite has been non-runnable since the bump to IntelliJ Platform Gradle plugin 2.13.1. `./gradlew runIdeForUiTests` fails immediately because the custom `RunIdeTask` registration is missing the `splitMode` property (now required by IPG 2.x), and the task is not configuration-cache compatible. On top of that, when the IDE *does* fail to start, every test class blocks for the full 2-minute `BaseUiTest.waitForIde()` timeout before failing — burning ~16 minutes to confirm nothing works. Details in `docs/UI_tests/diagnostic-report.md`.
+
+Until this is fixed, no further UI-test work (13b–d), CI reporting (14), or demo trace viewer (19) can proceed.
+
+## Key Files
+
+- `build.gradle.kts:109-156` — `runIdeForUiTests` task registration.
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/BaseUiTest.kt:40-104` — `waitForIde()` + 2-minute blind timeout.
+- `docs/UI_tests/diagnostic-report.md` — full symptom trace and proposed fix outline.
+
+## Steps
+
+1. In `build.gradle.kts`, on the `runIdeForUiTests` task:
+   - Call `splitMode.set(false)` (IPG 2.13.1 requirement).
+   - Configure `splitModeTarget` to the matching value used in default `runIde`.
+   - Mark the task `@DisableCachingByDefault` or otherwise opt out of the configuration cache until IPG ships a compatible version.
+2. In `BaseUiTest.waitForIde()`:
+   - Replace the 2-minute blind `Thread.sleep` / fixed `waitFor` with a fast health-check loop that `HEAD`s the Remote Robot endpoint (`http://localhost:8082`) every 500 ms.
+   - Abort with a clear error after **30 seconds** of unreachable endpoint.
+   - Keep the existing window-focus / VFS-refresh / tool-window-setup logic after the health check passes.
+3. No changes to individual fixtures or tests.
+
+## Verification
+
+- `./gradlew runIdeForUiTests` launches an IDE process that becomes reachable on port 8082.
+- Running the UI test entry point connects within 30 seconds when the IDE is healthy.
+- Killing the IDE mid-run causes `BaseUiTest` to fail within 30 seconds (not 2 minutes).
+- All 30 existing UI scenarios execute (pass/fail independent of this task).
+
+## Out of Scope
+
+- New polling helpers (→ 13b), trace capture (→ 13c), page-object refactor (→ 13d), CI integration (→ 14).

--- a/docs/tasks/task-13b-ui-tests-reliability.md
+++ b/docs/tasks/task-13b-ui-tests-reliability.md
@@ -1,0 +1,58 @@
+# Task 13b: UI Tests — Reliability (polling, retry, quarantine)
+
+> **Goal:** Eliminate `Thread.sleep`/fixed timeouts, make transient failures retry once with visibility, and allow known-flaky tests to be quarantined without deletion.
+> **Depends on:** Task 13a
+> **Output:** `support/Wait.kt`, a retry-once JUnit 5 extension, a `@Quarantine` annotation + condition, all fixtures migrated off `Thread.sleep`.
+
+## Motivation
+
+Today's UI tests rely on `Thread.sleep` and fixed-duration `waitFor(30s..60s)` calls scattered across `BaseUiTest` and every fixture. This makes the suite either slow (when durations are padded) or flaky (when they aren't). When a test fails there is no retry, so every transient JCEF/Remote-Robot hiccup scores a red build. Conversely, when a test genuinely rots, the temptation is to delete it — losing coverage silently.
+
+We need three things: (1) a single polling primitive used everywhere, (2) a retry-once mechanism that tags retried runs so retries are *visible*, not hidden, and (3) a quarantine annotation that skips a test but surfaces it in reports so it can't be forgotten.
+
+## Key Files
+
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/BaseUiTest.kt` — main offender; multiple `Thread.sleep` and fixed `waitFor` calls.
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/PageMirrorToolWindowFixture.kt`
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/SnapshotBrowserFixture.kt`
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/PageMirrorSettingsFixture.kt`
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/GutterFixture.kt`
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/StatusBarFixture.kt`
+- New: `src/uiTest/kotlin/com/github/artem/pageobjectplugin/support/Wait.kt`
+- New: `src/uiTest/kotlin/com/github/artem/pageobjectplugin/support/RetryOnceExtension.kt`
+- New: `src/uiTest/kotlin/com/github/artem/pageobjectplugin/support/Quarantine.kt`
+
+## Steps
+
+1. **Polling primitives** (`support/Wait.kt`):
+   ```kotlin
+   fun <T> pollUntil(
+       timeout: Duration = 10.seconds,
+       interval: Duration = 100.milliseconds,
+       message: () -> String = { "condition not met" },
+       block: () -> T?
+   ): T
+   fun retryOnce(block: () -> Unit)
+   ```
+   `pollUntil` returns the first non-null value from `block` or throws with `message`. `retryOnce` runs `block`, catches any throwable, and re-runs once.
+2. Migrate every `Thread.sleep` and fixed `waitFor` across `BaseUiTest` and all five fixtures to `pollUntil`. Record any sleep that *cannot* be migrated (e.g., animation waits) as a TODO with justification.
+3. **Retry-once extension** (`support/RetryOnceExtension.kt`): JUnit 5 `TestExecutionExceptionHandler` + `InvocationInterceptor` that reruns a failing test once, reports the second run with a `@Flaky` marker (injected into the test display name so it surfaces in both IntelliJ runner and the Task 14 `claude-summary.md`).
+4. **Quarantine** (`support/Quarantine.kt`):
+   ```kotlin
+   @Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+   @ExtendWith(QuarantineCondition::class)
+   annotation class Quarantine(val reason: String, val ticket: String = "")
+   ```
+   `QuarantineCondition` is a JUnit 5 `ExecutionCondition` that disables the test but attaches the reason to the report. Task 14 will surface quarantined tests under a dedicated section in `claude-summary.md`.
+5. Register `RetryOnceExtension` via `@ExtendWith` on `BaseUiTest` so all UI tests inherit it.
+
+## Verification
+
+- `grep -r "Thread.sleep" src/uiTest/kotlin/` returns only lines with a TODO comment justifying the exception.
+- A deliberately-failing test (throws on first invocation, passes on second) retries once and is reported as `@Flaky`.
+- A test annotated `@Quarantine("example", ticket = "ISSUE-1")` is skipped at runtime and appears in the JUnit report with the reason attached.
+- All existing UI scenarios still pass after migration.
+
+## Out of Scope
+
+- Per-test trace capture (→ 13c), page-object refactor (→ 13d), parallelization (not in roadmap).

--- a/docs/tasks/task-13c-ui-tests-diagnostics.md
+++ b/docs/tasks/task-13c-ui-tests-diagnostics.md
@@ -1,0 +1,82 @@
+# Task 13c: UI Tests — Per-Test Diagnostics Trace Bundle
+
+> **Goal:** On UI test failure, capture a structured bundle of artifacts (IDE log, tool-window DOM, JCEF console, screenshot timeline, thread dump) with a machine-readable `trace.json` manifest. This bundle is the direct input to the Task 19 (C3) Playwright-style trace viewer.
+> **Depends on:** Task 13a (unblock), Task 13b (polling — for step recording)
+> **Output:** `TraceBundleExtension` replacing `ScreenshotOnFailureExtension`; one bundle per failing test under `build/reports/uiTest/traces/<test>/`.
+
+## Motivation
+
+`ScreenshotOnFailureExtension` captures a single PNG on failure and nothing else. When a UI test breaks in CI, debugging requires guessing: was the IDE frozen? Did the tool window's JCEF DOM render? Did a JS error fire in the snapshot iframe? Was there a deadlock? Right now none of this is visible.
+
+We want a single extension that, on failure, writes a self-contained directory per test with every signal a human or Claude needs to diagnose it — and crucially, that directory's layout and `trace.json` schema is designed up-front to match what Task 19's trace viewer will consume. C3 then becomes a filter + rendering layer over the same artifacts instead of a parallel capture system.
+
+## Key Files
+
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/extensions/ScreenshotOnFailureExtension.kt:18-50` — replace with `TraceBundleExtension`.
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/SnapshotBrowserFixture.kt` — reuse existing `callJs` path to dump tool-window DOM.
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/BaseUiTest.kt` — register `TraceBundleExtension` globally.
+- New: `src/uiTest/kotlin/com/github/artem/pageobjectplugin/support/TraceBundleExtension.kt`
+- New: `src/uiTest/kotlin/com/github/artem/pageobjectplugin/support/StepRecorder.kt`
+
+## Bundle Layout
+
+```
+build/reports/uiTest/traces/<ClassName>__<testName>/
+  trace.json           # Manifest listing all artifacts + step timeline
+  idea.log             # Tail of IDE's idea.log
+  dom.html             # Tool-window JCEF DOM snapshot
+  jcef-console.log     # Captured console.log/warn/error from JCEF (port 9222 CDP)
+  threads.txt          # Thread dump of the IDE process
+  screenshots/
+    001-<step>.png
+    002-<step>.png
+    ...
+```
+
+## `trace.json` Schema (v1)
+
+```json
+{
+  "version": 1,
+  "test": { "className": "...", "method": "...", "displayName": "...", "feature": "highlight-all" },
+  "startedAt": "2026-04-07T12:00:00Z",
+  "durationMs": 1234,
+  "status": "failed",
+  "failure": { "message": "...", "stack": "...", "file": "...", "line": 42 },
+  "steps": [
+    { "index": 1, "label": "open settings", "at": "...", "screenshot": "screenshots/001-open-settings.png" }
+  ],
+  "artifacts": {
+    "ideaLog": "idea.log",
+    "dom": "dom.html",
+    "jcefConsole": "jcef-console.log",
+    "threads": "threads.txt"
+  }
+}
+```
+
+This schema is the contract with Task 19.
+
+## Steps
+
+1. **StepRecorder** — a thread-local collector. Pages/Flows from Task 13d will call `StepRecorder.step("label") { ... }`, which captures a timestamped entry and a screenshot. Until 13d lands, `BaseUiTest` exposes `step(label)` as a thin wrapper.
+2. **JCEF console capture** — enable remote debug on port 9222 (already documented in `CLAUDE.md` pitfalls) and open a CDP client that tees `Runtime.consoleAPICalled` events to a list. Flush to `jcef-console.log` on test end.
+3. **DOM dump** — reuse the existing `callJs` helper in `SnapshotBrowserFixture` to run `document.documentElement.outerHTML` and write to `dom.html`.
+4. **IDE log tail** — copy the last N KB of `idea.log` from the sandbox (`runIdeForUiTests` working dir).
+5. **Thread dump** — invoke `jstack` against the IDE PID if available; otherwise fall back to `Thread.getAllStackTraces()` from inside the IDE via Remote Robot `callJs`.
+6. **TraceBundleExtension** — implements `TestWatcher` + `AfterTestExecutionCallback`. On **failure OR** (when `-PcaptureAllTraces=true`) **any** result, assemble the bundle directory and write `trace.json`.
+7. Delete `ScreenshotOnFailureExtension` (superseded).
+8. Register the new extension in `BaseUiTest` so all UI tests inherit it.
+
+## Verification
+
+- Running a deliberately-failing UI test produces a directory at `build/reports/uiTest/traces/<name>/` containing all files listed in the layout above.
+- `trace.json` validates against the v1 schema and can be round-tripped via `kotlinx.serialization`.
+- With `-PcaptureAllTraces=true`, passing tests also produce bundles (needed by Task 19).
+- CI artifact upload (Task 14) picks up the `traces/` directory.
+
+## Out of Scope
+
+- Rendering the trace viewer UI (→ Task 19).
+- Parallel test execution across shards.
+- Page-object refactor that adds `step(...)` call sites (→ 13d).

--- a/docs/tasks/task-13d-ui-tests-page-object-refactor.md
+++ b/docs/tasks/task-13d-ui-tests-page-object-refactor.md
@@ -1,0 +1,71 @@
+# Task 13d: UI Tests — Page Object Pattern Refactor
+
+> **Goal:** Refactor the flat Remote Robot fixture layer into a layered structure (`locators/` + `pages/` + `flows/`) so UI tests read as high-level scenarios, XPaths live in exactly one place, and `BaseUiTest` shrinks to pure lifecycle code.
+> **Depends on:** Task 13a (unblock), Task 13b (polling helpers), Task 13c (trace bundle — `step()` integration)
+> **Output:** New `locators/`, `pages/`, `flows/` packages under `src/uiTest/kotlin/…`; `ToolWindowUiTest` and `SettingsUiTest` rewritten as reference examples; `CLAUDE.md` layering rule documented.
+
+## Motivation
+
+The existing fixtures (`PageMirrorToolWindowFixture`, `SnapshotBrowserFixture`, `PageMirrorSettingsFixture`, `GutterFixture`, `StatusBarFixture`) are already a partial Page Object implementation — they encapsulate component XPaths and expose action methods. But:
+
+- **XPaths are hardcoded inline** in each fixture instead of an extractable locators layer, so updating an IntelliJ chrome selector means touching many files.
+- **No composite pages** exist — flows that span multiple fixtures (load snapshot → assert highlight → change settings) are duplicated across tests.
+- **`BaseUiTest` has grown to 271 lines** and contains IDE-navigation helpers (`openFileInEditor`, caret movement, etc.) that belong in a Page class, not the base.
+- The plugin's own product is a Page Object generator — it's fitting that its test suite be an exemplar of the pattern.
+
+## Key Files
+
+- Existing, to be refactored:
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/BaseUiTest.kt:40-271`
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/PageMirrorToolWindowFixture.kt`
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/SnapshotBrowserFixture.kt`
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/PageMirrorSettingsFixture.kt`
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/GutterFixture.kt`
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/fixtures/StatusBarFixture.kt`
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ToolWindowUiTest.kt`
+  - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/SettingsUiTest.kt`
+- New:
+  ```
+  src/uiTest/kotlin/com/github/artem/pageobjectplugin/
+    locators/
+      IntelliJLocators.kt      # IDE chrome XPaths (IdeFrameImpl, IdeStatusBar, ToolWindow headers)
+      PageMirrorLocators.kt    # Plugin XPaths (tool window combo, refresh button, settings fields)
+    pages/
+      PluginToolWindowPage.kt  # Composes tool window + browser + status bar
+      PluginSettingsPage.kt    # Settings dialog open → edit → apply
+      EditorPage.kt            # File open, caret move, gutter read (moved out of BaseUiTest)
+    flows/
+      SnapshotLoadFlow.kt      # "open file → wait for auto-discovery → assert highlight"
+      SettingsChangeFlow.kt    # "open settings → set value → apply → assert effect"
+  ```
+- `CLAUDE.md` — add layering rule to the "Common Pitfalls" or a new "UI Test Conventions" section.
+
+## Layering Rule
+
+> **Tests** call **Flows** or **Pages** — never raw fixtures.
+> **Flows** orchestrate multiple **Pages**.
+> **Pages** compose one or more **Fixtures** and call `StepRecorder.step("...")` for each logical action.
+> **Fixtures** contain no literal XPath strings — all locators come from the `locators/` package.
+
+## Steps
+
+1. Extract every literal XPath from the five fixtures into `IntelliJLocators` and `PageMirrorLocators`. Each locator is a `val` returning `Locator` (Remote Robot's type). Group by component with comments.
+2. Create the three `pages/` classes. Each page takes a `RemoteRobot` in its constructor, holds references to the fixtures it needs, and exposes high-level methods that wrap fixture calls in `StepRecorder.step("...")` (from Task 13c).
+3. Move `openFileInEditor`, caret-movement, gutter-read helpers from `BaseUiTest` into `EditorPage`. `BaseUiTest` should shrink to: `@BeforeAll` lifecycle, `TraceBundleExtension` registration, `RemoteRobot` accessor. Target: **< 100 lines**.
+4. Create the two `flows/` classes as thin Kotlin functions/objects that chain page calls.
+5. Rewrite `ToolWindowUiTest` and `SettingsUiTest` against the new Page/Flow layer as reference examples. Remaining UI test classes stay on the old API for now — migrate incrementally in follow-up work. Keep fixtures themselves as thin adapters so both styles coexist.
+6. Update `CLAUDE.md` with the layering rule above.
+
+## Verification
+
+- `grep -rE "byXpath\(|By\.xpath\(" src/uiTest/kotlin/.../fixtures/` returns only references to constants from `locators/*.kt` (no inline literal XPaths in fixtures).
+- `BaseUiTest.kt` is under 100 lines.
+- `ToolWindowUiTest` and `SettingsUiTest` contain zero direct fixture instantiations — they only call pages or flows.
+- All 30 existing UI scenarios still pass.
+- A new reader can follow a test from scenario to page to fixture to locator without hunting.
+
+## Out of Scope
+
+- Migrating all remaining UI test classes (`SnapshotBrowserUiTest`, `GutterUiTest`, etc.) — tracked as follow-up.
+- Parameterized tests / shared test-data abstraction.
+- Parallel execution / sharding.

--- a/docs/tasks/task-14-ci-test-reporting.md
+++ b/docs/tasks/task-14-ci-test-reporting.md
@@ -1,0 +1,99 @@
+# Task 14: CI Test Reporting + Claude Inner Loop
+
+> **Goal:** Single Gradle aggregator task that runs unit + UI + npm tests and emits a machine-readable JSON and human-readable Markdown summary optimized for Claude Code to autonomously iterate (run → read → fix → re-run).
+> **Depends on:** Task 13a–c (UI tests runnable + trace bundles exist)
+> **Output:** `./gradlew testReport`, `build/reports/claude-summary.{json,md}`, CI artifact upload, `CLAUDE.md` Test Loop section.
+
+## Motivation
+
+Today's CI produces scattered reports (JUnit XML under `build/test-results/`, HTML under `build/reports/tests/`, npm test output in package directories). For Claude Code to iterate on a failure, it must know *where* to look, *what* failed, and *why* — without paging through HTML or digging per package. A single canonical summary file per build is the fastest path.
+
+We also need guardrails: when Claude encounters a failing test, the temptation to delete/skip it must be blocked by explicit process rules. `CLAUDE.md` is the right place.
+
+## Key Files
+
+- `build.gradle.kts` — new `testReport` aggregator task.
+- `.github/workflows/ci.yml` — upload both summary files as artifacts.
+- `CLAUDE.md` — new "Test Loop" section.
+- New: `buildSrc/src/main/kotlin/ClaudeSummary.kt` (or equivalent) — aggregator logic.
+
+## `claude-summary.json` Schema
+
+```json
+{
+  "version": 1,
+  "generatedAt": "2026-04-07T12:00:00Z",
+  "totals": { "passed": 123, "failed": 4, "skipped": 2, "flaky": 1, "quarantined": 3, "durationMs": 456789 },
+  "suites": [
+    {
+      "suite": "unit | uiTest | npm:playwright-snapshot-saver | npm:snapshot-core",
+      "tests": [
+        {
+          "name": "ClassName.testName",
+          "status": "passed | failed | skipped | flaky | quarantined",
+          "durationMs": 123,
+          "file": "src/test/.../Foo.kt",
+          "line": 42,
+          "failureMessage": "...",
+          "tracePath": "build/reports/uiTest/traces/ClassName__testName/"
+        }
+      ]
+    }
+  ],
+  "quarantined": [{ "name": "...", "reason": "...", "ticket": "..." }]
+}
+```
+
+## `claude-summary.md` Layout
+
+```
+# Test Summary — <commit sha>
+
+Totals: 123 passed, 4 failed, 2 skipped, 1 flaky, 3 quarantined (7m 36s)
+
+## Failures (4)
+1. `com.example.FooTest.bar` — NullPointerException at Foo.kt:42
+   Trace: build/reports/uiTest/traces/FooTest__bar/
+2. ...
+
+## Flaky (retried once) (1)
+- `com.example.BazTest.qux` — passed on retry
+
+## Quarantined (3)
+- `com.example.XyzTest.old` — reason: "CEF race", ticket: ISSUE-123
+```
+
+## Steps
+
+1. **Aggregator task** (`testReport`) that depends on `test`, `uiTest`, and each npm package's `npmTest` equivalent. After all complete (even with failures — use `finalizedBy`), parse:
+   - JUnit XML from `build/test-results/test/**/*.xml` and `build/test-results/uiTest/**/*.xml`.
+   - Each npm package's JSON reporter output (jest/vitest/playwright `--reporter=json` already used by existing packages).
+   - `@Quarantine` metadata emitted by Task 13b.
+   - Trace bundle paths from Task 13c.
+2. Emit `build/reports/claude-summary.json` and `build/reports/claude-summary.md` with the schemas above.
+3. **CI wiring** — update `.github/workflows/ci.yml` to:
+   - Run `./gradlew testReport` (non-failing even if tests fail, so the artifact uploads).
+   - Upload `build/reports/claude-summary.*` and `build/reports/uiTest/traces/**` as a single artifact named `test-report-<sha>`.
+   - Fail the job after upload if `totals.failed > 0`.
+4. **`CLAUDE.md` "Test Loop" section**:
+   - `./gradlew testReport` → read `build/reports/claude-summary.md` → fix → re-run.
+   - **Redlines** (non-negotiable):
+     - Never delete a failing test to turn CI green.
+     - Never add `@Ignore` / `@Disabled` without a ticket and `@Quarantine(reason, ticket)` — bare skips are banned.
+     - Never mark a test `@Quarantine` without also opening a tracking issue.
+     - Always re-run the full `testReport` after a fix; never cherry-pick a single test to claim green.
+     - Never use `node -e` or inline scripts for verification — add a real test.
+
+## Verification
+
+- `./gradlew testReport` produces both files; running locally with an intentionally failing test shows the failure in the Markdown under `## Failures`.
+- `claude-summary.json` parses as valid JSON matching the schema.
+- CI job uploads `test-report-<sha>` artifact; downloading it locally yields browsable traces.
+- A fresh Claude Code session given only `claude-summary.md` + a repo checkout can identify which file and line to fix.
+- `CLAUDE.md` contains the Test Loop section with all redlines verbatim.
+
+## Out of Scope
+
+- Parallel CI shards.
+- Historical test metrics (flakiness dashboards).
+- Demo / trace viewer (→ Task 19).

--- a/docs/tasks/task-15-snapshot-core-extraction.md
+++ b/docs/tasks/task-15-snapshot-core-extraction.md
@@ -1,0 +1,69 @@
+# Task 15: Extract Framework-Agnostic `snapshot-core`
+
+> **Goal:** Split `playwright-snapshot-saver` into a framework-agnostic `snapshot-core` package plus a thin Playwright adapter, enabling future Selenium / Cypress / Appium adapters (Tasks 17, 20) without duplicating HTML inlining and manifest logic.
+> **Depends on:** nothing (but best after Task 14 so refactor regressions are caught by the aggregator)
+> **Output:** New `packages/snapshot-core/`, refactored `packages/playwright-snapshot-saver/` depending on it, stable public API.
+
+## Motivation
+
+Today, HTML inlining, manifest generation, and bundle layout logic all live inside `packages/playwright-snapshot-saver/src/`. Adding a Selenium or Cypress adapter would require copy-pasting these. A clean `PageAdapter` abstraction lets the core handle the universal work and each driver-specific package provide only a ~50-line adapter.
+
+## Key Files
+
+- `packages/playwright-snapshot-saver/src/index.ts` — public `saveSnapshot` entry point.
+- `packages/playwright-snapshot-saver/src/html-inliner.ts` — move to `snapshot-core`.
+- `packages/playwright-snapshot-saver/src/manifest-generator.ts` — move to `snapshot-core`.
+- `packages/playwright-snapshot-saver/src/reporter.ts` — stays in Playwright package (framework-specific).
+- `packages/playwright-snapshot-saver/tests/` — move inliner/manifest tests to `snapshot-core/tests/`.
+- New: `packages/snapshot-core/` (new npm package, private workspace, published as `@pagemirror/snapshot-core`).
+
+## `PageAdapter` Interface
+
+```ts
+export interface PageAdapter {
+  getHTML(): Promise<string>;
+  getCSS(): Promise<StylesheetData[]>;   // list of { href?: string, source: string }
+  getURL(): Promise<string>;
+  getViewport(): Promise<{ width: number; height: number }>;
+  screenshot(options?: { format?: "webp" | "png" }): Promise<Buffer>;
+  getUserAgent(): Promise<string | undefined>;
+}
+
+export interface SaveSnapshotOptions {
+  outputDir: string;
+  name: string;
+  group?: string;
+  screenshot?: "webp" | "png" | false;
+  manifest?: boolean;
+  extraSelectors?: string[];
+  excludeSelectors?: string[];
+  extraAttributes?: string[];
+  driver?: { name: "playwright" | "selenium" | "cypress" | "appium"; version: string };
+}
+
+export async function saveSnapshot(adapter: PageAdapter, options: SaveSnapshotOptions): Promise<string>;
+```
+
+## Steps
+
+1. Scaffold `packages/snapshot-core/` with `package.json`, `tsconfig.json`, `src/`, `tests/`, and add it to the root workspaces list.
+2. Move `html-inliner.ts` and `manifest-generator.ts` verbatim into `packages/snapshot-core/src/`. Adjust imports.
+3. Add `src/page-adapter.ts` defining `PageAdapter` and `SaveSnapshotOptions`.
+4. Add `src/save-snapshot.ts` implementing the orchestration (call adapter → inline → write manifest → write screenshot → produce bundle per `docs/snapshot-bundle-spec.md`).
+5. Move the subset of `playwright-snapshot-saver/tests/` that tests inliner and manifest into `snapshot-core/tests/`. Tests that exercise the full Playwright integration stay where they are.
+6. In `packages/playwright-snapshot-saver/`, replace the moved files with a thin `PlaywrightAdapter` implementing `PageAdapter` against `@playwright/test`'s `Page` and re-export `saveSnapshot` from `snapshot-core` so the public API is unchanged.
+7. Update `packages/playwright-snapshot-saver/package.json` to depend on `@pagemirror/snapshot-core` via workspace protocol.
+8. Update `test-project/` if its `file:` dependency path changes.
+
+## Verification
+
+- `npm test` from the repo root runs both `snapshot-core` and `playwright-snapshot-saver` test suites green.
+- `npm run build` in both packages succeeds.
+- `test-project/` can still produce snapshots via Playwright runs identical to the pre-refactor output (byte-for-byte for a fixed fixture page).
+- Public `import { saveSnapshot } from 'playwright-snapshot-saver'` still works.
+
+## Out of Scope
+
+- Selenium / Cypress adapters (→ Task 17).
+- Appium / mobile (→ Task 20).
+- Changing the bundle spec — if needed, bump `snapshot-bundle-spec.md` version first.

--- a/docs/tasks/task-16-python-playwright-support.md
+++ b/docs/tasks/task-16-python-playwright-support.md
@@ -1,0 +1,94 @@
+# Task 16: Python Playwright Support
+
+> **Goal:** Make the plugin recognize Python Playwright locators in `.py` files (highlight + gutter) AND ship a `playwright-snapshot-saver-python` package so Python users can produce snapshot bundles.
+> **Depends on:** Task 15 (snapshot-core — for the bundle spec contract), `docs/snapshot-bundle-spec.md` frozen.
+> **Output:** `PythonLocatorExtractor.kt`, `LocatorExtractorRegistry`, new PyPI package `packages/playwright-snapshot-saver-python/`.
+
+## Motivation
+
+PageObjectPlugin currently supports TypeScript Playwright only. Python is the second-most-common Playwright language. Adding it exercises the plugin's assumed-TS-everywhere architecture and forces extraction of a language-agnostic locator interface that A2 (JVM) can reuse.
+
+Python users also need a snapshot saver in their language — the existing npm package is unreachable from `pytest`. We ship a sibling PyPI package that produces byte-identical bundles.
+
+## Key Files
+
+### Plugin side
+- `src/main/kotlin/com/github/artem/pageobjectplugin/locators/LocatorExtractor.kt` — introduce `LocatorExtractor` interface (refactor), keep existing class as `TypeScriptLocatorExtractor`.
+- New: `src/main/kotlin/com/github/artem/pageobjectplugin/locators/PythonLocatorExtractor.kt`
+- New: `src/main/kotlin/com/github/artem/pageobjectplugin/locators/LocatorExtractorRegistry.kt`
+- `src/main/kotlin/com/github/artem/pageobjectplugin/annotators/SelectorValidationAnnotator.kt` — route through the registry.
+- `src/main/kotlin/com/github/artem/pageobjectplugin/settings/PageMirrorSettings.kt` — add `.py` to default `fileExtensions`.
+- New: `src/test/kotlin/com/github/artem/pageobjectplugin/locators/PythonLocatorExtractorTest.kt`
+
+### Saver package
+- New: `packages/playwright-snapshot-saver-python/`
+  - `pyproject.toml`, `src/playwright_snapshot_saver/__init__.py`
+  - `save_snapshot.py` — sync + async variants
+  - `html_inliner.py` — port of the TS version using `beautifulsoup4`
+  - `manifest_generator.py`
+  - `pytest_plugin.py` — pytest reporter analog
+  - `tests/` — `pytest` integration tests against a fixture HTML page
+
+## Python Locator Patterns
+
+Recognize (regex-based, no PSI — consistent with the no-JS/TS-module rule in `CLAUDE.md`):
+- `page.get_by_test_id("...")`
+- `page.get_by_role("button", name="...")`
+- `page.get_by_label("...")`
+- `page.get_by_placeholder("...")`
+- `page.get_by_text("...")`
+- `page.locator("...")`
+- Variable-bound receivers: `self.page.locator("...")`, `my_page.get_by_test_id("...")`
+
+## `LocatorExtractor` Interface
+
+```kotlin
+interface LocatorExtractor {
+    fun supportedExtensions(): Set<String>
+    fun extract(psiFileText: String, offset: Int): ExtractedLocator?
+    fun extractAll(psiFileText: String): List<ExtractedLocator>
+}
+```
+
+`LocatorExtractorRegistry` is a project service that holds all registered extractors and resolves by file extension.
+
+## Python Saver API
+
+```python
+from playwright_snapshot_saver import save_snapshot
+
+# Sync
+save_snapshot(page, name="login/initial", output_dir=".snapshots")
+
+# Async
+await save_snapshot_async(page, name="login/initial", output_dir=".snapshots")
+```
+
+Options mirror the TS package: `group`, `screenshot`, `manifest`, `extra_selectors`, `exclude_selectors`, `extra_attributes`.
+
+The pytest plugin (`pytest_plugin.py`) provides auto-capture on test failure when enabled via `@pytest.fixture` or `pytest.ini`.
+
+## Steps
+
+1. Refactor existing locator extraction into `LocatorExtractor` interface + `TypeScriptLocatorExtractor`; introduce `LocatorExtractorRegistry`. All existing tests still pass.
+2. Implement `PythonLocatorExtractor` with regex patterns above. Unit tests cover every pattern + edge cases (nested calls, kwargs, multi-line, comments).
+3. Wire `SelectorValidationAnnotator` to look up the extractor via the registry by file extension.
+4. Add `.py` to default `fileExtensions` in settings; update `PageMirrorConfigurable` if the default needs to be surfaced.
+5. Scaffold `packages/playwright-snapshot-saver-python/` with modern `pyproject.toml` (PEP 621) and `hatchling` or `poetry` build.
+6. Port `html-inliner.ts` to Python using `beautifulsoup4` + stdlib `urllib` — produce output matching the TS version for the shared fixture page (verified by golden-file test).
+7. Port `manifest-generator.ts` — emit spec-v1 compliant `manifest.json` per `docs/snapshot-bundle-spec.md`.
+8. Implement `save_snapshot` / `save_snapshot_async` for `playwright.sync_api.Page` and `playwright.async_api.Page`.
+9. Implement `pytest_plugin.py` reporter (fixture + hook) analogous to `playwright-snapshot-saver`'s Playwright reporter.
+10. Integration tests: `pytest` suite that launches a headless Chromium, visits a fixture page, calls `save_snapshot`, and asserts bundle layout + manifest contents.
+
+## Verification
+
+- **Plugin**: unit tests for `PythonLocatorExtractor` pass; manual smoke — open a `.py` Page Object with Playwright locators, confirm gutter badges and caret-driven tool-window highlight.
+- **Saver**: `pytest` integration tests pass; a bundle produced by the Python saver is byte-compatible with a TS bundle for the same fixture page (except for timestamp and driver fields).
+- `.snapshots/` bundles from both savers load identically in the plugin tool window.
+
+## Out of Scope
+
+- Python PSI-based extraction (regex is sufficient per `CLAUDE.md`).
+- pytest-xdist parallelization.
+- Publishing to PyPI (done separately when the package is ready).

--- a/docs/tasks/task-17-selenium-cypress-adapters.md
+++ b/docs/tasks/task-17-selenium-cypress-adapters.md
@@ -1,0 +1,61 @@
+# Task 17: Selenium + Cypress Snapshot Saver Adapters
+
+> **Goal:** Ship two new npm packages, `selenium-snapshot-saver` and `cypress-snapshot-saver`, each a thin `PageAdapter` implementation over `snapshot-core` (Task 15). Enables Selenium/Cypress users to produce identical snapshot bundles.
+> **Depends on:** Task 15 (`snapshot-core` extracted).
+> **Output:** Two new packages under `packages/`, each with integration tests against a fixture page.
+
+## Motivation
+
+Task 15 built the `PageAdapter` abstraction specifically so new driver adapters become small. Selenium and Cypress are the other two dominant JS test frameworks — shipping adapters for them multiplies the plugin's reach without touching plugin code at all.
+
+## Key Files
+
+- `packages/snapshot-core/src/page-adapter.ts` — interface to implement.
+- New: `packages/selenium-snapshot-saver/`
+  - `src/index.ts` — `SeleniumAdapter implements PageAdapter`
+  - `src/save.ts` — re-export `saveSnapshot` bound to the adapter
+  - `tests/` — WebDriver integration test
+- New: `packages/cypress-snapshot-saver/`
+  - `src/index.ts` — `CypressAdapter` + Cypress task plugin (`cy.task('saveSnapshot', ...)`)
+  - `tests/` — Cypress e2e fixture project
+
+## Adapter Notes
+
+### SeleniumAdapter
+- Wraps `selenium-webdriver`'s `WebDriver`.
+- `getHTML()` → `driver.getPageSource()`
+- `getCSS()` → execute JS: walk `document.styleSheets`, serialize rules.
+- `screenshot()` → `driver.takeScreenshot()` (returns base64 PNG) → optionally convert to WebP via `sharp`.
+- `getViewport()` → `driver.manage().window().getRect()`
+- `getURL()` / `getUserAgent()` → `driver.getCurrentUrl()` / `executeScript("return navigator.userAgent")`.
+
+### CypressAdapter
+- Cypress runs tests in-browser, so the adapter runs as a Node-side task plugin.
+- Exposes a Cypress task (`cy.task('saveSnapshot', opts)`) that receives HTML + URL + viewport from a browser-side companion script and delegates to `snapshot-core`.
+- Screenshot uses Cypress's `Cypress.screenshot()` output file.
+
+## Steps
+
+1. **Selenium package**:
+   - Scaffold `packages/selenium-snapshot-saver/` (workspace member). Depend on `@pagemirror/snapshot-core` and peer-depend on `selenium-webdriver`.
+   - Implement `SeleniumAdapter`.
+   - Write a Mocha/Vitest integration test that launches ChromeDriver, opens a fixture HTML page, calls `saveSnapshot`, asserts bundle layout + manifest per `docs/snapshot-bundle-spec.md`.
+   - README with usage example.
+2. **Cypress package**:
+   - Scaffold `packages/cypress-snapshot-saver/`. Depend on `@pagemirror/snapshot-core` and peer-depend on `cypress`.
+   - Implement the Node task plugin + browser-side helper.
+   - Integration test: a Cypress e2e spec that visits a fixture page and calls `cy.task('saveSnapshot', ...)`; assert bundle produced.
+   - README with usage example.
+3. Wire both packages into the Task 14 `testReport` aggregator so their test output shows up in `claude-summary.*`.
+
+## Verification
+
+- Both packages build and their integration tests pass locally and in CI.
+- Bundles produced by Selenium and Cypress adapters load in the plugin tool window identically to Playwright bundles.
+- Manifest declares the correct driver (`selenium` / `cypress`) per the spec.
+
+## Out of Scope
+
+- Bundling a Cypress component-test adapter (only e2e mode for now).
+- Publishing to npm registry.
+- Support for Selenium 3 (target Selenium 4+).

--- a/docs/tasks/task-18-jvm-playwright-support.md
+++ b/docs/tasks/task-18-jvm-playwright-support.md
@@ -1,0 +1,75 @@
+# Task 18: Java/Kotlin Playwright Support
+
+> **Goal:** Recognize Playwright Java API locators in `.java` and `.kt` files (highlight + gutter) AND ship `snapshot-saver-jvm` — a Kotlin JVM library that produces spec-v1 bundles from `com.microsoft.playwright.Page`.
+> **Depends on:** Task 16 (introduces `LocatorExtractor` interface + registry), `docs/snapshot-bundle-spec.md`.
+> **Output:** `JvmLocatorExtractor.kt`, new Gradle artifact `packages/playwright-snapshot-saver-jvm/`.
+
+## Motivation
+
+Playwright's Java API is used by a substantial Selenium-migration crowd and shares the same surface with Kotlin test suites. This task closes the language gap for the JVM ecosystem and finishes Track A. Because the plugin itself is Kotlin/JVM, the saver can reuse the plugin's existing Jsoup dependency for HTML inlining — no new dependencies.
+
+## Key Files
+
+### Plugin side
+- `src/main/kotlin/com/github/artem/pageobjectplugin/locators/LocatorExtractorRegistry.kt` — register new extractor for `.java`, `.kt`.
+- New: `src/main/kotlin/com/github/artem/pageobjectplugin/locators/JvmLocatorExtractor.kt`
+- New: `src/test/kotlin/com/github/artem/pageobjectplugin/locators/JvmLocatorExtractorTest.kt`
+- `src/main/kotlin/com/github/artem/pageobjectplugin/settings/PageMirrorSettings.kt` — add `.java`, `.kt` to default `fileExtensions`.
+
+### Saver package
+- New: `packages/playwright-snapshot-saver-jvm/` (own `build.gradle.kts`, included via `settings.gradle.kts`).
+  - Published coordinates: `com.example.pagemirror:snapshot-saver-jvm`
+  - `src/main/kotlin/.../SnapshotSaver.kt` — `SnapshotSaver.save(page, name, options)`
+  - `src/main/kotlin/.../HtmlInliner.kt` — Jsoup-based inliner
+  - `src/main/kotlin/.../ManifestGenerator.kt`
+  - `src/main/kotlin/.../junit5/SnapshotSaverExtension.kt` — JUnit 5 extension analog of the TS reporter
+  - `src/test/` — JUnit 5 integration tests using `com.microsoft.playwright`
+
+## JVM Locator Patterns
+
+- `page.getByTestId("...")`
+- `page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("..."))`
+- `page.getByLabel("...")`
+- `page.getByPlaceholder("...")`
+- `page.getByText("...")`
+- `page.locator("...")`
+- Both Java (`new Page.GetByRoleOptions()`) and Kotlin (`GetByRoleOptions { name = "..." }`) idioms.
+- Variable-bound receivers (`this.page.locator(...)`, `pageObject.submitButton()` — latter is out of scope since it requires cross-file resolution, handled by Task 16's registry-level convention of field references).
+
+## Saver API
+
+```kotlin
+// Kotlin
+SnapshotSaver.save(page, name = "login/initial") {
+    outputDir = File(".snapshots")
+    screenshot = ScreenshotFormat.WEBP
+    extraSelectors += "[data-custom]"
+}
+
+// Java
+SnapshotSaver.save(page, "login/initial", new SaveOptions().setOutputDir(new File(".snapshots")));
+```
+
+## Steps
+
+1. Implement `JvmLocatorExtractor` (regex-based, per `CLAUDE.md`). Unit tests for each pattern in both Java and Kotlin syntax.
+2. Register extractor in `LocatorExtractorRegistry` for `.java`, `.kt`.
+3. Add `.java`, `.kt` to default `fileExtensions` in settings.
+4. Scaffold `packages/playwright-snapshot-saver-jvm/` as a sibling Gradle project, included via root `settings.gradle.kts`. Kotlin JVM, Java 17 target.
+5. Implement `HtmlInliner` in Kotlin using Jsoup (port of TS version, verified against the shared fixture page via golden-file test).
+6. Implement `ManifestGenerator` emitting spec-v1 JSON via `kotlinx.serialization`.
+7. Implement `SnapshotSaver.save()` against `com.microsoft.playwright.Page`. Options class mirrors the TS API.
+8. Implement `SnapshotSaverExtension` as a JUnit 5 `TestWatcher` + `ParameterResolver` — auto-captures on failure when registered.
+9. Integration tests: JUnit 5 suite that launches Playwright Java, visits a fixture page, calls the saver, asserts bundle layout.
+
+## Verification
+
+- **Plugin**: unit tests for `JvmLocatorExtractor` pass; manual smoke on a `.java` and `.kt` Playwright test file — gutter and highlight work.
+- **Saver**: `./gradlew :playwright-snapshot-saver-jvm:test` green; bundles byte-compatible with Python + TS savers for the shared fixture (minus timestamp + driver field).
+- All three language savers (TS, Python, JVM) produce bundles that load identically in the plugin tool window.
+
+## Out of Scope
+
+- Cross-file resolution of Page Object field references (requires PSI, breaks the no-JS/TS-module rule for JVM files too — future work).
+- JUnit 4 support.
+- Publishing to Maven Central.

--- a/docs/tasks/task-19-feature-demo-trace-viewer.md
+++ b/docs/tasks/task-19-feature-demo-trace-viewer.md
@@ -1,0 +1,102 @@
+# Task 19: Feature Demo — Playwright-Style Trace Viewer
+
+> **Goal:** Produce a self-contained HTML trace viewer (Playwright-style) per PR that lets reviewers step through every UI test exercising a changed or added feature — timeline, action log, before/after DOM snapshots, screenshots — triggered by adding a `demo` label on a PR.
+> **Depends on:** Task 13c (trace bundle + `trace.json` schema), Task 14 (CI reporting, artifact upload).
+> **Output:** `./gradlew demoReport -PfeatureName=<tag>` Gradle task, `@Feature("name")` annotation, CI workflow triggered by `demo` label, `build/reports/demo/<feature>/index.html` artifact.
+
+## Motivation
+
+Reviewing a UI-heavy PR today means pulling the branch, running tests locally, and eyeballing screenshots. That's friction. We want a reviewer to click a link on the PR and instantly walk through every test scenario that covers the changed feature — happy path and negative cases — with the same fidelity Playwright's trace viewer offers its users. This is reviewer ergonomics, not a testing feature.
+
+Crucially, this task does **not** build a parallel capture pipeline. It reuses the exact trace bundles Task 13c already produces and adds: (1) a `@Feature("tag")` annotation to select tests, (2) a Gradle task to filter + package, (3) a self-contained HTML renderer, (4) CI wiring for the `demo` label.
+
+## Key Files
+
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/support/TraceBundleExtension.kt` — reuse; extend to record `@Feature` tag in `trace.json`.
+- New: `src/uiTest/kotlin/com/github/artem/pageobjectplugin/annotations/Feature.kt`
+- New: `src/uiTest/kotlin/com/github/artem/pageobjectplugin/support/FeatureTagListener.kt` — JUnit 5 `TestExecutionListener` that writes the tag into the trace.
+- `build.gradle.kts` — new `demoReport` task.
+- New: `buildSrc/src/main/kotlin/DemoReportRenderer.kt` — reads trace bundles, emits self-contained HTML.
+- New: `src/main/resources/demo-viewer/` — static HTML+JS+CSS template for the viewer (embedded into the rendered output).
+- `.github/workflows/demo.yml` — triggered by `pull_request` with `demo` label.
+
+## `@Feature` Annotation
+
+```kotlin
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Feature(val tag: String)
+```
+
+Tests opt in: either a whole class is tagged, or an individual method. `FeatureTagListener` reads the annotation and injects `test.feature` into the generated `trace.json` (schema already defined in Task 13c).
+
+## Test Selection Logic
+
+When `demoReport` runs, it includes a UI test if **either** holds:
+1. The test has `@Feature("<tag>")` matching `-PfeatureName=<tag>`, **OR**
+2. The test's covered source files intersect `-PchangedFiles=...` (or, if not provided, files from `git diff origin/main...HEAD`).
+
+Both sources are unioned so:
+- **New features**: authors add `@Feature("new-foo")` to the tests they create — demo task enforces **≥ 2 scenarios** for the tag (fails otherwise) so happy-path + negative cases are both present.
+- **Updated features**: pre-existing tests carrying the tag automatically run alongside tests touched by the diff, letting reviewers confirm nothing regressed.
+
+Covered-files detection: use the existing Kotlin/Java coverage plugin (`kover` or `jacoco`) to map test → touched sources from a prior run, or fall back to a heuristic (test class package ↔ source package).
+
+## Gradle Task
+
+```
+./gradlew demoReport -PfeatureName=highlight-all
+./gradlew demoReport -PfeatureName=highlight-all -PchangedFiles=src/main/kotlin/.../Foo.kt,...
+```
+
+Steps the task performs:
+1. Enumerate UI tests and select per the logic above.
+2. Run them with `-PcaptureAllTraces=true` so passing tests also produce bundles.
+3. Enforce the ≥2-scenarios rule for a tag.
+4. Aggregate the produced `build/reports/uiTest/traces/<test>/` directories.
+5. Emit `build/reports/demo/<feature>/index.html`.
+
+## Trace Viewer (`index.html`)
+
+Self-contained: single HTML file with inlined CSS + JS + base64-encoded screenshots and DOM snapshots (so it's trivially shareable as a PR comment link to a CI artifact, no relative-path breakage).
+
+UI layout:
+- Left pane: list of tests with pass/fail status.
+- Center: timeline scrubber showing steps (from `StepRecorder`) with screenshots on hover.
+- Right: details for the selected step — DOM diff before/after, failure stack trace if any, link to source file.
+- Top: summary counts (N tests, M steps, X failures) + feature tag + git SHA.
+
+Implementation is vanilla JS — no framework, no build step — reading the `trace.json` files embedded as a single JSON blob in the HTML.
+
+## CI Wiring (`.github/workflows/demo.yml`)
+
+- Trigger: `pull_request` with type `labeled`, when the label is `demo`.
+- Job:
+  1. Checkout with full history.
+  2. Compute changed files from `git diff origin/${{ github.base_ref }}...HEAD`.
+  3. Run `./gradlew demoReport -PchangedFiles=... -PfeatureName=<derived-from-label-suffix-or-PR-title>`.
+  4. Upload `build/reports/demo/**` as an artifact.
+  5. Post a single PR comment linking the artifact. **No automatic runs on every push** — `demo` label must be re-added to regenerate.
+
+## Steps
+
+1. Add `@Feature` annotation and `FeatureTagListener`; extend `TraceBundleExtension` to write the tag into `trace.json`.
+2. Implement `DemoReportRenderer` in `buildSrc`: read trace bundles, template the self-contained HTML viewer.
+3. Write the static viewer template (`resources/demo-viewer/{index.html, app.js, styles.css}`) against the Task 13c `trace.json` schema.
+4. Register the `demoReport` Gradle task in `build.gradle.kts`. Implement test-selection logic. Enforce ≥2-scenarios rule.
+5. Add `.github/workflows/demo.yml` with the trigger above.
+6. Write a smoke test: a fixture UI test tagged `@Feature("smoke")`, run `demoReport`, assert the HTML exists and contains the test's step names.
+
+## Verification
+
+- `./gradlew demoReport -PfeatureName=smoke` produces `build/reports/demo/smoke/index.html`.
+- Opening the HTML in a browser shows the tests, timeline, screenshots, and DOM snapshots.
+- Running with a tag that has only one scenario fails with a clear error demanding happy + negative coverage.
+- A PR labeled `demo` in CI uploads the artifact and posts a linking comment.
+- Removing the `demo` label and re-adding it regenerates the artifact.
+
+## Out of Scope
+
+- Live/interactive DOM editing in the viewer.
+- Cross-PR diffing of trace bundles.
+- Non-UI test inclusion (unit/npm) — demo is UI-only.

--- a/docs/tasks/task-20-appium-mobile-support.md
+++ b/docs/tasks/task-20-appium-mobile-support.md
@@ -1,0 +1,72 @@
+# Task 20: Appium Mobile Snapshot Saver
+
+> **Goal:** Ship `appium-snapshot-saver` — a `PageAdapter` over Appium that captures native mobile page source + screenshot into a spec-v1 bundle, extending the manifest `viewport` with platform + device metadata.
+> **Depends on:** Task 15 (`snapshot-core`), Task 17 (pattern for adapter packages).
+> **Output:** New `packages/appium-snapshot-saver/`, decision on HTML-vs-XML rendering fallback tracked as follow-up.
+
+## Motivation
+
+Appium exposes UI tree dumps as XML, not HTML. Supporting it stretches the snapshot-bundle spec in a productive way: it forces the core to acknowledge that "page source" isn't always HTML, and it opens the plugin to mobile QA workflows. This is the largest unknown in the roadmap — scoped last deliberately.
+
+## Key Files
+
+- `packages/snapshot-core/src/page-adapter.ts` — may need a `sourceFormat: "html" | "xml"` field on the adapter result.
+- New: `packages/appium-snapshot-saver/`
+  - `src/index.ts` — `AppiumAdapter implements PageAdapter`
+  - `tests/` — integration test against Appium's demo app or a stubbed driver
+
+## Adapter Notes
+
+### AppiumAdapter
+- Wraps `webdriverio`'s Appium client.
+- `getHTML()` → `driver.getPageSource()` (returns XML on native, HTML in webview mode).
+- `getCSS()` → empty list for native contexts (no CSS concept).
+- `screenshot()` → `driver.takeScreenshot()`.
+- `getViewport()` → `driver.getWindowSize()` + device metadata from session capabilities.
+- Manifest extension:
+  ```json
+  {
+    "version": 1,
+    "viewport": {
+      "width": 390,
+      "height": 844,
+      "platform": "iOS",
+      "deviceName": "iPhone 14",
+      "orientation": "portrait"
+    },
+    "appium": "2.5.4"
+  }
+  ```
+  This is an **additive** manifest change — does not bump `spec.version`.
+
+## Open Question: Plugin-side Rendering of XML
+
+The plugin's tool window iframe is HTML-only. XML page-source cannot render there directly. Options:
+
+1. **Out of scope for this task** — the saver produces bundles; the plugin renderer adds an XML fallback later (track as new task, "Task 21: Plugin XML viewer for native mobile snapshots").
+2. **Convert at capture time** — the Appium adapter transforms XML into a debug-styled HTML tree representation before writing. Lossy for some attributes, but renders immediately.
+
+**Decision:** take option 1 — keep bundles faithful to the source format and defer rendering. The saver writes `index.xml` *alongside* `index.html` (a minimal HTML that loads/displays the XML for debugging). The plugin continues to treat these bundles as "supported for file listing and screenshot only" until Task 21 lands.
+
+## Steps
+
+1. Add an optional `sourceFormat: "html" | "xml"` field to `PageAdapter`'s return from `getHTML()` (or rename to `getSource()`). Update Playwright/Selenium/Cypress adapters to pass `"html"` explicitly.
+2. Update `snapshot-core` to write both `index.html` (a minimal wrapper showing "native snapshot — see index.xml") and `index.xml` when `sourceFormat === "xml"`.
+3. Scaffold `packages/appium-snapshot-saver/`. Depend on `@pagemirror/snapshot-core`, peer-depend on `webdriverio`.
+4. Implement `AppiumAdapter`. Extract platform/device from session capabilities and pass into `SaveSnapshotOptions.viewport` extras.
+5. Update `docs/snapshot-bundle-spec.md` with the additive manifest fields and the dual-file layout. Do **not** bump schema version (additive change per spec rules).
+6. Integration test: either against the Appium demo app via a CI-provisioned emulator, or against a stubbed driver that returns canned page source + screenshot. Prefer stubbed for CI stability; real-device test stays manual.
+7. README with platform-specific setup notes.
+
+## Verification
+
+- Bundles produced by `AppiumAdapter` conform to spec v1 with the additive mobile fields.
+- Both `index.html` and `index.xml` present for native snapshots; only `index.html` for webview snapshots.
+- `snapshot-core` tests still pass; no regression for Playwright/Selenium/Cypress bundles.
+- The plugin tool window can list and show screenshots for mobile bundles (full XML rendering waits for the follow-up task).
+
+## Out of Scope
+
+- Plugin-side XML tree rendering (→ follow-up Task 21).
+- iOS-specific accessibility inspection.
+- Publishing to npm registry.


### PR DESCRIPTION
## Summary

This PR adds extensive documentation for the PageObjectPlugin roadmap and implementation tasks, organizing future work into three tracks (Language Support, Snapshot Saver Consolidation, and Repo/Inner Loop Improvements) with detailed specifications for each task.

## Key Changes

- **Roadmap.md**: High-level overview organizing 13 tasks across three tracks (A, B, C) with suggested execution order and verification criteria
- **snapshot-bundle-spec.md**: Formal specification for the on-disk snapshot bundle format (v1) consumed by the plugin and produced by all language-specific savers
- **Track A (Language Support)**:
  - Task 16: Python Playwright support with `PythonLocatorExtractor` and `playwright-snapshot-saver-python` PyPI package
  - Task 18: Java/Kotlin Playwright support with `JvmLocatorExtractor` and `snapshot-saver-jvm` Gradle artifact
- **Track B (Snapshot Saver Consolidation)**:
  - Task 15: Extract framework-agnostic `snapshot-core` with `PageAdapter` interface
  - Task 17: Selenium and Cypress snapshot saver adapters
  - Task 20: Appium mobile snapshot saver with XML support
- **Track C (Repo/Inner Loop)**:
  - Task 13a: Unblock UI test runner (fix `splitMode` + fast health check)
  - Task 13b: UI test reliability (polling helpers, retry-once, `@Quarantine` annotation)
  - Task 13c: Per-test diagnostics trace bundle with `trace.json` manifest
  - Task 13d: Page Object pattern refactor (locators/pages/flows layering)
  - Task 14: CI test reporting with `claude-summary.json/md` for autonomous iteration
  - Task 19: Feature demo trace viewer (Playwright-style) triggered by `demo` label

## Notable Implementation Details

- **Locator Extraction**: Introduces `LocatorExtractor` interface and registry pattern to support multiple languages (TypeScript, Python, Java/Kotlin) without duplicating extraction logic
- **Snapshot Bundle Format**: Standardizes on self-contained HTML with inlined CSS, optional WebP screenshot, and `manifest.json` metadata across all language savers
- **Trace Viewer**: Reuses existing trace bundles from Task 13c, adds `@Feature` annotation for test selection, and renders as self-contained HTML with timeline, action log, and DOM snapshots
- **Test Reporting**: Aggregates JUnit XML and npm test output into machine-readable JSON and Markdown summaries optimized for Claude Code autonomous iteration
- **UI Test Layering**: Proposes strict separation of concerns (locators → pages → flows → tests) with `StepRecorder` integration for trace capture

All tasks include detailed steps, verification criteria, and dependencies to enable parallel execution where possible.

https://claude.ai/code/session_01TibAzr5rfA6Zn83PgPq6Y5