### PR TITLE
Task 14: Implement CI test reporting and Claude inner loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
           name: unit-test-reports
           path: build/reports/tests/test/
 
+      # Raw JUnit XML — consumed by the test-report aggregator job below.
+      - name: Upload raw unit-test XML (for aggregator)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-test-raw
+          path: build/test-results/test/
+
       - name: Upload test report to dashboard
         if: success() || failure()
         run: |
@@ -137,6 +145,18 @@ jobs:
             build/screenshots/uiTest/
             build/idea-sandbox/system/log/
 
+      # Raw JUnit XML + per-test trace bundles — consumed by the
+      # test-report aggregator job below. Path layout matches what the
+      # aggregator expects under `build/`.
+      - name: Upload raw uiTest results (for aggregator)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-raw
+          path: |
+            build/test-results/uiTest/
+            build/reports/uiTest/traces/
+
       - name: Upload UI test report to dashboard
         if: success() || failure()
         run: |
@@ -196,13 +216,26 @@ jobs:
 
       - name: Run Playwright tests
         working-directory: packages/playwright-snapshot-saver
-        run: npx playwright test --reporter=list,html
+        # Reporter set is configured in playwright.config.ts (list + html + json).
+        # The json reporter writes test-results/results.json, which the
+        # test-report job feeds into the buildSrc aggregator (Task 14).
+        run: npx playwright test
 
       - name: Upload Playwright reports
         if: failure()
         uses: actions/upload-artifact@v4
         with:
           name: playwright-test-reports
+          path: packages/playwright-snapshot-saver/test-results/
+
+      # Raw Playwright JSON reporter output — consumed by the test-report
+      # aggregator job below. results.json is written by the `json`
+      # reporter declared in playwright.config.ts.
+      - name: Upload raw Playwright JSON (for aggregator)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-raw
           path: packages/playwright-snapshot-saver/test-results/
 
       - name: Upload Playwright report to dashboard
@@ -219,3 +252,141 @@ jobs:
           job_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
           git_ref=${{ github.ref_name }}&\
           git_sha=${{ github.sha }}"
+
+  # ── Task 14: Claude Inner Loop ──────────────────────────────────────────
+  #
+  # Downloads the raw test outputs from each parallel job, runs the
+  # buildSrc aggregator (`./gradlew aggregateTestReport`), and uploads
+  # the resulting `claude-summary.{json,md}` bundle to:
+  #   1. The `test-report-<sha>` GitHub Actions artifact (for ad-hoc
+  #      manual download).
+  #   2. The `claude-summary` suite on reports.artemon.cloud (the MAIN
+  #      step — this is how remote Claude Code sessions consume CI test
+  #      results via /api/v1/external/runs without needing GitHub auth).
+  #
+  # See CLAUDE.md "Test Loop" for the loop redlines, including the
+  # non-negotiable rule that this job's dashboard upload step must not
+  # be removed, disabled, or marked `continue-on-error`.
+  test-report:
+    name: Aggregate Claude Test Report
+    needs: [unit-tests, ui-tests, playwright-tests]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # Download every raw test surface. continue-on-error so a single
+      # missing artifact (e.g. a job that didn't run because an upstream
+      # one failed early) does not block aggregation.
+      - name: Download raw unit-test XML
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-test-raw
+          path: build/test-results/test/
+        continue-on-error: true
+
+      - name: Download raw uiTest results
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-test-raw
+          path: build/
+        continue-on-error: true
+
+      - name: Download raw Playwright JSON
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-test-raw
+          path: packages/playwright-snapshot-saver/test-results/
+        continue-on-error: true
+
+      # Aggregator runs even if some downloads were missing — it tolerates
+      # empty inputs by emitting an empty suite. continue-on-error so a
+      # non-zero exit (failed tests) still lets the upload steps run.
+      - name: Generate Claude summary
+        id: aggregate
+        run: ./gradlew aggregateTestReport
+        continue-on-error: true
+
+      - name: Upload combined test report bundle (GH artifact)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-${{ github.sha }}
+          path: |
+            build/reports/claude-summary.json
+            build/reports/claude-summary.md
+            build/reports/uiTest/traces/
+
+      # ── MAIN STEP: enables the remote Claude inner loop. ──
+      # Intentionally NO `continue-on-error` and an explicit HTTP-code
+      # check: a non-2xx response turns this job red even when every test
+      # passed. A green test-report job without a dashboard artifact
+      # means remote Claude sessions cannot read CI results, which is the
+      # whole point of the loop. Removing or disabling this step is a
+      # CLAUDE.md redline (see "Test Loop" → Redlines).
+      - name: Upload claude-summary bundle to reports.artemon.cloud
+        if: always()
+        env:
+          RD_TOKEN: ${{ secrets.RD_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GIT_REF: ${{ github.ref_name }}
+          GIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if [ ! -f build/reports/claude-summary.json ]; then
+            echo "::error::claude-summary.json missing — aggregator did not run"
+            exit 1
+          fi
+          mkdir -p claude-summary-bundle
+          cp build/reports/claude-summary.json build/reports/claude-summary.md claude-summary-bundle/
+          if [ -d build/reports/uiTest/traces ]; then
+            cp -r build/reports/uiTest/traces claude-summary-bundle/traces
+          fi
+          (cd claude-summary-bundle && zip -r ../claude-summary-bundle.zip .)
+          URL="https://reports.artemon.cloud/api/v1/upload?suite=claude-summary&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}"
+          HTTP_CODE=$(curl -sS -o /tmp/rd-response.txt -w '%{http_code}' -X POST \
+            -H "Authorization: Bearer ${RD_TOKEN}" \
+            -F "report=@claude-summary-bundle.zip" "$URL")
+          echo "Dashboard response: $HTTP_CODE"
+          cat /tmp/rd-response.txt || true
+          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
+            echo "::error::claude-summary dashboard upload failed (HTTP $HTTP_CODE) — the remote Claude loop is broken"
+            exit 1
+          fi
+
+      # Best-effort housekeeping — a failed finalize is a warning, not a
+      # build failure, because the dashboard tolerates re-finalizes.
+      - name: Finalize run on dashboard
+        if: always()
+        env:
+          RD_TOKEN: ${{ secrets.RD_TOKEN }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          curl -sS -X POST \
+            -H "Authorization: Bearer ${RD_TOKEN}" \
+            "https://reports.artemon.cloud/api/v1/executions/${RUN_ID}/finalize" \
+            || echo "::warning::finalize call failed — non-fatal"
+
+      # Final gate: propagate test failure to the job exit code, but only
+      # AFTER both the GH artifact and the dashboard bundle are already up.
+      - name: Fail the job if any test failed
+        run: |
+          if [ ! -f build/reports/claude-summary.json ]; then
+            echo "::error::claude-summary.json missing — see aggregate step logs"
+            exit 1
+          fi
+          sudo apt-get install -y --no-install-recommends jq >/dev/null 2>&1 || true
+          FAILED=$(jq -r '.totals.failed // 0' build/reports/claude-summary.json)
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED test(s) failed — see claude-summary.md (GH artifact test-report-${{ github.sha }} or dashboard suite 'claude-summary')"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,67 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 When investigating Gradle plugin APIs or build tooling, prefer reading project docs and running `./gradlew` commands (`help --task`, `dependencies`, `buildEnvironment`, etc.) over exploring files outside the project directory (e.g., `.gradle/caches/`, `.intellijPlatform/`). Stay within the project boundary.
 
+## Test Loop
+
+Tests run on **CI**, not locally. The plugin's test surface (Xvfb-driven
+UI tests, npm/Playwright integration tests, JCEF, sandboxed IDE) is
+expensive and platform-sensitive enough that the canonical "did my change
+break anything?" signal is the CI run for your branch — not `./gradlew test`
+in a developer terminal. The loop is:
+
+1. Push your branch.
+2. Wait for the `test-report` job in `.github/workflows/ci.yml` to
+   complete. It depends on `unit-tests`, `ui-tests`, and `playwright-tests`
+   and runs the buildSrc aggregator (`./gradlew aggregateTestReport`) on
+   their combined raw output.
+3. Read `claude-summary.md` from the `claude-summary` suite on
+   `reports.artemon.cloud` (see "Report Dashboard Access" below for the
+   token + read endpoints):
+
+   ```bash
+   BASE="${REPORT_DASHBOARD_URL:-https://reports.artemon.cloud}"
+   AUTH="Authorization: Bearer $REPORT_DASHBOARD_TOKEN"
+   RUN_ID=$(curl -sH "$AUTH" "$BASE/api/v1/external/runs" \
+              | jq -r '.data[0].run_id')
+   curl -sH "$AUTH" \
+     "$BASE/api/v1/external/runs/$RUN_ID/claude-summary/claude-summary.md"
+   ```
+
+4. The Markdown lists every failing test with `file:line` and (for UI
+   tests) the path to its trace bundle inside the same dashboard suite
+   (`/api/v1/external/runs/$RUN_ID/claude-summary/traces/<Class>__<method>/`).
+5. Fix locally. Push. Repeat from step 2.
+
+The aggregated `claude-summary.json` schema is documented in
+`docs/tasks/task-14-ci-test-reporting.md`. The same bundle is also
+uploaded as the GitHub Actions artifact `test-report-<sha>` for ad-hoc
+download, but the dashboard is the **primary** read path because it does
+not require GitHub auth and survives across sessions.
+
+`./gradlew testReport` exists as a developer-debugging side-tool that
+runs every suite locally and produces the same `claude-summary.{json,md}`
+under `build/reports/`. Use it when iterating on a single suite, but do
+not treat its output as the source of truth — only the CI run for your
+branch is authoritative.
+
+**Redlines** (non-negotiable):
+
+- **Never remove, disable, or `continue-on-error` the "Upload
+  claude-summary bundle to reports.artemon.cloud" step in
+  `.github/workflows/ci.yml`.** That upload is the main step of the
+  Test Loop; if it stops running the loop is broken even when every
+  test passes, because the remote dashboard endpoint is how this and
+  any future Claude Code session sees CI results. If the upload step
+  is flaky, fix the root cause — do not bypass it.
+- **Never delete a failing test to turn CI green.**
+- **Never add `@Ignore` / `@Disabled` without a ticket** linked in the
+  same commit; bare skips are banned.
+- **After a fix, always push and wait for the `test-report` CI job to
+  complete** before declaring green. Never cherry-pick a single local
+  test run as proof.
+- **Never use `node -e` or inline scripts for verification** — add a
+  real test (unit or integration).
+
 ## Workflow Rules
 
 - **Never use `node -e` for ad-hoc verification.** Always create a proper test (unit or integration) instead of running inline scripts. Tests are reusable, documented, and run in CI.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -193,4 +193,86 @@ tasks {
         // Never fail the build just because the index couldn't render.
         isIgnoreExitValue = true
     }
+
+    // ── Task 14: CI test reporting + Claude inner loop ────────────────────
+    //
+    // Runs the Playwright suite from the snapshot-saver package. The JSON
+    // reporter (configured in `packages/playwright-snapshot-saver/playwright.config.ts`)
+    // writes machine-readable results to `test-results/results.json`, which
+    // the aggregator below consumes.
+    register<Exec>("playwrightTest") {
+        description = "Runs Playwright tests under packages/playwright-snapshot-saver."
+        group = "verification"
+        workingDir = rootDir.resolve("packages/playwright-snapshot-saver")
+        commandLine("npx", "playwright", "test")
+    }
+
+    /**
+     * Parses every test surface (unit, uiTest, playwright) and writes
+     * `build/reports/claude-summary.{json,md}`. Lives in `buildSrc/` so it
+     * has zero dependency on the IntelliJ Platform classpath and can run
+     * even when no test source set has compiled. See
+     * `docs/tasks/task-14-ci-test-reporting.md` for the schema and the
+     * "Test Loop" section in `CLAUDE.md` for how it's consumed.
+     */
+    register("aggregateTestReport") {
+        description = "Aggregates test results into build/reports/claude-summary.{json,md}."
+        group = "verification"
+        val rootDirFile = rootDir
+        val buildDirFile = layout.buildDirectory.get().asFile
+        doLast {
+            val gitSha: String? = System.getenv("GITHUB_SHA")?.takeIf { it.isNotBlank() }
+                ?: runCatching {
+                    ProcessBuilder("git", "rev-parse", "HEAD")
+                        .directory(rootDirFile)
+                        .redirectErrorStream(true)
+                        .start()
+                        .inputStream.bufferedReader().readText().trim().ifEmpty { null }
+                }.getOrNull()
+            val summary = com.github.artem.pageobjectplugin.buildtools.ClaudeSummaryGenerator.run(
+                rootDir = rootDirFile,
+                buildDir = buildDirFile,
+                gitSha = gitSha,
+            )
+            logger.lifecycle(
+                "claude-summary: ${summary.totals.passed} passed, ${summary.totals.failed} failed, " +
+                    "${summary.totals.skipped} skipped, ${summary.totals.flaky} flaky " +
+                    "→ build/reports/claude-summary.{json,md}",
+            )
+            if (summary.totals.failed > 0) {
+                throw GradleException(
+                    "${summary.totals.failed} test(s) failed — see build/reports/claude-summary.md",
+                )
+            }
+        }
+    }
+
+    /**
+     * Developer entry point. Runs every test surface and then aggregates.
+     * The `whenReady` hook below makes the per-suite tasks tolerate
+     * failures so the aggregator always runs and emits the summary, while
+     * `aggregateTestReport` itself fails the build if any test failed.
+     *
+     * The canonical "did my change break anything?" loop is the CI run for
+     * the branch (see CLAUDE.md "Test Loop"). This task is only for
+     * iterating on a single suite locally.
+     */
+    register("testReport") {
+        description = "Runs all tests and emits build/reports/claude-summary.{json,md}."
+        group = "verification"
+        dependsOn("test", "uiTest", "playwrightTest")
+        finalizedBy("aggregateTestReport")
+    }
+}
+
+// When `testReport` is the entry point, let every per-suite task complete
+// (even on failure) so the aggregator gets to read all three sets of XML
+// / JSON outputs. Standalone `./gradlew test` (or `uiTest`, etc.) is
+// unaffected and still fails loudly.
+gradle.taskGraph.whenReady {
+    if (hasTask(":testReport")) {
+        tasks.named<Test>("test") { ignoreFailures = true }
+        tasks.named<Test>("uiTest") { ignoreFailures = true }
+        tasks.named<Exec>("playwrightTest") { isIgnoreExitValue = true }
+    }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    `kotlin-dsl`
+    kotlin("plugin.serialization") version "2.1.0"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     `kotlin-dsl`
-    kotlin("plugin.serialization") version "2.1.0"
 }
 
 repositories {
@@ -8,15 +7,18 @@ repositories {
 }
 
 dependencies {
+    // Runtime-only kotlinx-serialization-json (NO compiler plugin):
+    // we only use Json.parseToJsonElement / buildJsonObject / JsonElement,
+    // none of which need codegen. Pulling in the
+    // `org.jetbrains.kotlin.plugin.serialization` Gradle plugin would
+    // conflict with `kotlin-dsl`'s embedded Kotlin compiler (Gradle 9.4
+    // ships Kotlin ~2.0.21 and the serialization plugin's BOM forces a
+    // newer kotlin-gradle-plugin-api that has no matching Gradle variant).
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
 
     testImplementation(kotlin("test"))
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-}
-
-kotlin {
-    jvmToolchain(21)
 }
 
 tasks.test {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+rootProject.name = "buildSrc"
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryGenerator.kt
@@ -1,8 +1,14 @@
 package com.github.artem.pageobjectplugin.buildtools
 
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+import kotlinx.serialization.json.putJsonObject
 import java.io.File
 import java.time.Instant
 
@@ -16,6 +22,11 @@ import java.time.Instant
  *  - UI tests:      `<buildDir>/test-results/uiTest/`
  *  - UI traces:     `<buildDir>/reports/uiTest/traces/`
  *  - Playwright:    `<rootDir>/packages/playwright-snapshot-saver/test-results/results.json`
+ *
+ * JSON output is built manually via `buildJsonObject {}` so buildSrc does
+ * not need the `kotlinx.serialization` Gradle compiler plugin (which
+ * conflicts with `kotlin-dsl`'s embedded Kotlin — see
+ * `buildSrc/build.gradle.kts`). Only the runtime library is required.
  */
 object ClaudeSummaryGenerator {
 
@@ -23,12 +34,10 @@ object ClaudeSummaryGenerator {
     private val json = Json {
         prettyPrint = true
         prettyPrintIndent = "  "
-        encodeDefaults = true
     }
 
     fun run(rootDir: File, buildDir: File, gitSha: String? = null): ClaudeSummary {
         val unit = JUnitXmlParser.parse(buildDir.resolve("test-results/test"))
-            .map { it.copy() }
         val uiRaw = JUnitXmlParser.parse(buildDir.resolve("test-results/uiTest"))
         val ui = TraceJsonAugmenter.augment(
             tracesRoot = buildDir.resolve("reports/uiTest/traces"),
@@ -61,9 +70,43 @@ object ClaudeSummaryGenerator {
         )
 
         val reportsDir = buildDir.resolve("reports").apply { mkdirs() }
-        reportsDir.resolve("claude-summary.json").writeText(json.encodeToString(summary))
-        reportsDir.resolve("claude-summary.md").writeText(MarkdownEmitter.render(summary, gitSha))
+        reportsDir.resolve("claude-summary.json")
+            .writeText(json.encodeToString(JsonElement.serializer(), summary.toJsonElement()))
+        reportsDir.resolve("claude-summary.md")
+            .writeText(MarkdownEmitter.render(summary, gitSha))
 
         return summary
+    }
+
+    private fun ClaudeSummary.toJsonElement(): JsonElement = buildJsonObject {
+        put("version", version)
+        put("generatedAt", generatedAt)
+        putJsonObject("totals") {
+            put("passed", totals.passed)
+            put("failed", totals.failed)
+            put("skipped", totals.skipped)
+            put("flaky", totals.flaky)
+            put("durationMs", totals.durationMs)
+        }
+        putJsonArray("suites") {
+            suites.forEach { suite ->
+                addJsonObject {
+                    put("suite", suite.suite)
+                    putJsonArray("tests") {
+                        suite.tests.forEach { test ->
+                            addJsonObject {
+                                put("name", test.name)
+                                put("status", test.status)
+                                put("durationMs", test.durationMs)
+                                if (test.file != null) put("file", test.file) else put("file", JsonNull)
+                                if (test.line != null) put("line", test.line) else put("line", JsonNull)
+                                if (test.failureMessage != null) put("failureMessage", test.failureMessage) else put("failureMessage", JsonNull)
+                                if (test.tracePath != null) put("tracePath", test.tracePath) else put("tracePath", JsonNull)
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryGenerator.kt
@@ -1,0 +1,69 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.time.Instant
+
+/**
+ * Top-level orchestrator. Wires the parsers + augmenter + emitter together
+ * and writes both `claude-summary.json` and `claude-summary.md` under
+ * `<buildDir>/reports/`.
+ *
+ * Path layout (relative to [rootDir] / [buildDir]):
+ *  - Unit tests:    `<buildDir>/test-results/test/`
+ *  - UI tests:      `<buildDir>/test-results/uiTest/`
+ *  - UI traces:     `<buildDir>/reports/uiTest/traces/`
+ *  - Playwright:    `<rootDir>/packages/playwright-snapshot-saver/test-results/results.json`
+ */
+object ClaudeSummaryGenerator {
+
+    @OptIn(ExperimentalSerializationApi::class)
+    private val json = Json {
+        prettyPrint = true
+        prettyPrintIndent = "  "
+        encodeDefaults = true
+    }
+
+    fun run(rootDir: File, buildDir: File, gitSha: String? = null): ClaudeSummary {
+        val unit = JUnitXmlParser.parse(buildDir.resolve("test-results/test"))
+            .map { it.copy() }
+        val uiRaw = JUnitXmlParser.parse(buildDir.resolve("test-results/uiTest"))
+        val ui = TraceJsonAugmenter.augment(
+            tracesRoot = buildDir.resolve("reports/uiTest/traces"),
+            entries = uiRaw,
+            relativizeBase = rootDir,
+        )
+        val playwright = PlaywrightJsonParser.parse(
+            rootDir.resolve("packages/playwright-snapshot-saver/test-results/results.json")
+        )
+
+        val suites = listOf(
+            Suite(suite = "unit", tests = unit),
+            Suite(suite = "uiTest", tests = ui),
+            Suite(suite = "npm:playwright-snapshot-saver", tests = playwright),
+        ).filter { it.tests.isNotEmpty() }
+
+        val totals = Totals(
+            passed = suites.sumOf { s -> s.tests.count { it.status == "passed" } },
+            failed = suites.sumOf { s -> s.tests.count { it.status == "failed" } },
+            skipped = suites.sumOf { s -> s.tests.count { it.status == "skipped" } },
+            flaky = suites.sumOf { s -> s.tests.count { it.status == "flaky" } },
+            durationMs = suites.sumOf { s -> s.tests.sumOf { it.durationMs } },
+        )
+
+        val summary = ClaudeSummary(
+            version = 1,
+            generatedAt = Instant.now().toString(),
+            totals = totals,
+            suites = suites,
+        )
+
+        val reportsDir = buildDir.resolve("reports").apply { mkdirs() }
+        reportsDir.resolve("claude-summary.json").writeText(json.encodeToString(summary))
+        reportsDir.resolve("claude-summary.md").writeText(MarkdownEmitter.render(summary, gitSha))
+
+        return summary
+    }
+}

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryModel.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryModel.kt
@@ -1,7 +1,5 @@
 package com.github.artem.pageobjectplugin.buildtools
 
-import kotlinx.serialization.Serializable
-
 /**
  * Schema v1 of `build/reports/claude-summary.json`. Documented in
  * `docs/tasks/task-14-ci-test-reporting.md`. Consumed by Claude Code
@@ -11,8 +9,13 @@ import kotlinx.serialization.Serializable
  * No `quarantined` field: Task 13b never shipped `@Quarantine`, so the
  * Task 14 schema drops the field rather than carrying a perpetually-empty
  * placeholder.
+ *
+ * The model classes are NOT `@Serializable`: buildSrc cannot apply the
+ * `kotlinx.serialization` Gradle plugin without conflicting with
+ * `kotlin-dsl`'s embedded Kotlin compiler (see `buildSrc/build.gradle.kts`
+ * comment). JSON output is built manually via `buildJsonObject {}` in
+ * [ClaudeSummaryGenerator], which only needs the runtime library.
  */
-@Serializable
 data class ClaudeSummary(
     val version: Int = 1,
     val generatedAt: String,
@@ -20,7 +23,6 @@ data class ClaudeSummary(
     val suites: List<Suite>,
 )
 
-@Serializable
 data class Totals(
     val passed: Int,
     val failed: Int,
@@ -29,14 +31,12 @@ data class Totals(
     val durationMs: Long,
 )
 
-@Serializable
 data class Suite(
     /** "unit" | "uiTest" | "npm:playwright-snapshot-saver" | ... */
     val suite: String,
     val tests: List<TestEntry>,
 )
 
-@Serializable
 data class TestEntry(
     /** Fully-qualified `ClassName.testName` (or Playwright `file > test`). */
     val name: String,

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryModel.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryModel.kt
@@ -1,0 +1,54 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Schema v1 of `build/reports/claude-summary.json`. Documented in
+ * `docs/tasks/task-14-ci-test-reporting.md`. Consumed by Claude Code
+ * sessions reading the bundle from reports.artemon.cloud (suite slug
+ * `claude-summary`) — see CLAUDE.md "Test Loop".
+ *
+ * No `quarantined` field: Task 13b never shipped `@Quarantine`, so the
+ * Task 14 schema drops the field rather than carrying a perpetually-empty
+ * placeholder.
+ */
+@Serializable
+data class ClaudeSummary(
+    val version: Int = 1,
+    val generatedAt: String,
+    val totals: Totals,
+    val suites: List<Suite>,
+)
+
+@Serializable
+data class Totals(
+    val passed: Int,
+    val failed: Int,
+    val skipped: Int,
+    val flaky: Int,
+    val durationMs: Long,
+)
+
+@Serializable
+data class Suite(
+    /** "unit" | "uiTest" | "npm:playwright-snapshot-saver" | ... */
+    val suite: String,
+    val tests: List<TestEntry>,
+)
+
+@Serializable
+data class TestEntry(
+    /** Fully-qualified `ClassName.testName` (or Playwright `file > test`). */
+    val name: String,
+    /** "passed" | "failed" | "skipped" | "flaky" */
+    val status: String,
+    val durationMs: Long,
+    val file: String? = null,
+    val line: Int? = null,
+    val failureMessage: String? = null,
+    /**
+     * Relative path under the report bundle to the per-test trace dir.
+     * Populated only for `uiTest` entries with a matching trace.json bundle.
+     */
+    val tracePath: String? = null,
+)

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/JUnitXmlParser.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/JUnitXmlParser.kt
@@ -1,0 +1,113 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import org.w3c.dom.NodeList
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Parses Surefire-format JUnit XML files (`TEST-*.xml`) into [TestEntry]
+ * records. Both JUnit4 and JUnit5 emit this shape via Gradle's built-in
+ * test reporter, so one parser handles both.
+ *
+ * The parser does NOT distinguish flaky from passed: that information is
+ * not in the XML and comes from the trace.json augmenter for uiTest. For
+ * unit tests, "flaky" is always 0.
+ */
+object JUnitXmlParser {
+
+    /**
+     * @param dir directory containing one or more `TEST-*.xml` files; may
+     *            also be missing or empty (returns an empty list).
+     */
+    fun parse(dir: File): List<TestEntry> {
+        if (!dir.isDirectory) return emptyList()
+        val xmlFiles = dir.walkTopDown()
+            .filter { it.isFile && it.name.startsWith("TEST-") && it.extension == "xml" }
+            .toList()
+        if (xmlFiles.isEmpty()) return emptyList()
+
+        val factory = DocumentBuilderFactory.newInstance().apply {
+            // Defensive: disable external entity resolution.
+            setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+            isNamespaceAware = false
+            isValidating = false
+        }
+        val builder = factory.newDocumentBuilder()
+
+        return xmlFiles.flatMap { file ->
+            val doc = builder.parse(file)
+            val testcases = doc.getElementsByTagName("testcase")
+            buildList(testcases.length) {
+                for (i in 0 until testcases.length) {
+                    add(parseTestcase(testcases.item(i) as Element))
+                }
+            }
+        }
+    }
+
+    private fun parseTestcase(el: Element): TestEntry {
+        val classname = el.getAttribute("classname").ifEmpty { "Unknown" }
+        val name = el.getAttribute("name").ifEmpty { "unknown" }
+        val durationMs = (el.getAttribute("time").toDoubleOrNull() ?: 0.0)
+            .let { (it * 1000).toLong() }
+
+        val failure = el.firstChildElement("failure") ?: el.firstChildElement("error")
+        val skipped = el.firstChildElement("skipped")
+
+        val status = when {
+            failure != null -> "failed"
+            skipped != null -> "skipped"
+            else -> "passed"
+        }
+
+        val message = failure?.getAttribute("message")?.takeIf { it.isNotBlank() }
+        val stack = failure?.textContent.orEmpty()
+        val (file, line) = extractFirstFrame(classname, stack)
+
+        return TestEntry(
+            name = "$classname.$name",
+            status = status,
+            durationMs = durationMs,
+            file = file,
+            line = line,
+            failureMessage = message,
+            tracePath = null,
+        )
+    }
+
+    /**
+     * Walk the failure stack top-down looking for the first frame whose
+     * source file matches the test class. We return `Foo.kt:42` so the
+     * Markdown emitter can render `at Foo.kt:42` directly. Prefers a
+     * frame from the test class itself; falls back to the first frame
+     * with a source location.
+     *
+     * Stack frame examples:
+     *   at com.github.artem.pageobjectplugin.FooTest.bar(FooTest.kt:42)
+     *   at com.github.artem.pageobjectplugin.FooTest.bar(FooTest.java:42)
+     */
+    private fun extractFirstFrame(classname: String, stack: String): Pair<String?, Int?> {
+        if (stack.isBlank()) return null to null
+        val classFrameRegex = Regex(
+            """at\s+\Q$classname\E\.\S+\(([^:)]+):(\d+)\)"""
+        )
+        val frameRegex = Regex("""at\s+\S+\(([^:)]+):(\d+)\)""")
+        val match = classFrameRegex.find(stack)
+            ?: frameRegex.find(stack)
+            ?: return null to null
+        return match.groupValues[1] to match.groupValues[2].toIntOrNull()
+    }
+
+    private fun Element.firstChildElement(tag: String): Element? {
+        val list: NodeList = childNodes
+        for (i in 0 until list.length) {
+            val n = list.item(i)
+            if (n.nodeType == Node.ELEMENT_NODE && (n as Element).tagName == tag) {
+                return n
+            }
+        }
+        return null
+    }
+}

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/MarkdownEmitter.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/MarkdownEmitter.kt
@@ -1,0 +1,96 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+/**
+ * Renders a [ClaudeSummary] to the human-readable Markdown layout
+ * documented in `docs/tasks/task-14-ci-test-reporting.md` and used by the
+ * Test Loop section of `CLAUDE.md`.
+ *
+ * Sections:
+ *  - Header with totals + duration.
+ *  - `## Failures` (only if any failed): every failed test, its
+ *    `file:line`, message, and (uiTest) trace bundle path.
+ *  - `## Flaky` (only if any flaky): every flaky test that passed on retry.
+ *  - `## Suites`: per-suite pass/fail/skip counts as a quick TOC.
+ */
+object MarkdownEmitter {
+
+    fun render(summary: ClaudeSummary, gitSha: String? = null): String {
+        val sb = StringBuilder()
+        val header = if (gitSha != null) "Test Summary — ${gitSha.take(12)}" else "Test Summary"
+        sb.appendLine("# $header")
+        sb.appendLine()
+        sb.appendLine("Generated: ${summary.generatedAt}")
+        sb.appendLine()
+        sb.appendLine("Totals: ${formatTotals(summary.totals)}")
+        sb.appendLine()
+
+        val failures = summary.suites.flatMap { s -> s.tests.filter { it.status == "failed" }.map { s.suite to it } }
+        if (failures.isNotEmpty()) {
+            sb.appendLine("## Failures (${failures.size})")
+            sb.appendLine()
+            failures.forEachIndexed { i, (suite, t) ->
+                sb.appendLine("${i + 1}. `${t.name}` _(${suite})_")
+                val location = locationOf(t)
+                val message = t.failureMessage?.let { msg -> stripStackBoilerplate(msg) }
+                if (message != null && location != null) {
+                    sb.appendLine("   $message — at $location")
+                } else if (message != null) {
+                    sb.appendLine("   $message")
+                } else if (location != null) {
+                    sb.appendLine("   at $location")
+                }
+                if (t.tracePath != null) {
+                    sb.appendLine("   Trace: ${t.tracePath}")
+                }
+            }
+            sb.appendLine()
+        }
+
+        val flaky = summary.suites.flatMap { s -> s.tests.filter { it.status == "flaky" }.map { s.suite to it } }
+        if (flaky.isNotEmpty()) {
+            sb.appendLine("## Flaky (retried once) (${flaky.size})")
+            sb.appendLine()
+            flaky.forEach { (suite, t) ->
+                sb.append("- `${t.name}` _(${suite})_ — passed on retry")
+                if (t.tracePath != null) sb.append(" — Trace: ${t.tracePath}")
+                sb.appendLine()
+            }
+            sb.appendLine()
+        }
+
+        sb.appendLine("## Suites")
+        sb.appendLine()
+        summary.suites.forEach { suite ->
+            val passed = suite.tests.count { it.status == "passed" }
+            val failed = suite.tests.count { it.status == "failed" }
+            val skipped = suite.tests.count { it.status == "skipped" }
+            val flak = suite.tests.count { it.status == "flaky" }
+            val durMs = suite.tests.sumOf { it.durationMs }
+            sb.appendLine("- **${suite.suite}** — $passed passed, $failed failed, $skipped skipped, $flak flaky (${formatDuration(durMs)})")
+        }
+
+        return sb.toString()
+    }
+
+    private fun formatTotals(t: Totals): String {
+        return "${t.passed} passed, ${t.failed} failed, ${t.skipped} skipped, ${t.flaky} flaky (${formatDuration(t.durationMs)})"
+    }
+
+    private fun formatDuration(ms: Long): String {
+        if (ms < 1000) return "${ms}ms"
+        val totalSec = ms / 1000
+        val min = totalSec / 60
+        val sec = totalSec % 60
+        return if (min > 0) "${min}m ${sec}s" else "${sec}s"
+    }
+
+    private fun locationOf(t: TestEntry): String? {
+        val f = t.file ?: return null
+        return if (t.line != null) "$f:${t.line}" else f
+    }
+
+    private fun stripStackBoilerplate(message: String): String {
+        // Use only the first line so the bullet stays one row tall.
+        return message.lines().firstOrNull()?.trim().orEmpty().ifEmpty { message.trim() }
+    }
+}

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/PlaywrightJsonParser.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/PlaywrightJsonParser.kt
@@ -1,0 +1,116 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+
+/**
+ * Parses the Playwright `json` reporter output (default location
+ * `packages/playwright-snapshot-saver/test-results/results.json`) into
+ * [TestEntry] records. Schema reference:
+ * https://playwright.dev/docs/test-reporters#json-reporter
+ *
+ * Top-level shape:
+ * ```
+ * {
+ *   "suites": [
+ *     {
+ *       "title": "login.spec.ts",
+ *       "file": "tests/login.spec.ts",
+ *       "specs": [
+ *         {
+ *           "title": "logs in",
+ *           "line": 12,
+ *           "tests": [
+ *             {
+ *               "results": [
+ *                 { "status": "passed" | "failed" | "skipped", "duration": 1234, "error": {...} }
+ *               ]
+ *             }
+ *           ]
+ *         }
+ *       ],
+ *       "suites": [ ...nested... ]
+ *     }
+ *   ]
+ * }
+ * ```
+ */
+object PlaywrightJsonParser {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    fun parse(file: File): List<TestEntry> {
+        if (!file.isFile) return emptyList()
+        val root = json.parseToJsonElement(file.readText()).jsonObject
+        val suites = root["suites"]?.jsonArrayOrNull() ?: return emptyList()
+        val out = mutableListOf<TestEntry>()
+        suites.forEach { walkSuite(it.jsonObject, parentFile = null, out = out) }
+        return out
+    }
+
+    private fun walkSuite(suite: JsonObject, parentFile: String?, out: MutableList<TestEntry>) {
+        val suiteFile = suite["file"]?.jsonPrimitive?.contentOrNull ?: parentFile
+
+        suite["specs"]?.jsonArrayOrNull()?.forEach { specEl ->
+            val spec = specEl.jsonObject
+            val title = spec["title"]?.jsonPrimitive?.contentOrNull ?: "unknown"
+            val line = spec["line"]?.jsonPrimitive?.intOrNull
+            val testNodes = spec["tests"]?.jsonArrayOrNull().orEmpty()
+
+            // Each `tests[]` entry holds a list of `results[]` (one per retry).
+            // We collapse retries: if any retry failed and a later one passed,
+            // mark "flaky"; otherwise use the final result.
+            testNodes.forEach { tNode ->
+                val results = tNode.jsonObject["results"]?.jsonArrayOrNull().orEmpty()
+                if (results.isEmpty()) return@forEach
+                val statuses = results.map { it.jsonObject["status"]?.jsonPrimitive?.contentOrNull }
+                val finalStatus = statuses.lastOrNull()
+                val flaky = statuses.size > 1 && statuses.dropLast(1).any { it == "failed" } && finalStatus == "passed"
+                val mappedStatus = when {
+                    flaky -> "flaky"
+                    finalStatus == "passed" -> "passed"
+                    finalStatus == "failed" || finalStatus == "timedOut" -> "failed"
+                    finalStatus == "skipped" -> "skipped"
+                    else -> "failed"
+                }
+                val durationMs = results.sumOf { it.jsonObject["duration"]?.jsonPrimitive?.doubleOrNull?.toLong() ?: 0L }
+                val failingResult = results.lastOrNull { it.jsonObject["status"]?.jsonPrimitive?.contentOrNull in setOf("failed", "timedOut") }
+                val errorMessage = failingResult?.jsonObject?.get("error")?.jsonObject?.get("message")
+                    ?.jsonPrimitive?.contentOrNull
+                    ?.let { stripAnsi(it).lines().firstOrNull()?.trim() }
+
+                out.add(
+                    TestEntry(
+                        name = if (suiteFile != null) "$suiteFile > $title" else title,
+                        status = mappedStatus,
+                        durationMs = durationMs,
+                        file = suiteFile,
+                        line = line,
+                        failureMessage = errorMessage,
+                        tracePath = null,
+                    )
+                )
+            }
+        }
+
+        suite["suites"]?.jsonArrayOrNull()?.forEach { walkSuite(it.jsonObject, suiteFile, out) }
+    }
+
+    private fun JsonElement.jsonArrayOrNull(): JsonArray? = (this as? JsonArray) ?: try {
+        jsonArray
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+
+    private val ansiRegex = Regex("\u001B\\[[;\\d]*m")
+    private fun stripAnsi(s: String) = ansiRegex.replace(s, "")
+}

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/TraceJsonAugmenter.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/TraceJsonAugmenter.kt
@@ -1,0 +1,106 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+
+/**
+ * Reads `trace.json` files written by `TraceBundleExtension` and merges
+ * the data into matching uiTest [TestEntry]s. Specifically:
+ *
+ * - Sets `status = "flaky"` when `trace.json.flaky == true` and the test
+ *   eventually passed (RetryOnceExtension semantics).
+ * - Fills `tracePath` so the Markdown emitter can render
+ *   `Trace: build/reports/uiTest/traces/<dir>/`.
+ * - Backfills `file` / `line` from `trace.json.failure` when the JUnit XML
+ *   stack frame did not yield them.
+ *
+ * The matching key is `<ClassSimpleName>__<method-with-non-word-replaced-by-_>`,
+ * which is exactly the directory naming rule from
+ * `TraceBundleExtension.writeBundle` (TraceBundleExtension.kt:91-95).
+ */
+object TraceJsonAugmenter {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    /**
+     * @param tracesRoot the directory passed to `TraceBundleExtension`,
+     *                   e.g. `build/reports/uiTest/traces/`.
+     * @param entries the parsed uiTest entries to mutate.
+     * @param relativizeBase the directory that will be the parent of the
+     *                       trace bundle in the final report layout (used
+     *                       to compute the `tracePath` field). Typically
+     *                       the project root or the report root.
+     */
+    fun augment(
+        tracesRoot: File,
+        entries: List<TestEntry>,
+        relativizeBase: File,
+    ): List<TestEntry> {
+        if (!tracesRoot.isDirectory) return entries
+        val byKey = entries.associateBy { entryKey(it.name) }
+        val updated = entries.toMutableList()
+        val updatedIndex = entries.withIndex().associate { (i, e) -> entryKey(e.name) to i }
+
+        tracesRoot.listFiles()?.forEach { bundleDir ->
+            if (!bundleDir.isDirectory) return@forEach
+            val key = bundleDir.name
+            val entryIndex = updatedIndex[key] ?: return@forEach
+            val original = byKey[key] ?: return@forEach
+            val traceJson = bundleDir.resolve("trace.json")
+            val tracePath = relativize(relativizeBase, bundleDir).trimEnd('/') + "/"
+
+            val merged = if (traceJson.isFile) {
+                val obj = runCatching { json.parseToJsonElement(traceJson.readText()).jsonObject }.getOrNull()
+                if (obj == null) {
+                    original.copy(tracePath = tracePath)
+                } else {
+                    val flaky = obj["flaky"]?.jsonPrimitive?.booleanOrNull == true
+                    val failure = obj["failure"]?.jsonObject
+                    val newStatus = if (flaky && original.status == "passed") "flaky" else original.status
+                    val newFile = original.file ?: failure?.get("file")?.jsonPrimitive?.contentOrNull
+                    val newLine = original.line ?: failure?.get("line")?.jsonPrimitive?.intOrNull
+                    val newMessage = original.failureMessage ?: failure?.get("message")?.jsonPrimitive?.contentOrNull
+                    original.copy(
+                        status = newStatus,
+                        file = newFile,
+                        line = newLine,
+                        failureMessage = newMessage,
+                        tracePath = tracePath,
+                    )
+                }
+            } else {
+                original.copy(tracePath = tracePath)
+            }
+            updated[entryIndex] = merged
+        }
+        return updated
+    }
+
+    /**
+     * Mirrors `TraceBundleExtension.writeBundle`:
+     *   classSimple + "__" + method.replace(Regex("[^A-Za-z0-9_]"), "_")
+     */
+    private fun entryKey(name: String): String {
+        // name is "FQCN.method" — strip to simple class.
+        val lastDot = name.lastIndexOf('.')
+        if (lastDot < 0) return name
+        val fqcn = name.substring(0, lastDot)
+        val method = name.substring(lastDot + 1)
+        val simple = fqcn.substringAfterLast('.')
+        val safeMethod = method.replace(Regex("[^A-Za-z0-9_]"), "_")
+        return "${simple}__${safeMethod}"
+    }
+
+    private fun relativize(base: File, target: File): String {
+        val basePath = base.absoluteFile.toPath()
+        val targetPath = target.absoluteFile.toPath()
+        return runCatching { basePath.relativize(targetPath).toString() }
+            .getOrDefault(target.absolutePath)
+            .replace('\\', '/')
+    }
+}

--- a/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryGeneratorTest.kt
+++ b/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/ClaudeSummaryGeneratorTest.kt
@@ -1,0 +1,111 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ClaudeSummaryGeneratorTest {
+
+    private fun fixture(name: String): File {
+        val url = javaClass.classLoader.getResource("fixtures/$name")
+            ?: error("missing fixture: $name")
+        return File(url.toURI())
+    }
+
+    /**
+     * End-to-end: lay out a fake `rootDir` + `buildDir` containing all
+     * three test surfaces, run the generator, and assert the JSON totals
+     * + Markdown layout match the documented schema. This is the test
+     * that fulfills Task 14's "intentionally failing test shows up in
+     * Markdown" verification step from `docs/tasks/task-14-ci-test-reporting.md`.
+     */
+    @Test
+    fun `aggregates unit, ui, and playwright suites into JSON and Markdown`(@TempDir tempDir: File) {
+        val rootDir = tempDir.resolve("root").apply { mkdirs() }
+        val buildDir = tempDir.resolve("root/build").apply { mkdirs() }
+
+        // Lay out unit test XML
+        val unitXmlDir = buildDir.resolve("test-results/test").apply { mkdirs() }
+        fixture("junit-unit").listFiles()!!.forEach { it.copyTo(unitXmlDir.resolve(it.name)) }
+
+        // Lay out uiTest XML + matching trace bundle
+        val uiXmlDir = buildDir.resolve("test-results/uiTest").apply { mkdirs() }
+        fixture("junit-ui").listFiles()!!.forEach { it.copyTo(uiXmlDir.resolve(it.name)) }
+        val tracesDir = buildDir.resolve("reports/uiTest/traces").apply { mkdirs() }
+        fixture("uiTraces").listFiles()!!.forEach { src ->
+            val dst = tracesDir.resolve(src.name).apply { mkdirs() }
+            src.listFiles()!!.forEach { it.copyTo(dst.resolve(it.name)) }
+        }
+
+        // Lay out Playwright JSON
+        val pwDir = rootDir.resolve("packages/playwright-snapshot-saver/test-results").apply { mkdirs() }
+        fixture("playwright/results.json").copyTo(pwDir.resolve("results.json"))
+
+        val summary = ClaudeSummaryGenerator.run(rootDir, buildDir, gitSha = "abcdef1234567890")
+
+        // Three suites present (unit, uiTest, playwright)
+        assertEquals(3, summary.suites.size)
+
+        // Totals: 1 unit pass + 1 unit skip + 1 unit fail
+        //       + 1 ui pass + 1 ui fail (the trace says flaky=true, but augmenter
+        //         only flips status to "flaky" when the JUnit verdict was "passed",
+        //         so a flaky-then-fail stays "failed")
+        //       + 1 pw pass + 1 pw fail + 1 pw skip
+        // = 3 passed, 3 failed, 2 skipped, 0 flaky
+        assertEquals(3, summary.totals.passed)
+        assertEquals(3, summary.totals.failed)
+        assertEquals(2, summary.totals.skipped)
+        assertEquals(0, summary.totals.flaky)
+
+        // The uiTest entry should have its tracePath populated by the augmenter.
+        val ui = summary.suites.single { it.suite == "uiTest" }
+        val clickRetried = ui.tests.single { it.name.endsWith(".clickRetried") }
+        assertNotNull(clickRetried.tracePath)
+        assertTrue(clickRetried.tracePath!!.contains("BarUiTest__clickRetried"))
+
+        // The generator wrote both summary files
+        val mdFile = buildDir.resolve("reports/claude-summary.md")
+        val jsonFile = buildDir.resolve("reports/claude-summary.json")
+        assertTrue(mdFile.isFile, "claude-summary.md should exist")
+        assertTrue(jsonFile.isFile, "claude-summary.json should exist")
+
+        val md = mdFile.readText()
+        // Header + sha
+        assertTrue(md.contains("Test Summary — abcdef123456"), "header missing sha")
+        // Failures section lists every failing test with file:line.
+        assertTrue(md.contains("## Failures"))
+        assertTrue(md.contains("FooTest.kt:42"), "missing unit failure file:line: $md")
+        assertTrue(md.contains("BarUiTest.kt:88"), "missing ui failure file:line: $md")
+        assertTrue(
+            md.contains("rejects empty password"),
+            "missing playwright failure title: $md",
+        )
+        // Trace path is rendered for the ui failure.
+        assertTrue(md.contains("Trace: build/reports/uiTest/traces/BarUiTest__clickRetried/"), md)
+        // Suites table is present.
+        assertTrue(md.contains("## Suites"))
+        assertTrue(md.contains("**unit**"))
+        assertTrue(md.contains("**uiTest**"))
+        assertTrue(md.contains("**npm:playwright-snapshot-saver**"))
+    }
+
+    @Test
+    fun `intentionally failing unit test surfaces in markdown failures section`(@TempDir tempDir: File) {
+        // Reduced fixture: only the unit XML, isolating the "failing test surfaces with file:line"
+        // requirement from the task verification step.
+        val rootDir = tempDir.resolve("root").apply { mkdirs() }
+        val buildDir = tempDir.resolve("root/build").apply { mkdirs() }
+        val unitXmlDir = buildDir.resolve("test-results/test").apply { mkdirs() }
+        fixture("junit-unit").listFiles()!!.forEach { it.copyTo(unitXmlDir.resolve(it.name)) }
+
+        ClaudeSummaryGenerator.run(rootDir, buildDir)
+        val md = buildDir.resolve("reports/claude-summary.md").readText()
+
+        assertTrue(md.contains("## Failures (1)"))
+        assertTrue(md.contains("`com.example.FooTest.failsWithStack`"))
+        assertTrue(md.contains("FooTest.kt:42"))
+    }
+}

--- a/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/JUnitXmlParserTest.kt
+++ b/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/JUnitXmlParserTest.kt
@@ -1,0 +1,44 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class JUnitXmlParserTest {
+
+    private fun fixture(name: String): File {
+        // resources are copied to test runtime classpath; resolve via classloader.
+        val url = javaClass.classLoader.getResource("fixtures/$name")
+            ?: error("missing fixture: $name")
+        return File(url.toURI())
+    }
+
+    @Test
+    fun `parses passed, failed, and skipped from a JUnit4 testsuite`() {
+        val entries = JUnitXmlParser.parse(fixture("junit-unit"))
+        assertEquals(3, entries.size)
+
+        val passed = entries.single { it.name.endsWith(".passes") }
+        assertEquals("passed", passed.status)
+        assertEquals(123L, passed.durationMs)
+        assertNull(passed.failureMessage)
+
+        val failed = entries.single { it.name.endsWith(".failsWithStack") }
+        assertEquals("failed", failed.status)
+        assertEquals("FooTest.kt", failed.file)
+        assertEquals(42, failed.line)
+        assertNotNull(failed.failureMessage)
+        assertTrue(failed.failureMessage!!.contains("expected"))
+
+        val skipped = entries.single { it.name.endsWith(".isSkipped") }
+        assertEquals("skipped", skipped.status)
+    }
+
+    @Test
+    fun `returns empty list when directory does not exist`() {
+        assertEquals(emptyList(), JUnitXmlParser.parse(File("/nonexistent/${System.nanoTime()}")))
+    }
+}

--- a/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/PlaywrightJsonParserTest.kt
+++ b/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/PlaywrightJsonParserTest.kt
@@ -1,0 +1,41 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PlaywrightJsonParserTest {
+
+    private fun fixture(name: String): File {
+        val url = javaClass.classLoader.getResource("fixtures/$name")
+            ?: error("missing fixture: $name")
+        return File(url.toURI())
+    }
+
+    @Test
+    fun `maps Playwright statuses to passed, failed, and skipped`() {
+        val entries = PlaywrightJsonParser.parse(fixture("playwright/results.json"))
+        assertEquals(3, entries.size)
+
+        val passed = entries.single { it.name.endsWith("logs in with valid creds") }
+        assertEquals("passed", passed.status)
+        assertEquals(1234L, passed.durationMs)
+        assertEquals("tests/login.spec.ts", passed.file)
+        assertEquals(12, passed.line)
+
+        val failed = entries.single { it.name.endsWith("rejects empty password") }
+        assertEquals("failed", failed.status)
+        assertNotNull(failed.failureMessage)
+        assertTrue(failed.failureMessage!!.contains("expected toast"))
+
+        val skipped = entries.single { it.name.endsWith("is intentionally skipped") }
+        assertEquals("skipped", skipped.status)
+    }
+
+    @Test
+    fun `returns empty list when results file is missing`() {
+        assertEquals(emptyList(), PlaywrightJsonParser.parse(File("/nonexistent/${System.nanoTime()}.json")))
+    }
+}

--- a/buildSrc/src/test/resources/fixtures/junit-ui/TEST-com.example.BarUiTest.xml
+++ b/buildSrc/src/test/resources/fixtures/junit-ui/TEST-com.example.BarUiTest.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.example.BarUiTest" tests="2" skipped="0" failures="1" errors="0" timestamp="2026-04-08T12:00:00" hostname="ci" time="3.5">
+  <testcase name="opensToolWindow" classname="com.example.BarUiTest" time="1.5"/>
+  <testcase name="clickRetried" classname="com.example.BarUiTest" time="2.0">
+    <failure message="Element not found" type="java.lang.AssertionError">java.lang.AssertionError: Element not found
+	at com.example.BarUiTest.clickRetried(BarUiTest.kt:88)
+</failure>
+  </testcase>
+</testsuite>

--- a/buildSrc/src/test/resources/fixtures/junit-unit/TEST-com.example.FooTest.xml
+++ b/buildSrc/src/test/resources/fixtures/junit-unit/TEST-com.example.FooTest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.example.FooTest" tests="3" skipped="0" failures="1" errors="0" timestamp="2026-04-08T12:00:00" hostname="ci" time="0.456">
+  <testcase name="passes" classname="com.example.FooTest" time="0.123"/>
+  <testcase name="failsWithStack" classname="com.example.FooTest" time="0.234">
+    <failure message="expected:&lt;1&gt; but was:&lt;2&gt;" type="org.junit.ComparisonFailure">org.junit.ComparisonFailure: expected:&lt;1&gt; but was:&lt;2&gt;
+	at com.example.FooTest.failsWithStack(FooTest.kt:42)
+	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+</failure>
+  </testcase>
+  <testcase name="isSkipped" classname="com.example.FooTest" time="0.000">
+    <skipped/>
+  </testcase>
+</testsuite>

--- a/buildSrc/src/test/resources/fixtures/playwright/results.json
+++ b/buildSrc/src/test/resources/fixtures/playwright/results.json
@@ -1,0 +1,48 @@
+{
+  "config": {},
+  "suites": [
+    {
+      "title": "login.spec.ts",
+      "file": "tests/login.spec.ts",
+      "specs": [
+        {
+          "title": "logs in with valid creds",
+          "line": 12,
+          "tests": [
+            {
+              "results": [
+                { "status": "passed", "duration": 1234 }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "rejects empty password",
+          "line": 30,
+          "tests": [
+            {
+              "results": [
+                {
+                  "status": "failed",
+                  "duration": 567,
+                  "error": { "message": "expected toast to be visible" }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "title": "is intentionally skipped",
+          "line": 50,
+          "tests": [
+            {
+              "results": [
+                { "status": "skipped", "duration": 0 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/buildSrc/src/test/resources/fixtures/uiTraces/BarUiTest__clickRetried/trace.json
+++ b/buildSrc/src/test/resources/fixtures/uiTraces/BarUiTest__clickRetried/trace.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "test": {
+    "className": "com.example.BarUiTest",
+    "method": "clickRetried",
+    "displayName": "click retried"
+  },
+  "startedAt": "2026-04-08T12:00:00Z",
+  "durationMs": 2000,
+  "status": "failed",
+  "flaky": true,
+  "failure": {
+    "message": "Element not found",
+    "stack": "java.lang.AssertionError: Element not found\n\tat com.example.BarUiTest.clickRetried(BarUiTest.kt:88)\n",
+    "file": "src/uiTest/kotlin/com/example/BarUiTest.kt",
+    "line": 88
+  },
+  "steps": [],
+  "artifacts": {
+    "ideaLog": "idea.log",
+    "dom": "dom.html"
+  }
+}

--- a/packages/playwright-snapshot-saver/playwright.config.ts
+++ b/packages/playwright-snapshot-saver/playwright.config.ts
@@ -6,7 +6,17 @@ export default defineConfig({
   expect: { timeout: 10000 },
   retries: 0,
   workers: 1,
-  reporter: 'list',
+  // Three reporters in parallel:
+  //   list   — human-readable console output (CI logs + local dev)
+  //   html   — `playwright-report/index.html`, uploaded to the per-suite
+  //            dashboard slot
+  //   json   — `test-results/results.json`, consumed by buildSrc's
+  //            ClaudeSummaryGenerator (Task 14)
+  reporter: [
+    ['list'],
+    ['html', { open: 'never' }],
+    ['json', { outputFile: 'test-results/results.json' }],
+  ],
   use: {
     viewport: { width: 1280, height: 720 },
     screenshot: 'off',


### PR DESCRIPTION
## Summary

Implements Task 14 of the Claude Code integration roadmap: a comprehensive CI test reporting system that aggregates results from unit tests, UI tests, and Playwright tests into a unified `claude-summary` bundle. This enables remote Claude Code sessions to consume CI test results without requiring GitHub authentication.

## Key Changes

### CI Workflow Enhancement (`.github/workflows/ci.yml`)
- Added artifact uploads for raw test outputs from each test job:
  - `unit-test-raw`: JUnit XML from unit tests
  - `ui-test-raw`: JUnit XML + trace bundles from UI tests
  - `playwright-test-raw`: Playwright JSON reporter output
- Introduced new `test-report` job that:
  - Downloads raw test artifacts from parallel jobs
  - Runs `./gradlew aggregateTestReport` to generate `claude-summary.{json,md}`
  - Uploads the bundle to `reports.artemon.cloud` for remote Claude sessions
  - Includes explicit HTTP status code validation (non-2xx fails the job)
- Updated Playwright test step to rely on `playwright.config.ts` reporter configuration

### Test Report Aggregation (`buildSrc/`)
- **`ClaudeSummaryGenerator.kt`**: Orchestrates parsing of all three test surfaces and writes JSON + Markdown summaries
- **`JUnitXmlParser.kt`**: Parses Surefire-format JUnit XML from unit and UI tests
- **`PlaywrightJsonParser.kt`**: Parses Playwright's JSON reporter output, handles retry logic and flaky detection
- **`TraceJsonAugmenter.kt`**: Enriches UI test entries with trace bundle metadata and flaky status from `trace.json`
- **`MarkdownEmitter.kt`**: Renders human-readable Markdown with failures, flaky tests, and per-suite summaries
- **`ClaudeSummaryModel.kt`**: Defines the v1 schema for `claude-summary.json` (version, totals, per-suite test entries)

### Gradle Tasks (`build.gradle.kts`)
- `aggregateTestReport`: Parses all test surfaces and generates the summary bundle; fails if any tests failed
- `testReport`: Developer-facing task that runs all test suites locally and produces the same summary output
- `playwrightTest`: Wrapper for running Playwright tests

### Test Fixtures & Tests
- Comprehensive unit tests for each parser (JUnit, Playwright, augmenter)
- End-to-end integration test (`ClaudeSummaryGeneratorTest`) verifying the full aggregation pipeline
- Fixture files simulating real test outputs from all three surfaces

### Documentation
- Updated `CLAUDE.md` with "Test Loop" section explaining the canonical CI-driven testing workflow
- Documented redlines for the test-report job (must not be disabled or marked `continue-on-error`)
- Included curl examples for accessing results from the dashboard

### Configuration
- Added `buildSrc/build.gradle.kts` with kotlinx-serialization dependency for JSON handling
- Updated `playwright.config.ts` to enable json reporter alongside list and html reporters

## Notable Implementation Details

- **Flaky Detection**: Playwright parser detects flaky tests (failed retry → passed); UI test augmenter reads `trace.json` to mark tests as flaky when appropriate
- **Trace Path Resolution**: UI test entries are enriched with relative paths to trace bundles for dashboard navigation
- **Graceful Degradation**: Aggregator tolerates missing test surfaces (e.g., if a job didn't run) and emits empty suites
- **Schema Versioning**: `claude-summary.json` includes version field for future evolution
- **No GitHub Auth Required**: Dashboard upload enables remote Claude sessions to read results via `/api/v1/external/runs` without GitHub credentials

https://claude.ai/code/session_01YQE9PFKapHsSeg6BkBMdUn