### PR TITLE
task-19 PR3: demoReport Gradle task + CI workflow

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -1,0 +1,86 @@
+name: demo-report
+
+on:
+  pull_request:
+    types: [labeled]
+
+jobs:
+  demo-report:
+    if: github.event.label.name == 'demo'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Parse feature tag from PR title
+        id: tag
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          if [[ "$PR_TITLE" =~ ^\[demo:([a-z0-9-]+)\] ]]; then
+            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail if tag missing
+        if: steps.tag.outputs.tag == ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'demo-report: the `demo` label requires the PR title to start with `[demo:<tag>]` (e.g. `[demo:highlight-all] ...`). Re-add the label after fixing the title.',
+            });
+            core.setFailed('Missing [demo:<tag>] prefix in PR title.');
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Compute changed files
+        id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$BASE_REF" --depth=1
+          FILES=$(git diff --name-only "origin/$BASE_REF...HEAD" | paste -sd, -)
+          echo "files=$FILES" >> "$GITHUB_OUTPUT"
+
+      - name: Run demoReport
+        env:
+          DEMO_BASE_REF: origin/${{ github.base_ref }}
+        run: |
+          ./gradlew demoReport \
+            -PfeatureName=${{ steps.tag.outputs.tag }} \
+            -PchangedFiles="${{ steps.changed.outputs.files }}"
+
+      - name: Upload demo report
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-report-${{ github.event.pull_request.head.sha }}
+          path: build/reports/demo/**
+
+      - name: Comment artifact link
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `Demo report for \`${{ steps.tag.outputs.tag }}\` uploaded — download artifact \`demo-report-${{ github.event.pull_request.head.sha }}\` from [this workflow run](${runUrl}). Re-add the \`demo\` label to regenerate.`,
+            });

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
+import java.nio.file.Files as NioFiles
 
 plugins {
     id("org.jetbrains.kotlin.jvm") version "2.1.0"
@@ -263,6 +264,84 @@ tasks {
         dependsOn("test", "uiTest", "playwrightTest")
         finalizedBy("aggregateTestReport")
     }
+
+    register("demoReport") {
+        group = "verification"
+        description = "Run selected UI tests and render a self-contained feature-demo HTML trace viewer."
+
+        val featureNameProp = providers.gradleProperty("featureName")
+        val changedFilesProp = providers.gradleProperty("changedFiles")
+        val projectDirFile = projectDir
+        val buildDirFile = layout.buildDirectory.get().asFile
+        val templateDirFile = rootProject.file("src/main/resources/demo-viewer")
+
+        doLast {
+            val featureName = featureNameProp.orNull
+                ?: error("demoReport requires -PfeatureName=<tag>")
+
+            val changedFiles: List<String> = changedFilesProp.orNull?.let { prop ->
+                prop.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+            } ?: gitDiffChangedFiles(projectDirFile)
+
+            val selection = com.github.artem.pageobjectplugin.buildtools
+                .DemoTestSelector.select(
+                    projectDir = projectDirFile.toPath(),
+                    featureTag = featureName,
+                    changedFiles = changedFiles,
+                )
+            val selectedTests = selection.selected
+            val taggedCount = selection.taggedCount
+
+            if (taggedCount < 2) {
+                error(
+                    "demoReport requires at least 2 scenarios tagged @Feature(\"$featureName\") " +
+                        "(found $taggedCount). Add a happy-path AND a negative-case test."
+                )
+            }
+
+            val gradlew = if (System.getProperty("os.name").startsWith("Windows")) "gradlew.bat" else "./gradlew"
+            val cmd = mutableListOf(gradlew, "uiTest", "-PcaptureAllTraces=true")
+            selectedTests.forEach { cmd += listOf("--tests", it) }
+            val exitCode = ProcessBuilder(cmd)
+                .directory(projectDirFile)
+                .inheritIO()
+                .start()
+                .waitFor()
+            if (exitCode != 0) error("uiTest sub-build failed with exit code $exitCode")
+
+            val traceRoot = buildDirFile.resolve("reports/uiTest/traces").toPath()
+            val bundles = NioFiles.list(traceRoot).use { stream ->
+                stream.filter { NioFiles.isDirectory(it) }.toList()
+            }
+
+            val gitSha = ProcessBuilder("git", "rev-parse", "HEAD")
+                .directory(projectDirFile)
+                .redirectErrorStream(true)
+                .start()
+                .inputStream.bufferedReader().readText().trim()
+
+            val outDir = buildDirFile.resolve("reports/demo/$featureName").toPath()
+            com.github.artem.pageobjectplugin.buildtools.DemoReportRenderer.render(
+                bundles = bundles,
+                outputDir = outDir,
+                featureTag = featureName,
+                gitSha = gitSha,
+                templateDir = templateDirFile.toPath(),
+            )
+
+            logger.lifecycle("demoReport: wrote $outDir/index.html")
+        }
+    }
+}
+
+fun gitDiffChangedFiles(projectDir: java.io.File): List<String> {
+    val baseRef = System.getenv("DEMO_BASE_REF") ?: "origin/main"
+    return ProcessBuilder("git", "diff", "--name-only", "$baseRef...HEAD")
+        .directory(projectDir)
+        .redirectErrorStream(true)
+        .start()
+        .inputStream.bufferedReader().readText()
+        .lines().map { it.trim() }.filter { it.isNotEmpty() }
 }
 
 // When `testReport` is the entry point, let every per-suite task complete

--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoTestSelector.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoTestSelector.kt
@@ -1,0 +1,85 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Selects UI test methods for the `demoReport` task by (1) scanning
+ * `src/uiTest/kotlin` for `@Feature("<tag>")` annotations and (2) including
+ * test classes whose package matches the package of any changed source file
+ * under `src/main/kotlin`.
+ *
+ * Scanning is done via regex over Kotlin source — no reflection, no compile
+ * step. The regex is intentionally conservative; if a test uses `@Feature` in
+ * an unusual form (e.g., constant reference) it will not be picked up, and
+ * authors should inline the literal tag.
+ */
+object DemoTestSelector {
+
+    data class Result(val selected: List<String>, val taggedCount: Int)
+
+    private val featureRegex = Regex("""@Feature\(\s*"([^"]+)"\s*\)""")
+    private val packageRegex = Regex("""^\s*package\s+([\w.]+)""", RegexOption.MULTILINE)
+    private val classRegex = Regex("""class\s+(\w+)""")
+    private val funRegex = Regex("""fun\s+(\w+)\s*\(""")
+
+    fun select(projectDir: Path, featureTag: String, changedFiles: List<String>): Result {
+        val uiTestRoot = projectDir.resolve("src/uiTest/kotlin")
+        if (!Files.isDirectory(uiTestRoot)) return Result(emptyList(), 0)
+
+        val changedPackages: Set<String> = changedFiles
+            .filter { it.startsWith("src/main/kotlin/") && it.endsWith(".kt") }
+            .mapNotNull { rel ->
+                val withoutRoot = rel.removePrefix("src/main/kotlin/")
+                val slash = withoutRoot.lastIndexOf('/')
+                if (slash <= 0) null else withoutRoot.substring(0, slash).replace('/', '.')
+            }
+            .toSet()
+
+        val selected = linkedSetOf<String>()
+        var taggedCount = 0
+
+        Files.walk(uiTestRoot).use { stream ->
+            stream.filter { it.toString().endsWith(".kt") && Files.isRegularFile(it) }.forEach { file ->
+                val text = Files.readString(file)
+                val pkg = packageRegex.find(text)?.groupValues?.get(1) ?: return@forEach
+                val className = classRegex.find(text)?.groupValues?.get(1) ?: return@forEach
+                val fqn = "$pkg.$className"
+
+                // Class-level tag
+                val classTag = featureRegex.findAll(text.substringBefore("class "))
+                    .map { it.groupValues[1] }.firstOrNull()
+
+                // Walk function declarations; match per-method tag.
+                // Look back only to the nearest brace boundary (end of prior
+                // function body or opening of the class) so annotations on
+                // neighbouring functions are not picked up.
+                val funcTags = mutableMapOf<String, String?>()
+                val funcPositions = funRegex.findAll(text)
+                    .map { it.groupValues[1] to it.range.first }
+                    .toList()
+                funcPositions.forEach { (name, pos) ->
+                    val lastClose = text.lastIndexOf('}', pos - 1)
+                    val lastOpen = text.lastIndexOf('{', pos - 1)
+                    val regionStart = maxOf(lastClose, lastOpen, 0)
+                    val lookBack = text.substring(regionStart, pos)
+                    val mTag = featureRegex.find(lookBack)?.groupValues?.get(1)
+                    funcTags[name] = mTag ?: classTag
+                }
+
+                funcTags.forEach { (fn, tag) ->
+                    if (tag == featureTag) {
+                        selected.add("$fqn.$fn")
+                        taggedCount++
+                    }
+                }
+
+                if (changedPackages.any { pkg == it || pkg.startsWith("$it.") }) {
+                    selected.add(fqn)
+                }
+            }
+        }
+
+        return Result(selected.toList(), taggedCount)
+    }
+}

--- a/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoTestSelectorTest.kt
+++ b/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoTestSelectorTest.kt
@@ -1,0 +1,81 @@
+package com.github.artem.pageobjectplugin.buildtools
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+class DemoTestSelectorTest {
+
+    private fun seed(root: Path) {
+        val uiTestDir = root.resolve("src/uiTest/kotlin/com/example/foo")
+        Files.createDirectories(uiTestDir)
+        uiTestDir.resolve("AlphaUiTest.kt").writeText(
+            """
+            package com.example.foo
+            import com.github.artem.pageobjectplugin.ui.annotations.Feature
+            class AlphaUiTest {
+                @Feature("smoke") fun happy() {}
+                @Feature("smoke") fun negative() {}
+                fun untagged() {}
+            }
+            """.trimIndent(),
+        )
+        val uiTestDir2 = root.resolve("src/uiTest/kotlin/com/example/bar")
+        Files.createDirectories(uiTestDir2)
+        uiTestDir2.resolve("BetaUiTest.kt").writeText(
+            """
+            package com.example.bar
+            class BetaUiTest { fun logsIn() {} }
+            """.trimIndent(),
+        )
+        Files.createDirectories(root.resolve("src/main/kotlin/com/example/bar"))
+    }
+
+    @Test
+    fun `tag-matched tests are selected and counted`(@TempDir root: Path) {
+        seed(root)
+        val result = DemoTestSelector.select(
+            projectDir = root,
+            featureTag = "smoke",
+            changedFiles = emptyList(),
+        )
+        assertEquals(2, result.taggedCount)
+        assertTrue(result.selected.any { it.endsWith("AlphaUiTest.happy") })
+        assertTrue(result.selected.any { it.endsWith("AlphaUiTest.negative") })
+    }
+
+    @Test
+    fun `changed files select tests by package heuristic`(@TempDir root: Path) {
+        seed(root)
+        val result = DemoTestSelector.select(
+            projectDir = root,
+            featureTag = "smoke",
+            changedFiles = listOf("src/main/kotlin/com/example/bar/Thing.kt"),
+        )
+        assertTrue(result.selected.any { it.contains("BetaUiTest") })
+        assertTrue(result.selected.any { it.contains("AlphaUiTest") })
+    }
+
+    @Test
+    fun `insufficient tagged scenarios surfaces in count`(@TempDir root: Path) {
+        val ui = root.resolve("src/uiTest/kotlin/com/example/solo")
+        Files.createDirectories(ui)
+        ui.resolve("SoloUiTest.kt").writeText(
+            """
+            package com.example.solo
+            import com.github.artem.pageobjectplugin.ui.annotations.Feature
+            class SoloUiTest { @Feature("lone") fun only() {} }
+            """.trimIndent(),
+        )
+        val result = DemoTestSelector.select(
+            projectDir = root,
+            featureTag = "lone",
+            changedFiles = emptyList(),
+        )
+        assertEquals(1, result.taggedCount)
+    }
+}

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/DemoSmokeUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/DemoSmokeUiTest.kt
@@ -1,0 +1,24 @@
+package com.github.artem.pageobjectplugin.ui.tests
+
+import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
+import org.junit.jupiter.api.Test
+
+/**
+ * Minimal two-scenario fixture used to exercise the `demoReport` pipeline
+ * end-to-end. Both scenarios are trivial — they exist to produce two tagged
+ * trace bundles so the >=2-scenarios rule is satisfied.
+ */
+@Feature("smoke")
+class DemoSmokeUiTest : BaseUiTest() {
+
+    @Test
+    fun happyPath() {
+        takeScreenshot("smoke happy path")
+    }
+
+    @Test
+    fun negativePath() {
+        takeScreenshot("smoke negative path")
+    }
+}


### PR DESCRIPTION
## Summary
- `./gradlew demoReport -PfeatureName=<tag>` selects tests by `@Feature` tag or package heuristic from changed files, runs them with `-PcaptureAllTraces=true`, and renders `build/reports/demo/<tag>/index.html`
- Enforces >=2 scenarios per tag
- `.github/workflows/demo.yml` triggers on `demo` label, parses `[demo:<tag>]` from PR title, uploads the artifact, posts a PR comment
- `DemoSmokeUiTest` fixture provides two `@Feature("smoke")` scenarios for end-to-end verification
- Package heuristic is intentionally coarse: a change under `src/main/kotlin/com/foo/` selects tests under `src/uiTest/kotlin/com/foo/`. Shared-util changes will select broadly — acceptable for v1.

Final PR for Task 19.

## Test plan
- [x] `:buildSrc:test` passes (selector + renderer)
- [ ] `./gradlew demoReport -PfeatureName=smoke` produces `build/reports/demo/smoke/index.html` in CI
- [ ] Adding `demo` label to a PR with `[demo:smoke]` title uploads an artifact and posts a comment
- [ ] `test-report` CI job green