### PR TITLE
[demo:smoke]chore(ci): upgrade actions to Node 24, add status field and curl resi…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, 'claude/**']
+    branches: [main]
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,21 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       - name: Run unit tests
+        id: tests
         run: ./gradlew test
 
       - name: Upload test reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: unit-test-reports
           path: build/reports/tests/test/
@@ -38,7 +39,7 @@ jobs:
       # Raw JUnit XML — consumed by the test-report aggregator job below.
       - name: Upload raw unit-test XML (for aggregator)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: unit-test-raw
           path: build/test-results/test/
@@ -48,6 +49,8 @@ jobs:
         run: |
           cd build/reports/tests/test && zip -r ../../../../unit-test-report.zip . && cd ../../../..
           curl -X POST \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${{ secrets.RD_TOKEN }}" \
             -F "report=@unit-test-report.zip" \
             "https://reports.artemon.cloud/api/v1/upload?\
@@ -56,7 +59,8 @@ jobs:
           run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
           job_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
           git_ref=${{ github.ref_name }}&\
-          git_sha=${{ github.sha }}"
+          git_sha=${{ github.sha }}&\
+          status=${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
 
   ui-tests:
     name: UI E2E Tests
@@ -65,14 +69,14 @@ jobs:
     env:
       DISPLAY: ':99'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       - name: Install Xvfb and display dependencies
         run: |
@@ -110,6 +114,7 @@ jobs:
           exit 1
 
       - name: Run UI tests
+        id: tests
         run: ./gradlew uiTest --info
 
       - name: Dump trace bundles to log (diagnostic)
@@ -136,7 +141,7 @@ jobs:
 
       - name: Upload UI test reports
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ui-test-reports
           path: |
@@ -150,7 +155,7 @@ jobs:
       # aggregator expects under `build/`.
       - name: Upload raw uiTest results (for aggregator)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ui-test-raw
           path: |
@@ -162,6 +167,8 @@ jobs:
         run: |
           cd build/reports/tests/uiTest && zip -r ../../../../ui-test-report.zip . && cd ../../../..
           curl -X POST \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${{ secrets.RD_TOKEN }}" \
             -F "report=@ui-test-report.zip" \
             "https://reports.artemon.cloud/api/v1/upload?\
@@ -170,7 +177,8 @@ jobs:
           run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
           job_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
           git_ref=${{ github.ref_name }}&\
-          git_sha=${{ github.sha }}"
+          git_sha=${{ github.sha }}&\
+          status=${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
 
       - name: Upload UI trace bundles to dashboard
         if: success() || failure()
@@ -190,17 +198,22 @@ jobs:
             exit 0
           fi
           (cd build/reports/uiTest/traces && zip -r ../../../../ui-test-traces.zip .)
-          URL="https://reports.artemon.cloud/api/v1/upload?suite=ui-test-traces&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}"
-          curl -X POST -H "Authorization: Bearer ${RD_TOKEN}" -F "report=@ui-test-traces.zip" "$URL"
+          STATUS="${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
+          URL="https://reports.artemon.cloud/api/v1/upload?suite=ui-test-traces&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}&status=${STATUS}"
+          curl -X POST \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
+            -H "Authorization: Bearer ${RD_TOKEN}" \
+            -F "report=@ui-test-traces.zip" "$URL"
 
   playwright-tests:
     name: Playwright Snapshot Saver Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: npm
@@ -215,6 +228,7 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Run Playwright tests
+        id: tests
         working-directory: packages/playwright-snapshot-saver
         # Reporter set is configured in playwright.config.ts (list + html + json).
         # The json reporter writes test-results/results.json, which the
@@ -223,7 +237,7 @@ jobs:
 
       - name: Upload Playwright reports
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-test-reports
           path: packages/playwright-snapshot-saver/test-results/
@@ -233,7 +247,7 @@ jobs:
       # reporter declared in playwright.config.ts.
       - name: Upload raw Playwright JSON (for aggregator)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-test-raw
           path: packages/playwright-snapshot-saver/test-results/
@@ -243,6 +257,8 @@ jobs:
         run: |
           cd packages/playwright-snapshot-saver/playwright-report && zip -r ../../../playwright-report.zip . && cd ../../..
           curl -X POST \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${{ secrets.RD_TOKEN }}" \
             -F "report=@playwright-report.zip" \
             "https://reports.artemon.cloud/api/v1/upload?\
@@ -251,7 +267,8 @@ jobs:
           run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
           job_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
           git_ref=${{ github.ref_name }}&\
-          git_sha=${{ github.sha }}"
+          git_sha=${{ github.sha }}&\
+          status=${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
 
   # ── Task 14: Claude Inner Loop ──────────────────────────────────────────
   #
@@ -274,34 +291,34 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       # Download every raw test surface. continue-on-error so a single
       # missing artifact (e.g. a job that didn't run because an upstream
       # one failed early) does not block aggregation.
       - name: Download raw unit-test XML
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: unit-test-raw
           path: build/test-results/test/
         continue-on-error: true
 
       - name: Download raw uiTest results
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: ui-test-raw
           path: build/
         continue-on-error: true
 
       - name: Download raw Playwright JSON
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: playwright-test-raw
           path: packages/playwright-snapshot-saver/test-results/
@@ -317,7 +334,7 @@ jobs:
 
       - name: Upload combined test report bundle (GH artifact)
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: test-report-${{ github.sha }}
           path: |
@@ -352,8 +369,11 @@ jobs:
             cp -r build/reports/uiTest/traces claude-summary-bundle/traces
           fi
           (cd claude-summary-bundle && zip -r ../claude-summary-bundle.zip .)
-          URL="https://reports.artemon.cloud/api/v1/upload?suite=claude-summary&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}"
+          STATUS="${{ steps.aggregate.outcome == 'success' && 'passed' || 'failed' }}"
+          URL="https://reports.artemon.cloud/api/v1/upload?suite=claude-summary&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}&status=${STATUS}"
           HTTP_CODE=$(curl -sS -o /tmp/rd-response.txt -w '%{http_code}' -X POST \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${RD_TOKEN}" \
             -F "report=@claude-summary-bundle.zip" "$URL")
           echo "Dashboard response: $HTTP_CODE"
@@ -372,6 +392,8 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           curl -sS -X POST \
+            --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${RD_TOKEN}" \
             "https://reports.artemon.cloud/api/v1/executions/${RUN_ID}/finalize" \
             || echo "::warning::finalize call failed — non-fatal"

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -16,7 +16,7 @@ jobs:
       DISPLAY: ':99'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Fail if tag missing
         if: steps.tag.outputs.tag == ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.createComment({
@@ -46,12 +46,12 @@ jobs:
             core.setFailed('Missing [demo:<tag>] prefix in PR title.');
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
 
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
 
       - name: Install Xvfb and display dependencies
         run: |
@@ -99,6 +99,7 @@ jobs:
           exit 1
 
       - name: Run demoReport
+        id: demo
         env:
           DEMO_BASE_REF: origin/${{ github.base_ref }}
         run: |
@@ -108,7 +109,7 @@ jobs:
 
       - name: Upload demo report artifact
         id: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: demo-report-${{ github.event.pull_request.head.sha }}
           path: build/reports/demo/**
@@ -129,6 +130,8 @@ jobs:
           fi
           (cd "$DEMO_DIR" && zip -r ../../../../demo-report.zip .)
           curl -fsS -X POST \
+            --connect-timeout 10 --max-time 120 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${RD_DEMO_TOKEN}" \
             -F "report=@demo-report.zip" \
             "https://reports.artemon.cloud/api/v1/upload?\
@@ -137,7 +140,8 @@ jobs:
           run_url=${RUN_URL}&\
           job_url=${RUN_URL}&\
           git_ref=${GIT_REF}&\
-          git_sha=${GIT_SHA}"
+          git_sha=${GIT_SHA}&\
+          status=${{ steps.demo.outcome == 'success' && 'passed' || 'failed' }}"
 
       - name: Finalize run on dashboard
         if: always()
@@ -146,12 +150,14 @@ jobs:
           RUN_ID: ${{ github.run_id }}
         run: |
           curl -sS -X POST \
+            --connect-timeout 10 --max-time 30 \
+            --retry 3 --retry-connrefused --retry-delay 2 \
             -H "Authorization: Bearer ${RD_DEMO_TOKEN}" \
             "https://reports.artemon.cloud/api/v1/executions/${RUN_ID}/finalize" \
             || echo "::warning::finalize call failed — non-fatal"
 
       - name: Comment artifact link
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,39 +11,11 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      pull-requests: write
     env:
       DISPLAY: ':99'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Parse feature tag from PR title
-        id: tag
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-        run: |
-          set -euo pipefail
-          if [[ "$PR_TITLE" =~ ^\[demo:([a-z0-9-]+)\] ]]; then
-            echo "tag=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Fail if tag missing
-        if: steps.tag.outputs.tag == ''
-        uses: actions/github-script@v8
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: 'demo-report: the `demo` label requires the PR title to start with `[demo:<tag>]` (e.g. `[demo:highlight-all] ...`). Re-add the label after fixing the title.',
-            });
-            core.setFailed('Missing [demo:<tag>] prefix in PR title.');
 
       - name: Set up JDK 21
         uses: actions/setup-java@v5
@@ -66,16 +38,6 @@ jobs:
         run: |
           Xvfb :99 -screen 0 1920x1080x24 -ac +extension GLX &
           sleep 2
-
-      - name: Compute changed files
-        id: changed
-        env:
-          BASE_REF: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          git fetch origin "$BASE_REF" --depth=1
-          FILES=$(git diff --name-only "origin/$BASE_REF...HEAD" | paste -sd, -)
-          echo "files=$FILES" >> "$GITHUB_OUTPUT"
 
       - name: Start IDE for UI tests
         run: |
@@ -100,30 +62,18 @@ jobs:
 
       - name: Run demoReport
         id: demo
-        env:
-          DEMO_BASE_REF: origin/${{ github.base_ref }}
-        run: |
-          ./gradlew demoReport \
-            -PfeatureName=${{ steps.tag.outputs.tag }} \
-            -PchangedFiles="${{ steps.changed.outputs.files }}"
-
-      - name: Upload demo report artifact
-        id: upload
-        uses: actions/upload-artifact@v5
-        with:
-          name: demo-report-${{ github.event.pull_request.head.sha }}
-          path: build/reports/demo/**
+        run: ./gradlew demoReport -PfeatureName=all
 
       - name: Upload demo report to dashboard
+        if: success() || failure()
         env:
           RD_DEMO_TOKEN: ${{ secrets.RD_DEMO_TOKEN }}
-          FEATURE_TAG: ${{ steps.tag.outputs.tag }}
           RUN_ID: ${{ github.run_id }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           GIT_REF: ${{ github.ref_name }}
           GIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          DEMO_DIR="build/reports/demo/${FEATURE_TAG}"
+          DEMO_DIR="build/reports/demo/all"
           if [ ! -d "$DEMO_DIR" ]; then
             echo "::warning::Demo report directory not found — skipping dashboard upload."
             exit 0
@@ -155,19 +105,3 @@ jobs:
             -H "Authorization: Bearer ${RD_DEMO_TOKEN}" \
             "https://reports.artemon.cloud/api/v1/executions/${RUN_ID}/finalize" \
             || echo "::warning::finalize call failed — non-fatal"
-
-      - name: Comment artifact link
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const dashboardUrl = `https://reports.artemon.cloud/api/v1/external/runs/${context.runId}/demo/index.html`;
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `Demo report for \`${{ steps.tag.outputs.tag }}\` uploaded.\n\n` +
-                `- **Dashboard:** [View report](${dashboardUrl})\n` +
-                `- **Artifact:** \`demo-report-${{ github.event.pull_request.head.sha }}\` from [this workflow run](${runUrl})\n\n` +
-                `Re-add the \`demo\` label to regenerate.`,
-            });

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -267,7 +267,7 @@ tasks {
 
     register("demoReport") {
         group = "verification"
-        description = "Run selected UI tests and render a self-contained feature-demo HTML trace viewer."
+        description = "Run UI tests and render a self-contained demo HTML trace viewer."
 
         val featureNameProp = providers.gradleProperty("featureName")
         val changedFilesProp = providers.gradleProperty("changedFiles")
@@ -276,32 +276,32 @@ tasks {
         val templateDirFile = rootProject.file("src/main/resources/demo-viewer")
 
         doLast {
-            val featureName = featureNameProp.orNull
-                ?: error("demoReport requires -PfeatureName=<tag>")
-
-            val changedFiles: List<String> = changedFilesProp.orNull?.let { prop ->
-                prop.split(",").map { it.trim() }.filter { it.isNotEmpty() }
-            } ?: gitDiffChangedFiles(projectDirFile)
-
-            val selection = com.github.artem.pageobjectplugin.buildtools
-                .DemoTestSelector.select(
-                    projectDir = projectDirFile.toPath(),
-                    featureTag = featureName,
-                    changedFiles = changedFiles,
-                )
-            val selectedTests = selection.selected
-            val taggedCount = selection.taggedCount
-
-            if (taggedCount < 2) {
-                error(
-                    "demoReport requires at least 2 scenarios tagged @Feature(\"$featureName\") " +
-                        "(found $taggedCount). Add a happy-path AND a negative-case test."
-                )
-            }
+            val featureName = featureNameProp.orNull ?: "all"
 
             val gradlew = if (System.getProperty("os.name").startsWith("Windows")) "gradlew.bat" else "./gradlew"
             val cmd = mutableListOf(gradlew, "uiTest", "-PcaptureAllTraces=true")
-            selectedTests.forEach { cmd += listOf("--tests", it) }
+
+            if (featureName != "all") {
+                val changedFiles: List<String> = changedFilesProp.orNull?.let { prop ->
+                    prop.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+                } ?: gitDiffChangedFiles(projectDirFile)
+
+                val selection = com.github.artem.pageobjectplugin.buildtools
+                    .DemoTestSelector.select(
+                        projectDir = projectDirFile.toPath(),
+                        featureTag = featureName,
+                        changedFiles = changedFiles,
+                    )
+
+                if (selection.taggedCount < 2) {
+                    error(
+                        "demoReport requires at least 2 scenarios tagged @Feature(\"$featureName\") " +
+                            "(found ${selection.taggedCount}). Add a happy-path AND a negative-case test."
+                    )
+                }
+                selection.selected.forEach { cmd += listOf("--tests", it) }
+            }
+
             val exitCode = ProcessBuilder(cmd)
                 .directory(projectDirFile)
                 .inheritIO()


### PR DESCRIPTION
…lience

- Bump actions/checkout v4→v6, setup-java v4→v5, setup-node v4→v6, upload-artifact v4→v5, download-artifact v4→v5, github-script v7→v8, gradle/actions/setup-gradle v4→v5
- Send test result status (passed/failed) on every dashboard upload so the report dashboard can aggregate per-suite outcomes
- Add --connect-timeout 10, --retry 3, --retry-connrefused, and --retry-delay 2 to all curl calls against reports.artemon.cloud