### PR TITLE
Add feature-based grouping and resizable panes to demo viewer

### DIFF
--- a/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoReportRenderer.kt
+++ b/buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoReportRenderer.kt
@@ -66,6 +66,7 @@ object DemoReportRenderer {
         val className = (testObj?.get("className") as? JsonPrimitive)?.content ?: "Unknown"
         val method = (testObj?.get("method") as? JsonPrimitive)?.content ?: "unknown"
         val displayName = (testObj?.get("displayName") as? JsonPrimitive)?.content ?: method
+        val feature = (testObj?.get("feature") as? JsonPrimitive)?.contentOrNull()
         val status = (trace["status"] as? JsonPrimitive)?.content ?: "unknown"
 
         val stepsIn = (trace["steps"] as? JsonArray) ?: emptyList()
@@ -101,6 +102,7 @@ object DemoReportRenderer {
             put("method", method)
             put("displayName", displayName)
             put("status", status)
+            if (feature != null) put("feature", feature)
             put("steps", stepsOut)
             if (failureEl != null) put("failure", failureEl)
             if (domDataUri != null) put("domHtmlDataUri", domDataUri)

--- a/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoReportRendererTest.kt
+++ b/buildSrc/src/test/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoReportRendererTest.kt
@@ -1,14 +1,22 @@
 package com.github.artem.pageobjectplugin.buildtools
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.writeText
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 class DemoReportRendererTest {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
     @Test
     fun `renders self-contained HTML with test data`(@TempDir tmp: Path) {
@@ -55,5 +63,133 @@ class DemoReportRendererTest {
         assertFalse(html.contains("/*__DATA__*/"), "placeholder must be substituted")
         assertFalse(html.contains("/*__STYLES__*/"), "styles placeholder must be substituted")
         assertFalse(html.contains("/*__APP__*/"), "app placeholder must be substituted")
+    }
+
+    @Test
+    fun `embeds per-test feature so the viewer can group tests`(@TempDir tmp: Path) {
+        val templateDir = writeMinimalTemplate(tmp)
+
+        val happy = writeBundle(
+            tmp.resolve("traces/LoginUiTest__happy"),
+            className = "LoginUiTest",
+            method = "happy_path",
+            displayName = "happy path",
+            feature = "login",
+            status = "passed",
+        )
+        val negative = writeBundle(
+            tmp.resolve("traces/LoginUiTest__bad"),
+            className = "LoginUiTest",
+            method = "bad_password",
+            displayName = "bad password",
+            feature = "login",
+            status = "failed",
+        )
+        val other = writeBundle(
+            tmp.resolve("traces/SearchUiTest__suggest"),
+            className = "SearchUiTest",
+            method = "suggests_results",
+            displayName = "suggests results",
+            feature = "search",
+            status = "passed",
+        )
+
+        val out = tmp.resolve("out")
+        val result = DemoReportRenderer.render(
+            bundles = listOf(happy, negative, other),
+            outputDir = out,
+            featureTag = "all",
+            gitSha = "cafef00d",
+            templateDir = templateDir,
+        )
+
+        val payload = extractTraceData(Files.readString(result))
+        val tests = payload["tests"] as JsonArray
+        assertEquals(3, tests.size)
+
+        val byMethod = tests.associateBy { (it as JsonObject)["method"]!!.let { p -> (p as JsonPrimitive).content } }
+        assertEquals("login", featureOf(byMethod["happy_path"]!!))
+        assertEquals("login", featureOf(byMethod["bad_password"]!!))
+        assertEquals("search", featureOf(byMethod["suggests_results"]!!))
+    }
+
+    @Test
+    fun `per-test feature is omitted when the trace has none`(@TempDir tmp: Path) {
+        val templateDir = writeMinimalTemplate(tmp)
+        val bundle = writeBundle(
+            tmp.resolve("traces/UntaggedUiTest__runs"),
+            className = "UntaggedUiTest",
+            method = "runs",
+            displayName = "runs",
+            feature = null,
+            status = "passed",
+        )
+
+        val out = tmp.resolve("out")
+        val result = DemoReportRenderer.render(
+            bundles = listOf(bundle),
+            outputDir = out,
+            featureTag = "all",
+            gitSha = "abcdef",
+            templateDir = templateDir,
+        )
+
+        val payload = extractTraceData(Files.readString(result))
+        val test = (payload["tests"] as JsonArray).single() as JsonObject
+        assertFalse(test.containsKey("feature"), "feature must be omitted when not tagged")
+    }
+
+    private fun featureOf(el: kotlinx.serialization.json.JsonElement): String? {
+        val obj = el as JsonObject
+        return (obj["feature"] as? JsonPrimitive)?.content
+    }
+
+    private fun extractTraceData(html: String): JsonObject {
+        val marker = "window.__TRACE_DATA__ = "
+        val start = html.indexOf(marker)
+        assertTrue(start >= 0, "trace data assignment must be present")
+        val from = start + marker.length
+        val end = html.indexOf(";</script>", from)
+        assertTrue(end > from, "trace data terminator must be present")
+        val raw = html.substring(from, end).trim()
+        val parsed = json.parseToJsonElement(raw)
+        assertNotNull(parsed)
+        return parsed as JsonObject
+    }
+
+    private fun writeMinimalTemplate(tmp: Path): Path {
+        val templateDir = tmp.resolve("template").also { Files.createDirectories(it) }
+        templateDir.resolve("index.html").writeText(
+            "<html><style>/*__STYLES__*/</style><script>window.__TRACE_DATA__ = /*__DATA__*/ null;</script>" +
+                "<script>/*__APP__*/</script></html>",
+        )
+        templateDir.resolve("styles.css").writeText("body{}")
+        templateDir.resolve("app.js").writeText("console.log('ok');")
+        return templateDir
+    }
+
+    private fun writeBundle(
+        dir: Path,
+        className: String,
+        method: String,
+        displayName: String,
+        feature: String?,
+        status: String,
+    ): Path {
+        Files.createDirectories(dir)
+        val featureField = if (feature == null) "null" else "\"$feature\""
+        dir.resolve("trace.json").writeText(
+            """
+            {
+              "version":1,
+              "test":{"className":"$className","method":"$method","displayName":"$displayName","feature":$featureField},
+              "startedAt":"2026-04-09T00:00:00Z","durationMs":10,"status":"$status","flaky":false,
+              "steps":[{"index":0,"label":"do thing","at":"2026-04-09T00:00:00Z","durationMs":5,
+                        "screenshot":null,"error":null}],
+              "artifacts":{"ideaLog":null,"dom":null,"jcefConsole":null,"threads":null}
+            }
+            """.trimIndent(),
+        )
+        return dir
     }
 }

--- a/src/main/resources/demo-viewer/app.js
+++ b/src/main/resources/demo-viewer/app.js
@@ -19,19 +19,77 @@
   var timelineEl = document.getElementById('timeline');
   var detailsEl = document.getElementById('details');
 
+  // Group tests by feature, preserving the order in which features first appear.
+  var groups = [];
+  var groupIndexByName = {};
+  data.tests.forEach(function (t, i) {
+    var name = t.feature || data.feature || 'Ungrouped';
+    if (!(name in groupIndexByName)) {
+      groupIndexByName[name] = groups.length;
+      groups.push({ name: name, tests: [] });
+    }
+    groups[groupIndexByName[name]].tests.push({ test: t, index: i });
+  });
+
   var selectedTestIdx = 0;
   var selectedStepIdx = 0;
 
+  // Collapsed by default; auto-expand the group containing the initial selection.
+  var expandedGroups = {};
+  var initialGroup = groupNameForTestIdx(selectedTestIdx);
+  if (initialGroup != null) expandedGroups[initialGroup] = true;
+
+  // Resizer state for the screenshot pane (px). Persisted in-memory only.
+  var screenshotPaneHeight = 320;
+
+  function groupNameForTestIdx(idx) {
+    var t = data.tests[idx];
+    if (!t) return null;
+    return t.feature || data.feature || 'Ungrouped';
+  }
+
   function render() {
     listEl.innerHTML = '';
-    data.tests.forEach(function (t, i) {
-      var el = document.createElement('div');
-      el.className = 'test-item' + (i === selectedTestIdx ? ' selected' : '');
-      el.innerHTML =
-        '<span class="status ' + t.status + '"></span>' +
-        escapeHtml(t.displayName || t.method);
-      el.onclick = function () { selectedTestIdx = i; selectedStepIdx = 0; render(); };
-      listEl.appendChild(el);
+    groups.forEach(function (g) {
+      var groupEl = document.createElement('div');
+      var collapsed = !expandedGroups[g.name];
+      groupEl.className = 'feature-group' + (collapsed ? ' collapsed' : '');
+
+      var headerEl = document.createElement('div');
+      headerEl.className = 'feature-header';
+      headerEl.innerHTML =
+        '<span class="caret">' + (collapsed ? '\u25B6' : '\u25BC') + '</span>' +
+        '<span class="name">' + escapeHtml(g.name) + '</span>' +
+        '<span class="count">' + g.tests.length + '</span>';
+      headerEl.onclick = function () {
+        expandedGroups[g.name] = !expandedGroups[g.name];
+        render();
+      };
+      groupEl.appendChild(headerEl);
+
+      var testsEl = document.createElement('div');
+      testsEl.className = 'feature-tests';
+      g.tests.forEach(function (entry) {
+        var t = entry.test;
+        var i = entry.index;
+        var el = document.createElement('div');
+        el.className = 'test-item' + (i === selectedTestIdx ? ' selected' : '');
+        el.innerHTML =
+          '<span class="status ' + t.status + '"></span>' +
+          escapeHtml(t.displayName || t.method);
+        el.onclick = function (ev) {
+          ev.stopPropagation();
+          selectedTestIdx = i;
+          selectedStepIdx = 0;
+          // Make sure the group containing the selected test stays expanded.
+          expandedGroups[g.name] = true;
+          render();
+        };
+        testsEl.appendChild(el);
+      });
+      groupEl.appendChild(testsEl);
+
+      listEl.appendChild(groupEl);
     });
 
     var test = data.tests[selectedTestIdx];
@@ -46,26 +104,77 @@
       timelineEl.appendChild(el);
     });
 
-    var step = (test.steps || [])[selectedStepIdx];
+    renderDetails(test);
+  }
+
+  function renderDetails(test) {
     detailsEl.innerHTML = '';
+    var step = (test.steps || [])[selectedStepIdx];
+
+    var screenshotPane = document.createElement('div');
+    screenshotPane.className = 'screenshot-pane';
+    screenshotPane.style.height = screenshotPaneHeight + 'px';
     if (step && step.screenshotDataUri) {
       var img = document.createElement('img');
       img.src = step.screenshotDataUri;
-      detailsEl.appendChild(img);
+      img.alt = 'step screenshot';
+      screenshotPane.appendChild(img);
+    } else {
+      var empty = document.createElement('div');
+      empty.className = 'pane-empty';
+      empty.textContent = 'No screenshot for this step.';
+      screenshotPane.appendChild(empty);
     }
+    detailsEl.appendChild(screenshotPane);
+
+    var divider = document.createElement('div');
+    divider.className = 'pane-divider';
+    divider.title = 'Drag to resize screenshot';
+    attachResizer(divider, screenshotPane);
+    detailsEl.appendChild(divider);
+
+    var domPane = document.createElement('div');
+    domPane.className = 'dom-pane';
     if (test.failure) {
       var pre = document.createElement('pre');
       pre.textContent = test.failure.stack;
-      detailsEl.appendChild(pre);
+      domPane.appendChild(pre);
     }
     if (test.domHtmlDataUri) {
       var iframe = document.createElement('iframe');
       iframe.src = test.domHtmlDataUri;
-      iframe.style.width = '100%';
-      iframe.style.height = '300px';
       iframe.setAttribute('sandbox', '');
-      detailsEl.appendChild(iframe);
+      domPane.appendChild(iframe);
+    } else if (!test.failure) {
+      var emptyDom = document.createElement('div');
+      emptyDom.className = 'pane-empty';
+      emptyDom.textContent = 'No DOM snapshot for this test.';
+      domPane.appendChild(emptyDom);
     }
+    detailsEl.appendChild(domPane);
+  }
+
+  function attachResizer(handle, screenshotPane) {
+    handle.addEventListener('mousedown', function (e) {
+      e.preventDefault();
+      var startY = e.clientY;
+      var startHeight = screenshotPane.getBoundingClientRect().height;
+      document.body.classList.add('resizing-vert');
+
+      function onMove(ev) {
+        var delta = ev.clientY - startY;
+        var next = Math.max(80, Math.min(2000, startHeight + delta));
+        screenshotPaneHeight = next;
+        screenshotPane.style.height = next + 'px';
+      }
+      function onUp() {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        document.body.classList.remove('resizing-vert');
+      }
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
   }
 
   function escapeHtml(s) {

--- a/src/main/resources/demo-viewer/app.js
+++ b/src/main/resources/demo-viewer/app.js
@@ -118,6 +118,8 @@
       var img = document.createElement('img');
       img.src = step.screenshotDataUri;
       img.alt = 'step screenshot';
+      img.title = 'Click to view at full resolution';
+      img.onclick = function () { openLightbox(step.screenshotDataUri); };
       screenshotPane.appendChild(img);
     } else {
       var empty = document.createElement('div');
@@ -175,6 +177,50 @@
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onUp);
     });
+  }
+
+  // Lightbox for full-resolution screenshot viewing.
+  // The underlying PNG is the full IDE desktop (e.g. 1920x1080) even though
+  // the side panel CSS-scales it down to fit. Clicking opens a modal that
+  // starts at "fit-to-viewport" and toggles to "100% native pixels" on click.
+  function openLightbox(dataUri) {
+    var overlay = document.createElement('div');
+    overlay.className = 'lightbox-overlay';
+
+    var img = document.createElement('img');
+    img.className = 'lightbox-img fit';
+    img.src = dataUri;
+    img.alt = 'screenshot';
+    overlay.appendChild(img);
+
+    var hint = document.createElement('div');
+    hint.className = 'lightbox-hint';
+    hint.textContent = 'Click image to toggle 100% · Esc or click background to close';
+    overlay.appendChild(hint);
+
+    function close() {
+      document.removeEventListener('keydown', onKey);
+      overlay.remove();
+    }
+    function onKey(e) { if (e.key === 'Escape') close(); }
+
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) close();
+    });
+    img.addEventListener('click', function (e) {
+      e.stopPropagation();
+      if (img.classList.contains('fit')) {
+        img.classList.remove('fit');
+        img.classList.add('actual');
+        hint.textContent = '100% (native pixels) · Click image to fit · Esc to close';
+      } else {
+        img.classList.remove('actual');
+        img.classList.add('fit');
+        hint.textContent = 'Fit to viewport · Click image for 100% · Esc to close';
+      }
+    });
+    document.addEventListener('keydown', onKey);
+    document.body.appendChild(overlay);
   }
 
   function escapeHtml(s) {

--- a/src/main/resources/demo-viewer/app.js
+++ b/src/main/resources/demo-viewer/app.js
@@ -5,21 +5,24 @@
     return;
   }
 
-  var header = document.getElementById('summary');
-  var totalSteps = data.tests.reduce(function (acc, t) { return acc + (t.steps || []).length; }, 0);
-  var failures = data.tests.filter(function (t) { return t.status === 'failed'; }).length;
-  header.innerHTML =
-    '<span class="tag">' + escapeHtml(data.feature) + '</span>' +
-    '<span>' + data.tests.length + ' tests</span>' +
-    '<span>' + totalSteps + ' steps</span>' +
-    '<span>' + failures + ' failures</span>' +
-    '<span class="sha">' + escapeHtml(data.gitSha || '') + '</span>';
+  // ── DOM refs ─────────────────────────────────────────────
+  var headerEl = document.getElementById('summary');
+  var testListEl = document.getElementById('test-list');
+  var screenshotPaneEl = document.getElementById('screenshot-pane');
+  var dividerEl = document.getElementById('pane-divider');
+  var tabsEl = document.getElementById('tabs');
+  var tabListEl = document.getElementById('tab-list');
+  var tabBodyEl = document.getElementById('tab-body');
+  var stepListEl = document.getElementById('step-list');
 
-  var listEl = document.getElementById('test-list');
-  var timelineEl = document.getElementById('timeline');
-  var detailsEl = document.getElementById('details');
+  // ── State ────────────────────────────────────────────────
+  var selectedTestIdx = 0;
+  var selectedStepIdx = 0;
+  var selectedTab = 'dom';          // 'dom' | 'failure'
+  var bottomPaneHeight = 260;       // px, controlled by the divider drag
+  var expandedGroups = {};
 
-  // Group tests by feature, preserving the order in which features first appear.
+  // ── Feature grouping ─────────────────────────────────────
   var groups = [];
   var groupIndexByName = {};
   data.tests.forEach(function (t, i) {
@@ -31,41 +34,49 @@
     groups[groupIndexByName[name]].tests.push({ test: t, index: i });
   });
 
-  var selectedTestIdx = 0;
-  var selectedStepIdx = 0;
-
-  // Collapsed by default; auto-expand the group containing the initial selection.
-  var expandedGroups = {};
-  var initialGroup = groupNameForTestIdx(selectedTestIdx);
-  if (initialGroup != null) expandedGroups[initialGroup] = true;
-
-  // Resizer state for the screenshot pane (px). Persisted in-memory only.
-  var screenshotPaneHeight = 320;
-
   function groupNameForTestIdx(idx) {
     var t = data.tests[idx];
     if (!t) return null;
     return t.feature || data.feature || 'Ungrouped';
   }
 
-  function render() {
-    listEl.innerHTML = '';
+  // Collapse everything by default; expand the group containing the initial test.
+  var initialGroup = groupNameForTestIdx(selectedTestIdx);
+  if (initialGroup != null) expandedGroups[initialGroup] = true;
+
+  // ── Header ───────────────────────────────────────────────
+  function renderHeader() {
+    var totalSteps = data.tests.reduce(function (acc, t) {
+      return acc + (t.steps || []).length;
+    }, 0);
+    var failures = data.tests.filter(function (t) { return t.status === 'failed'; }).length;
+    headerEl.innerHTML =
+      '<span class="tag">' + escapeHtml(data.feature) + '</span>' +
+      '<span>' + data.tests.length + ' tests</span>' +
+      '<span>' + totalSteps + ' steps</span>' +
+      '<span>' + failures + ' failures</span>' +
+      '<span class="sha">' + escapeHtml(data.gitSha || '') + '</span>';
+  }
+
+  // ── Left sidebar: test list grouped by feature ──────────
+  function renderTestList() {
+    testListEl.innerHTML = '';
     groups.forEach(function (g) {
       var groupEl = document.createElement('div');
       var collapsed = !expandedGroups[g.name];
       groupEl.className = 'feature-group' + (collapsed ? ' collapsed' : '');
 
-      var headerEl = document.createElement('div');
-      headerEl.className = 'feature-header';
-      headerEl.innerHTML =
+      var gHeader = document.createElement('div');
+      gHeader.className = 'feature-header';
+      gHeader.innerHTML =
         '<span class="caret">' + (collapsed ? '\u25B6' : '\u25BC') + '</span>' +
         '<span class="name">' + escapeHtml(g.name) + '</span>' +
         '<span class="count">' + g.tests.length + '</span>';
-      headerEl.onclick = function () {
+      gHeader.onclick = function () {
         expandedGroups[g.name] = !expandedGroups[g.name];
-        render();
+        renderTestList();
       };
-      groupEl.appendChild(headerEl);
+      groupEl.appendChild(gHeader);
 
       var testsEl = document.createElement('div');
       testsEl.className = 'feature-tests';
@@ -76,113 +87,143 @@
         el.className = 'test-item' + (i === selectedTestIdx ? ' selected' : '');
         el.innerHTML =
           '<span class="status ' + t.status + '"></span>' +
-          escapeHtml(t.displayName || t.method);
+          '<span class="test-name">' + escapeHtml(t.displayName || t.method) + '</span>';
         el.onclick = function (ev) {
           ev.stopPropagation();
           selectedTestIdx = i;
           selectedStepIdx = 0;
-          // Make sure the group containing the selected test stays expanded.
           expandedGroups[g.name] = true;
-          render();
+          selectedTab = pickDefaultTab(data.tests[selectedTestIdx]);
+          renderAll();
         };
         testsEl.appendChild(el);
       });
       groupEl.appendChild(testsEl);
-
-      listEl.appendChild(groupEl);
+      testListEl.appendChild(groupEl);
     });
-
-    var test = data.tests[selectedTestIdx];
-    timelineEl.innerHTML = '';
-    (test.steps || []).forEach(function (s, i) {
-      var el = document.createElement('div');
-      el.className = 'step' + (i === selectedStepIdx ? ' selected' : '') + (s.error ? ' has-error' : '');
-      el.innerHTML =
-        '<span class="label">' + escapeHtml(s.label) + '</span>' +
-        '<span class="dur">' + s.durationMs + 'ms</span>';
-      el.onclick = function () { selectedStepIdx = i; render(); };
-      timelineEl.appendChild(el);
-    });
-
-    renderDetails(test);
   }
 
-  function renderDetails(test) {
-    detailsEl.innerHTML = '';
-    var step = (test.steps || [])[selectedStepIdx];
+  // ── Right sidebar: step timeline ────────────────────────
+  function renderStepList() {
+    stepListEl.innerHTML = '';
+    var test = data.tests[selectedTestIdx];
+    var steps = test.steps || [];
 
-    var screenshotPane = document.createElement('div');
-    screenshotPane.className = 'screenshot-pane';
-    screenshotPane.style.height = screenshotPaneHeight + 'px';
+    var heading = document.createElement('div');
+    heading.className = 'step-list-heading';
+    heading.textContent = 'Steps (' + steps.length + ')';
+    stepListEl.appendChild(heading);
+
+    if (steps.length === 0) {
+      var empty = document.createElement('div');
+      empty.className = 'pane-empty';
+      empty.textContent = 'No steps recorded.';
+      stepListEl.appendChild(empty);
+      return;
+    }
+
+    steps.forEach(function (s, i) {
+      var el = document.createElement('div');
+      el.className = 'step' +
+        (i === selectedStepIdx ? ' selected' : '') +
+        (s.error ? ' has-error' : '');
+      el.innerHTML =
+        '<div class="step-index">' + (s.index || (i + 1)) + '</div>' +
+        '<div class="step-body">' +
+          '<div class="label">' + escapeHtml(s.label) + '</div>' +
+          '<div class="dur">' + s.durationMs + 'ms</div>' +
+        '</div>';
+      el.onclick = function () {
+        selectedStepIdx = i;
+        renderStepList();
+        renderScreenshot();
+      };
+      stepListEl.appendChild(el);
+    });
+  }
+
+  // ── Center top: screenshot pane ─────────────────────────
+  function renderScreenshot() {
+    var test = data.tests[selectedTestIdx];
+    var step = (test.steps || [])[selectedStepIdx];
+    screenshotPaneEl.innerHTML = '';
+
     if (step && step.screenshotDataUri) {
       var img = document.createElement('img');
       img.src = step.screenshotDataUri;
       img.alt = 'step screenshot';
       img.title = 'Click to view at full resolution';
       img.onclick = function () { openLightbox(step.screenshotDataUri); };
-      screenshotPane.appendChild(img);
+      screenshotPaneEl.appendChild(img);
     } else {
       var empty = document.createElement('div');
       empty.className = 'pane-empty';
-      empty.textContent = 'No screenshot for this step.';
-      screenshotPane.appendChild(empty);
+      empty.textContent = step
+        ? 'No screenshot recorded for this step.'
+        : 'No step selected.';
+      screenshotPaneEl.appendChild(empty);
     }
-    detailsEl.appendChild(screenshotPane);
+  }
 
-    var divider = document.createElement('div');
-    divider.className = 'pane-divider';
-    divider.title = 'Drag to resize screenshot';
-    attachResizer(divider, screenshotPane);
-    detailsEl.appendChild(divider);
+  // ── Center bottom: tabs (DOM snapshot / Failure) ───────
+  function pickDefaultTab(test) {
+    if (test && test.failure) return 'failure';
+    if (test && test.domHtmlDataUri) return 'dom';
+    return 'dom';
+  }
 
-    var domPane = document.createElement('div');
-    domPane.className = 'dom-pane';
-    if (test.failure) {
-      var pre = document.createElement('pre');
-      pre.textContent = test.failure.stack;
-      domPane.appendChild(pre);
+  function renderTabs() {
+    var test = data.tests[selectedTestIdx];
+    var hasDom = !!test.domHtmlDataUri;
+    var hasFailure = !!test.failure;
+
+    // If neither tab has anything, hide the entire bottom section.
+    if (!hasDom && !hasFailure) {
+      tabsEl.classList.add('hidden');
+      dividerEl.classList.add('hidden');
+      return;
     }
-    if (test.domHtmlDataUri) {
+    tabsEl.classList.remove('hidden');
+    dividerEl.classList.remove('hidden');
+    tabsEl.style.height = bottomPaneHeight + 'px';
+
+    // Fall back to an enabled tab if the current one is empty for this test.
+    if (selectedTab === 'dom' && !hasDom) selectedTab = hasFailure ? 'failure' : 'dom';
+    if (selectedTab === 'failure' && !hasFailure) selectedTab = hasDom ? 'dom' : 'failure';
+
+    var specs = [
+      { id: 'dom', label: 'DOM Snapshot', enabled: hasDom },
+      { id: 'failure', label: 'Failure', enabled: hasFailure },
+    ];
+
+    tabListEl.innerHTML = '';
+    specs.forEach(function (spec) {
+      var btn = document.createElement('button');
+      btn.className = 'tab-button' + (spec.id === selectedTab ? ' active' : '');
+      btn.textContent = spec.label;
+      btn.disabled = !spec.enabled;
+      btn.onclick = function () {
+        if (!spec.enabled) return;
+        selectedTab = spec.id;
+        renderTabs();
+      };
+      tabListEl.appendChild(btn);
+    });
+
+    tabBodyEl.innerHTML = '';
+    if (selectedTab === 'dom' && hasDom) {
       var iframe = document.createElement('iframe');
       iframe.src = test.domHtmlDataUri;
       iframe.setAttribute('sandbox', '');
-      domPane.appendChild(iframe);
-    } else if (!test.failure) {
-      var emptyDom = document.createElement('div');
-      emptyDom.className = 'pane-empty';
-      emptyDom.textContent = 'No DOM snapshot for this test.';
-      domPane.appendChild(emptyDom);
+      tabBodyEl.appendChild(iframe);
+    } else if (selectedTab === 'failure' && hasFailure) {
+      var pre = document.createElement('pre');
+      pre.textContent = test.failure.stack;
+      tabBodyEl.appendChild(pre);
     }
-    detailsEl.appendChild(domPane);
   }
 
-  function attachResizer(handle, screenshotPane) {
-    handle.addEventListener('mousedown', function (e) {
-      e.preventDefault();
-      var startY = e.clientY;
-      var startHeight = screenshotPane.getBoundingClientRect().height;
-      document.body.classList.add('resizing-vert');
-
-      function onMove(ev) {
-        var delta = ev.clientY - startY;
-        var next = Math.max(80, Math.min(2000, startHeight + delta));
-        screenshotPaneHeight = next;
-        screenshotPane.style.height = next + 'px';
-      }
-      function onUp() {
-        document.removeEventListener('mousemove', onMove);
-        document.removeEventListener('mouseup', onUp);
-        document.body.classList.remove('resizing-vert');
-      }
-      document.addEventListener('mousemove', onMove);
-      document.addEventListener('mouseup', onUp);
-    });
-  }
-
-  // Lightbox for full-resolution screenshot viewing.
-  // The underlying PNG is the full IDE desktop (e.g. 1920x1080) even though
-  // the side panel CSS-scales it down to fit. Clicking opens a modal that
-  // starts at "fit-to-viewport" and toggles to "100% native pixels" on click.
+  // ── Lightbox (full-resolution zoom) ─────────────────────
   function openLightbox(dataUri) {
     var overlay = document.createElement('div');
     overlay.className = 'lightbox-overlay';
@@ -195,7 +236,7 @@
 
     var hint = document.createElement('div');
     hint.className = 'lightbox-hint';
-    hint.textContent = 'Click image to toggle 100% · Esc or click background to close';
+    hint.textContent = 'Fit to viewport · Click image for 100% · Esc to close';
     overlay.appendChild(hint);
 
     function close() {
@@ -223,10 +264,47 @@
     document.body.appendChild(overlay);
   }
 
+  // ── Divider resize ─────────────────────────────────────
+  // Dragging the handle UP shrinks the tabs pane (grows the screenshot),
+  // dragging DOWN grows the tabs pane.
+  function attachResizer() {
+    dividerEl.addEventListener('mousedown', function (e) {
+      e.preventDefault();
+      var startY = e.clientY;
+      var startHeight = tabsEl.getBoundingClientRect().height;
+      document.body.classList.add('resizing-vert');
+
+      function onMove(ev) {
+        var delta = startY - ev.clientY;
+        var next = Math.max(40, Math.min(1500, startHeight + delta));
+        bottomPaneHeight = next;
+        tabsEl.style.height = next + 'px';
+      }
+      function onUp() {
+        document.removeEventListener('mousemove', onMove);
+        document.removeEventListener('mouseup', onUp);
+        document.body.classList.remove('resizing-vert');
+      }
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+  }
+
+  function renderAll() {
+    renderTestList();
+    renderStepList();
+    renderScreenshot();
+    renderTabs();
+  }
+
   function escapeHtml(s) {
     return String(s == null ? '' : s)
       .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
   }
 
-  render();
+  // ── Init ───────────────────────────────────────────────
+  selectedTab = pickDefaultTab(data.tests[selectedTestIdx]);
+  renderHeader();
+  attachResizer();
+  renderAll();
 })();

--- a/src/main/resources/demo-viewer/index.html
+++ b/src/main/resources/demo-viewer/index.html
@@ -9,8 +9,15 @@
 <header id="summary"></header>
 <main>
   <aside id="test-list"></aside>
-  <section id="timeline"></section>
-  <section id="details"></section>
+  <section id="artifact">
+    <div id="screenshot-pane"></div>
+    <div id="pane-divider" title="Drag to resize"></div>
+    <div id="tabs">
+      <div id="tab-list" class="tab-list"></div>
+      <div id="tab-body" class="tab-body"></div>
+    </div>
+  </section>
+  <aside id="step-list"></aside>
 </main>
 <script>window.__TRACE_DATA__ = /*__DATA__*/ null;</script>
 <script>/*__APP__*/</script>

--- a/src/main/resources/demo-viewer/styles.css
+++ b/src/main/resources/demo-viewer/styles.css
@@ -1,16 +1,39 @@
 :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
 body { margin: 0; display: flex; flex-direction: column; height: 100vh; }
+body.resizing-vert { cursor: row-resize; user-select: none; }
 header#summary {
   padding: 8px 16px; border-bottom: 1px solid #8884;
   display: flex; gap: 24px; align-items: baseline;
 }
 header#summary .tag { font-weight: 600; }
 header#summary .sha { font-family: monospace; opacity: 0.7; }
-main { display: grid; grid-template-columns: 240px 1fr 360px; flex: 1; min-height: 0; }
-aside#test-list, section#timeline, section#details {
+main { display: grid; grid-template-columns: 260px 1fr 420px; flex: 1; min-height: 0; }
+aside#test-list, section#timeline {
   overflow: auto; padding: 8px; border-right: 1px solid #8884;
 }
-section#details { border-right: none; }
+section#details {
+  display: flex; flex-direction: column;
+  overflow: hidden; padding: 0; min-height: 0;
+}
+
+/* Feature groups */
+.feature-group { margin-bottom: 4px; }
+.feature-header {
+  display: flex; align-items: center; gap: 6px;
+  padding: 6px 8px; cursor: pointer; border-radius: 4px;
+  font-weight: 600; user-select: none;
+}
+.feature-header:hover { background: #8882; }
+.feature-header .caret { width: 12px; opacity: 0.7; font-size: 0.8em; }
+.feature-header .name { flex: 1; }
+.feature-header .count {
+  font-weight: 400; opacity: 0.6; font-size: 0.85em;
+  background: #8883; padding: 1px 6px; border-radius: 10px;
+}
+.feature-tests { padding-left: 14px; }
+.feature-group.collapsed .feature-tests { display: none; }
+
+/* Tests */
 .test-item { padding: 6px 8px; cursor: pointer; border-radius: 4px; }
 .test-item:hover { background: #8882; }
 .test-item.selected { background: #3b82f633; }
@@ -18,12 +41,44 @@ section#details { border-right: none; }
 .test-item .status.passed { background: #22c55e; }
 .test-item .status.failed { background: #ef4444; }
 .test-item .status.aborted { background: #f59e0b; }
+
+/* Steps */
 .step { padding: 6px 8px; cursor: pointer; border-bottom: 1px solid #8882; }
 .step.selected { background: #3b82f633; }
 .step .label { font-weight: 500; }
 .step .dur { opacity: 0.6; font-size: 0.85em; margin-left: 8px; }
 .step.has-error { color: #ef4444; }
-#details img, #details iframe {
-  max-width: 100%; border: 1px solid #8884; border-radius: 4px;
+
+/* Details: resizable screenshot pane + dom pane */
+.screenshot-pane {
+  flex: 0 0 auto; min-height: 80px;
+  overflow: auto; padding: 8px;
+  display: flex; align-items: flex-start; justify-content: center;
+  background: #0001;
 }
-#details pre { white-space: pre-wrap; font-size: 0.85em; }
+.screenshot-pane img {
+  max-width: 100%; height: auto;
+  border: 1px solid #8884; border-radius: 4px;
+}
+.pane-divider {
+  flex: 0 0 6px; cursor: row-resize;
+  background: #8883;
+  border-top: 1px solid #8884; border-bottom: 1px solid #8884;
+}
+.pane-divider:hover { background: #3b82f6aa; }
+.dom-pane {
+  flex: 1 1 auto; min-height: 0;
+  overflow: auto; padding: 8px;
+  display: flex; flex-direction: column;
+}
+.dom-pane iframe {
+  flex: 1 1 auto; width: 100%; min-height: 200px;
+  border: 1px solid #8884; border-radius: 4px;
+}
+.dom-pane pre {
+  white-space: pre-wrap; font-size: 0.85em;
+  color: #ef4444; margin: 0 0 8px 0;
+}
+.pane-empty {
+  opacity: 0.5; font-style: italic; padding: 16px; text-align: center;
+}

--- a/src/main/resources/demo-viewer/styles.css
+++ b/src/main/resources/demo-viewer/styles.css
@@ -59,6 +59,7 @@ section#details {
 .screenshot-pane img {
   max-width: 100%; height: auto;
   border: 1px solid #8884; border-radius: 4px;
+  cursor: zoom-in;
 }
 .pane-divider {
   flex: 0 0 6px; cursor: row-resize;
@@ -81,4 +82,33 @@ section#details {
 }
 .pane-empty {
   opacity: 0.5; font-style: italic; padding: 16px; text-align: center;
+}
+
+/* Lightbox for full-resolution screenshot viewing */
+.lightbox-overlay {
+  position: fixed; inset: 0;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex; align-items: center; justify-content: center;
+  z-index: 1000;
+  overflow: auto;
+}
+.lightbox-img.fit {
+  max-width: 95vw; max-height: 90vh;
+  width: auto; height: auto;
+  cursor: zoom-in;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+.lightbox-img.actual {
+  max-width: none; max-height: none;
+  width: auto; height: auto;
+  cursor: zoom-out;
+  margin: 24px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
+}
+.lightbox-hint {
+  position: fixed; left: 50%; bottom: 16px;
+  transform: translateX(-50%);
+  padding: 6px 12px; border-radius: 4px;
+  background: rgba(0, 0, 0, 0.6); color: #fff;
+  font-size: 0.85em; pointer-events: none;
 }

--- a/src/main/resources/demo-viewer/styles.css
+++ b/src/main/resources/demo-viewer/styles.css
@@ -1,22 +1,103 @@
 :root { color-scheme: light dark; font-family: system-ui, sans-serif; }
 body { margin: 0; display: flex; flex-direction: column; height: 100vh; }
 body.resizing-vert { cursor: row-resize; user-select: none; }
+
+/* ── Header ─────────────────────────────────────────────────── */
 header#summary {
   padding: 8px 16px; border-bottom: 1px solid #8884;
   display: flex; gap: 24px; align-items: baseline;
+  flex: 0 0 auto;
 }
 header#summary .tag { font-weight: 600; }
 header#summary .sha { font-family: monospace; opacity: 0.7; }
-main { display: grid; grid-template-columns: 260px 1fr 420px; flex: 1; min-height: 0; }
-aside#test-list, section#timeline {
-  overflow: auto; padding: 8px; border-right: 1px solid #8884;
-}
-section#details {
-  display: flex; flex-direction: column;
-  overflow: hidden; padding: 0; min-height: 0;
+
+/* ── Three-column layout: tests | artifact | steps ─────────── */
+main {
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr) 280px;
+  flex: 1 1 auto; min-height: 0;
 }
 
-/* Feature groups */
+aside#test-list, aside#step-list {
+  overflow: auto; padding: 8px;
+  min-width: 0;
+}
+aside#test-list { border-right: 1px solid #8884; }
+aside#step-list { border-left: 1px solid #8884; }
+
+/* ── Center column: screenshot + divider + tabs ────────────── */
+section#artifact {
+  display: flex; flex-direction: column;
+  min-width: 0; min-height: 0;
+  overflow: hidden;
+}
+
+/* Screenshot fills all remaining vertical space above the tabs. */
+#screenshot-pane {
+  flex: 1 1 auto; min-height: 80px;
+  display: flex; align-items: center; justify-content: center;
+  background: #0001; padding: 12px;
+  overflow: auto;
+}
+#screenshot-pane img {
+  max-width: 100%; max-height: 100%;
+  width: auto; height: auto;
+  object-fit: contain;
+  border: 1px solid #8884; border-radius: 4px;
+  cursor: zoom-in;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+#pane-divider {
+  flex: 0 0 6px; cursor: row-resize;
+  background: #8883;
+  border-top: 1px solid #8884; border-bottom: 1px solid #8884;
+}
+#pane-divider:hover { background: #3b82f6aa; }
+
+#tabs {
+  flex: 0 0 auto;
+  display: flex; flex-direction: column;
+  min-height: 0;
+}
+#tabs.hidden { display: none; }
+
+.tab-list {
+  display: flex; gap: 2px;
+  padding: 0 8px; border-bottom: 1px solid #8884;
+  flex: 0 0 auto;
+}
+.tab-button {
+  padding: 8px 14px; cursor: pointer;
+  border: none; border-bottom: 2px solid transparent;
+  background: none; color: inherit;
+  font: inherit; font-size: 0.9em;
+}
+.tab-button:hover:not(:disabled) { background: #8882; }
+.tab-button.active {
+  border-bottom-color: #3b82f6;
+  font-weight: 600;
+}
+.tab-button:disabled {
+  opacity: 0.35; cursor: not-allowed;
+}
+
+.tab-body {
+  flex: 1 1 auto; min-height: 0;
+  overflow: auto; padding: 8px;
+  display: flex; flex-direction: column;
+}
+.tab-body iframe {
+  flex: 1 1 auto; width: 100%; min-height: 120px;
+  border: 1px solid #8884; border-radius: 4px;
+  background: #fff;
+}
+.tab-body pre {
+  white-space: pre-wrap; font-size: 0.85em;
+  color: #ef4444; margin: 0; flex: 1 1 auto;
+}
+
+/* ── Feature groups in left sidebar ────────────────────────── */
 .feature-group { margin-bottom: 4px; }
 .feature-header {
   display: flex; align-items: center; gap: 6px;
@@ -33,58 +114,57 @@ section#details {
 .feature-tests { padding-left: 14px; }
 .feature-group.collapsed .feature-tests { display: none; }
 
-/* Tests */
-.test-item { padding: 6px 8px; cursor: pointer; border-radius: 4px; }
+.test-item {
+  padding: 6px 8px; cursor: pointer; border-radius: 4px;
+  display: flex; align-items: center; gap: 6px;
+}
 .test-item:hover { background: #8882; }
 .test-item.selected { background: #3b82f633; }
-.test-item .status { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 6px; }
+.test-item .status {
+  flex: 0 0 auto;
+  display: inline-block; width: 10px; height: 10px; border-radius: 50%;
+}
 .test-item .status.passed { background: #22c55e; }
 .test-item .status.failed { background: #ef4444; }
 .test-item .status.aborted { background: #f59e0b; }
+.test-item .test-name {
+  flex: 1 1 auto; min-width: 0;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
 
-/* Steps */
-.step { padding: 6px 8px; cursor: pointer; border-bottom: 1px solid #8882; }
+/* ── Step list in right sidebar ────────────────────────────── */
+.step-list-heading {
+  font-weight: 600; font-size: 0.75em;
+  opacity: 0.6; text-transform: uppercase; letter-spacing: 0.5px;
+  padding: 4px 8px 10px;
+}
+.step {
+  display: flex; gap: 8px;
+  padding: 6px 8px; cursor: pointer;
+  border-radius: 4px;
+  margin-bottom: 2px;
+}
+.step:hover { background: #8882; }
 .step.selected { background: #3b82f633; }
-.step .label { font-weight: 500; }
-.step .dur { opacity: 0.6; font-size: 0.85em; margin-left: 8px; }
 .step.has-error { color: #ef4444; }
+.step-index {
+  flex: 0 0 auto;
+  width: 22px; text-align: right;
+  opacity: 0.5; font-variant-numeric: tabular-nums;
+  font-size: 0.85em; padding-top: 1px;
+}
+.step-body { flex: 1 1 auto; min-width: 0; }
+.step .label {
+  font-weight: 500; font-size: 0.9em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.step .dur { opacity: 0.55; font-size: 0.78em; }
 
-/* Details: resizable screenshot pane + dom pane */
-.screenshot-pane {
-  flex: 0 0 auto; min-height: 80px;
-  overflow: auto; padding: 8px;
-  display: flex; align-items: flex-start; justify-content: center;
-  background: #0001;
-}
-.screenshot-pane img {
-  max-width: 100%; height: auto;
-  border: 1px solid #8884; border-radius: 4px;
-  cursor: zoom-in;
-}
-.pane-divider {
-  flex: 0 0 6px; cursor: row-resize;
-  background: #8883;
-  border-top: 1px solid #8884; border-bottom: 1px solid #8884;
-}
-.pane-divider:hover { background: #3b82f6aa; }
-.dom-pane {
-  flex: 1 1 auto; min-height: 0;
-  overflow: auto; padding: 8px;
-  display: flex; flex-direction: column;
-}
-.dom-pane iframe {
-  flex: 1 1 auto; width: 100%; min-height: 200px;
-  border: 1px solid #8884; border-radius: 4px;
-}
-.dom-pane pre {
-  white-space: pre-wrap; font-size: 0.85em;
-  color: #ef4444; margin: 0 0 8px 0;
-}
 .pane-empty {
   opacity: 0.5; font-style: italic; padding: 16px; text-align: center;
 }
 
-/* Lightbox for full-resolution screenshot viewing */
+/* ── Lightbox (click-to-zoom) ─────────────────────────────── */
 .lightbox-overlay {
   position: fixed; inset: 0;
   background: rgba(0, 0, 0, 0.85);

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/ElementPickerUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/ElementPickerUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.fixtures.PageMirrorToolWindowFixture
 import com.github.artem.pageobjectplugin.ui.fixtures.SnapshotBrowserFixture
 import com.github.artem.pageobjectplugin.ui.pages.EditorPage
@@ -18,6 +19,7 @@ import java.time.Duration
  * elements in the JCEF snapshot shows green boxes; clicking an element sends
  * its JSON back to the IDE and inserts a Playwright locator into the editor.
  */
+@Feature("element-picker")
 class ElementPickerUiTest : BaseUiTest() {
 
     private val editor by lazy { EditorPage(robot) }

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/GutterAnnotationUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/GutterAnnotationUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.fixtures.GutterFixture
 import com.github.artem.pageobjectplugin.ui.fixtures.PageMirrorToolWindowFixture
 import com.github.artem.pageobjectplugin.ui.pages.EditorPage
@@ -22,6 +23,7 @@ import java.time.Duration
  *   getByRole('button')            → 1 match  (login-button has role=button)
  *   getByText('Bad credentials')   → 0 matches (not in snapshot)
  */
+@Feature("gutter-validation")
 class GutterAnnotationUiTest : BaseUiTest() {
 
     private val editor by lazy { EditorPage(robot) }

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/HighlightBridgeUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/HighlightBridgeUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.fixtures.PageMirrorToolWindowFixture
 import com.github.artem.pageobjectplugin.ui.fixtures.SnapshotBrowserFixture
 import com.github.artem.pageobjectplugin.ui.pages.EditorPage
@@ -27,6 +28,7 @@ import java.time.Duration
  *
  * Note: exact line numbers may differ; adjust constants below if needed.
  */
+@Feature("highlight-bridge")
 class HighlightBridgeUiTest : BaseUiTest() {
 
     // Actual line numbers in test-project/page-objects/login.page.ts (constructor body)

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/SettingsUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/SettingsUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.flows.SettingsChangeFlow
 import com.github.artem.pageobjectplugin.ui.pages.EditorPage
 import org.junit.jupiter.api.AfterEach
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test
  * rewritten to match those accessible names instead of relying on UI DSL
  * class-name quirks (JBIntSpinner vs JSpinner, etc.).
  */
+@Feature("settings")
 class SettingsUiTest : BaseUiTest() {
 
     private val editor by lazy { EditorPage(robot) }

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/SnapshotRenderingUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/SnapshotRenderingUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.fixtures.PageMirrorToolWindowFixture
 import com.github.artem.pageobjectplugin.ui.fixtures.SnapshotBrowserFixture
 import com.github.artem.pageobjectplugin.ui.pages.EditorPage
@@ -17,6 +18,7 @@ import java.time.Duration
  *   - IDE started with test-project/ open (runIdeForUiTests task)
  *   - test-project/.snapshots/login/initial/ contains a valid snapshot bundle
  */
+@Feature("snapshot-rendering")
 class SnapshotRenderingUiTest : BaseUiTest() {
 
     private val editor by lazy { EditorPage(robot) }

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/StatusBarUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/StatusBarUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.fixtures.PageMirrorToolWindowFixture
 import com.github.artem.pageobjectplugin.ui.fixtures.StatusBarFixture
 import com.github.artem.pageobjectplugin.ui.pages.EditorPage
@@ -17,6 +18,7 @@ import java.time.Duration
  *   - "Page Mirror: No snapshot"  when no snapshot is loaded
  *   - "Page Mirror: {name}"       when a snapshot is loaded
  */
+@Feature("status-bar")
 class StatusBarUiTest : BaseUiTest() {
 
     private val editor by lazy { EditorPage(robot) }

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/ThemeUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/ThemeUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.fixtures.PageMirrorToolWindowFixture
 import com.github.artem.pageobjectplugin.ui.pages.EditorPage
 import com.github.artem.pageobjectplugin.ui.pages.PluginToolWindowPage
@@ -22,6 +23,7 @@ import java.time.Duration
  * state on the Kotlin side — the SnapshotService.applyTheme() is triggered
  * by LafManagerListener and uses the isDark flag to set the CSS class.
  */
+@Feature("theme")
 class ThemeUiTest : BaseUiTest() {
 
     private var originalThemeName: String = "IntelliJ Light"

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/ToolWindowUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/ToolWindowUiTest.kt
@@ -1,6 +1,7 @@
 package com.github.artem.pageobjectplugin.ui.tests
 
 import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
 import com.github.artem.pageobjectplugin.ui.flows.SnapshotLoadFlow
 import com.github.artem.pageobjectplugin.ui.pages.PluginToolWindowPage
 import com.github.artem.pageobjectplugin.ui.support.Wait
@@ -17,6 +18,7 @@ import java.time.Duration
  * test classes should follow this pattern: construct a Flow in @BeforeEach,
  * then talk to Pages in the test bodies. No raw fixture access.
  */
+@Feature("tool-window")
 class ToolWindowUiTest : BaseUiTest() {
 
     private val toolWindow by lazy { PluginToolWindowPage(robot) }


### PR DESCRIPTION
## Summary
Enhanced the demo test viewer with feature-based test grouping and an improved details pane layout with resizable screenshot/DOM sections.

## Key Changes

### Test Grouping by Feature
- Tests are now grouped by their feature tag in the left sidebar
- Groups are collapsible/expandable with visual indicators (caret icons)
- Groups display test counts and preserve the order features first appear
- The group containing the initially selected test auto-expands
- Clicking a test automatically expands its containing group

### Details Pane Improvements
- Split the details section into two resizable panes:
  - **Screenshot pane** (top, resizable): displays step screenshots with fallback message
  - **DOM pane** (bottom): shows failure stack traces and DOM snapshots
- Added a draggable divider between panes to adjust heights (80px-2000px range)
- Improved visual feedback during resizing with cursor changes and selection prevention
- Better empty state messages when screenshots or DOM snapshots are unavailable

### Data Serialization
- Updated `DemoReportRenderer` to embed per-test feature information in the trace data
- Feature field is omitted from JSON when not present (null values)
- Added comprehensive tests verifying feature embedding and grouping behavior

### UI Tests
- Added `@Feature` annotation imports to all UI test classes for future feature tagging

## Implementation Details
- Feature grouping uses a two-pass approach: first collecting unique features while preserving order, then rendering grouped test items
- Resizer uses standard mouse event handlers (mousedown/mousemove/mouseup) with document-level listeners for smooth dragging
- Collapsed state is maintained in-memory only (not persisted)
- Layout uses CSS flexbox for proper pane sizing and overflow handling

https://claude.ai/code/session_015Eu6NpXamiF5tW9ZkfxRLn