### PR TITLE
Refactor report uploads to use composite action with retry logic

### DIFF
--- a/.github/actions/upload-report/action.yml
+++ b/.github/actions/upload-report/action.yml
@@ -1,0 +1,156 @@
+name: Upload Report to Dashboard
+description: >
+  Upload a test report zip bundle to the report dashboard with health-check
+  polling, exponential backoff, and a configurable retry budget.  Forces IPv4
+  to work around IPv6 black-holing on some GitHub Actions runners.
+
+inputs:
+  file:
+    description: Path to the zip file to upload
+    required: true
+  suite:
+    description: Suite slug (e.g. unit-tests, ui-tests, claude-summary)
+    required: true
+  token:
+    description: Bearer token for the dashboard API
+    required: true
+  status:
+    description: Test outcome — "passed" or "failed"
+    required: true
+  max-wait:
+    description: Total retry budget in seconds
+    required: false
+    default: '300'
+  dashboard-url:
+    description: Dashboard base URL
+    required: false
+    default: 'https://reports.artemon.cloud'
+
+outputs:
+  success:
+    description: '"true" if the upload succeeded, "false" otherwise'
+    value: ${{ steps.upload.outputs.success }}
+  http-code:
+    description: HTTP status code from the last upload attempt
+    value: ${{ steps.upload.outputs.http-code }}
+  attempts:
+    description: Number of upload attempts made
+    value: ${{ steps.upload.outputs.attempts }}
+
+runs:
+  using: composite
+  steps:
+    - name: Upload report with retry
+      id: upload
+      shell: bash
+      env:
+        INPUT_FILE: ${{ inputs.file }}
+        INPUT_SUITE: ${{ inputs.suite }}
+        INPUT_TOKEN: ${{ inputs.token }}
+        INPUT_STATUS: ${{ inputs.status }}
+        INPUT_MAX_WAIT: ${{ inputs.max-wait }}
+        INPUT_DASHBOARD_URL: ${{ inputs.dashboard-url }}
+        INPUT_RUN_ID: ${{ github.run_id }}
+        INPUT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        INPUT_GIT_REF: ${{ github.ref_name }}
+        INPUT_GIT_SHA: ${{ github.sha }}
+      run: |
+        set -uo pipefail
+
+        FILE="${INPUT_FILE}"
+        SUITE="${INPUT_SUITE}"
+        TOKEN="${INPUT_TOKEN}"
+        STATUS="${INPUT_STATUS}"
+        MAX_WAIT="${INPUT_MAX_WAIT}"
+        DASHBOARD_URL="${INPUT_DASHBOARD_URL}"
+        RUN_ID="${INPUT_RUN_ID}"
+        RUN_URL="${INPUT_RUN_URL}"
+        GIT_REF="${INPUT_GIT_REF}"
+        GIT_SHA="${INPUT_GIT_SHA}"
+
+        HEALTH_URL="${DASHBOARD_URL}/health"
+        UPLOAD_URL="${DASHBOARD_URL}/api/v1/upload?suite=${SUITE}&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}&status=${STATUS}"
+
+        # ── Pre-flight ──────────────────────────────────────────────
+        if [ ! -f "$FILE" ]; then
+          echo "::error::Upload file not found: ${FILE}"
+          echo "success=false" >> "$GITHUB_OUTPUT"
+          echo "http-code=0"   >> "$GITHUB_OUTPUT"
+          echo "attempts=0"    >> "$GITHUB_OUTPUT"
+          exit 1
+        fi
+
+        attempt=0
+        start_time=$(date +%s)
+        last_http_code=0
+
+        # ── Main retry loop ─────────────────────────────────────────
+        while true; do
+          now=$(date +%s)
+          elapsed=$((now - start_time))
+          remaining=$((MAX_WAIT - elapsed))
+
+          if [ "$remaining" -le 0 ]; then
+            echo "::error::Upload retry budget exhausted after ${elapsed}s and ${attempt} attempt(s) (suite=${SUITE})"
+            echo "success=false"            >> "$GITHUB_OUTPUT"
+            echo "http-code=${last_http_code}" >> "$GITHUB_OUTPUT"
+            echo "attempts=${attempt}"      >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # Phase 1 — wait for server to be reachable (health-check loop)
+          health_backoff=5
+          while true; do
+            now=$(date +%s)
+            elapsed=$((now - start_time))
+            if [ $((MAX_WAIT - elapsed)) -le 0 ]; then break 2; fi
+
+            health_code=$(curl -4 -sS -o /dev/null -w '%{http_code}' \
+              --connect-timeout 10 --max-time 15 \
+              "${HEALTH_URL}" 2>/dev/null || echo "000")
+
+            if [ "$health_code" = "200" ]; then
+              break
+            fi
+
+            echo "::warning::Dashboard health check returned ${health_code} (elapsed ${elapsed}s, suite=${SUITE}) — retrying in ${health_backoff}s"
+            sleep "$health_backoff"
+            health_backoff=$((health_backoff * 2))
+            [ "$health_backoff" -gt 60 ] && health_backoff=60
+          done
+
+          # Phase 2 — upload
+          attempt=$((attempt + 1))
+          echo "Uploading ${FILE} to suite '${SUITE}' (attempt ${attempt}, elapsed ${elapsed}s)..."
+
+          last_http_code=$(curl -4 -sS -o /tmp/rd-upload-response.txt -w '%{http_code}' \
+            -X POST \
+            --connect-timeout 15 --max-time 120 \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -F "report=@${FILE}" \
+            "${UPLOAD_URL}" 2>/dev/null || echo "000")
+
+          if [ "$last_http_code" = "200" ] || [ "$last_http_code" = "201" ]; then
+            echo "Upload succeeded (HTTP ${last_http_code}) on attempt ${attempt}"
+            cat /tmp/rd-upload-response.txt 2>/dev/null || true
+            echo "success=true"                >> "$GITHUB_OUTPUT"
+            echo "http-code=${last_http_code}" >> "$GITHUB_OUTPUT"
+            echo "attempts=${attempt}"         >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::warning::Upload attempt ${attempt} failed (HTTP ${last_http_code}, elapsed ${elapsed}s, suite=${SUITE})"
+          cat /tmp/rd-upload-response.txt 2>/dev/null || true
+
+          upload_backoff=$((10 * attempt))
+          [ "$upload_backoff" -gt 60 ] && upload_backoff=60
+          sleep "$upload_backoff"
+        done
+
+        # Budget exhausted (break 2 from inner loop)
+        elapsed=$(($(date +%s) - start_time))
+        echo "::error::Upload retry budget exhausted after ${elapsed}s and ${attempt} attempt(s) (suite=${SUITE})"
+        echo "success=false"            >> "$GITHUB_OUTPUT"
+        echo "http-code=${last_http_code}" >> "$GITHUB_OUTPUT"
+        echo "attempts=${attempt}"      >> "$GITHUB_OUTPUT"
+        exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,23 +44,19 @@ jobs:
           name: unit-test-raw
           path: build/test-results/test/
 
+      - name: Zip unit test report
+        if: success() || failure()
+        run: cd build/reports/tests/test && zip -r ../../../../unit-test-report.zip . && cd ../../../..
+
       - name: Upload test report to dashboard
         if: success() || failure()
-        run: |
-          cd build/reports/tests/test && zip -r ../../../../unit-test-report.zip . && cd ../../../..
-          curl -X POST \
-            --connect-timeout 10 --max-time 120 \
-            --retry 3 --retry-connrefused --retry-delay 2 \
-            -H "Authorization: Bearer ${{ secrets.RD_TOKEN }}" \
-            -F "report=@unit-test-report.zip" \
-            "https://reports.artemon.cloud/api/v1/upload?\
-          suite=unit-tests&\
-          run_id=${{ github.run_id }}&\
-          run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
-          job_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
-          git_ref=${{ github.ref_name }}&\
-          git_sha=${{ github.sha }}&\
-          status=${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
+        continue-on-error: true
+        uses: ./.github/actions/upload-report
+        with:
+          file: unit-test-report.zip
+          suite: unit-tests
+          token: ${{ secrets.RD_TOKEN }}
+          status: ${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}
 
   ui-tests:
     name: UI E2E Tests
@@ -162,32 +158,23 @@ jobs:
             build/test-results/uiTest/
             build/reports/uiTest/traces/
 
+      - name: Zip UI test report
+        if: success() || failure()
+        run: cd build/reports/tests/uiTest && zip -r ../../../../ui-test-report.zip . && cd ../../../..
+
       - name: Upload UI test report to dashboard
         if: success() || failure()
-        run: |
-          cd build/reports/tests/uiTest && zip -r ../../../../ui-test-report.zip . && cd ../../../..
-          curl -X POST \
-            --connect-timeout 10 --max-time 120 \
-            --retry 3 --retry-connrefused --retry-delay 2 \
-            -H "Authorization: Bearer ${{ secrets.RD_TOKEN }}" \
-            -F "report=@ui-test-report.zip" \
-            "https://reports.artemon.cloud/api/v1/upload?\
-          suite=ui-tests&\
-          run_id=${{ github.run_id }}&\
-          run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
-          job_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
-          git_ref=${{ github.ref_name }}&\
-          git_sha=${{ github.sha }}&\
-          status=${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
+        continue-on-error: true
+        uses: ./.github/actions/upload-report
+        with:
+          file: ui-test-report.zip
+          suite: ui-tests
+          token: ${{ secrets.RD_TOKEN }}
+          status: ${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}
 
-      - name: Upload UI trace bundles to dashboard
+      - name: Prepare UI trace bundle
+        id: trace-bundle
         if: success() || failure()
-        env:
-          RD_TOKEN: ${{ secrets.RD_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GIT_REF: ${{ github.ref_name }}
-          GIT_SHA: ${{ github.sha }}
         run: |
           # `finalizedBy("generateTraceIndex")` already wrote the index on the
           # Gradle side; make doubly sure it exists before zipping so the
@@ -195,16 +182,21 @@ jobs:
           ./gradlew generateTraceIndex --quiet || true
           if [ ! -d build/reports/uiTest/traces ] || [ -z "$(ls -A build/reports/uiTest/traces 2>/dev/null)" ]; then
             echo "No trace bundles produced — skipping ui-test-traces upload."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           (cd build/reports/uiTest/traces && zip -r ../../../../ui-test-traces.zip .)
-          STATUS="${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
-          URL="https://reports.artemon.cloud/api/v1/upload?suite=ui-test-traces&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}&status=${STATUS}"
-          curl -X POST \
-            --connect-timeout 10 --max-time 120 \
-            --retry 3 --retry-connrefused --retry-delay 2 \
-            -H "Authorization: Bearer ${RD_TOKEN}" \
-            -F "report=@ui-test-traces.zip" "$URL"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Upload UI trace bundles to dashboard
+        if: (success() || failure()) && steps.trace-bundle.outputs.skip != 'true'
+        continue-on-error: true
+        uses: ./.github/actions/upload-report
+        with:
+          file: ui-test-traces.zip
+          suite: ui-test-traces
+          token: ${{ secrets.RD_TOKEN }}
+          status: ${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}
 
   playwright-tests:
     name: Playwright Snapshot Saver Tests
@@ -252,23 +244,19 @@ jobs:
           name: playwright-test-raw
           path: packages/playwright-snapshot-saver/test-results/
 
+      - name: Zip Playwright report
+        if: success() || failure()
+        run: cd packages/playwright-snapshot-saver/playwright-report && zip -r ../../../playwright-report.zip . && cd ../../..
+
       - name: Upload Playwright report to dashboard
         if: success() || failure()
-        run: |
-          cd packages/playwright-snapshot-saver/playwright-report && zip -r ../../../playwright-report.zip . && cd ../../..
-          curl -X POST \
-            --connect-timeout 10 --max-time 120 \
-            --retry 3 --retry-connrefused --retry-delay 2 \
-            -H "Authorization: Bearer ${{ secrets.RD_TOKEN }}" \
-            -F "report=@playwright-report.zip" \
-            "https://reports.artemon.cloud/api/v1/upload?\
-          suite=playwright-tests&\
-          run_id=${{ github.run_id }}&\
-          run_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
-          job_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}&\
-          git_ref=${{ github.ref_name }}&\
-          git_sha=${{ github.sha }}&\
-          status=${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}"
+        continue-on-error: true
+        uses: ./.github/actions/upload-report
+        with:
+          file: playwright-report.zip
+          suite: playwright-tests
+          token: ${{ secrets.RD_TOKEN }}
+          status: ${{ steps.tests.outcome == 'success' && 'passed' || 'failed' }}
 
   # ── Task 14: Claude Inner Loop ──────────────────────────────────────────
   #
@@ -342,21 +330,11 @@ jobs:
             build/reports/claude-summary.md
             build/reports/uiTest/traces/
 
-      # ── MAIN STEP: enables the remote Claude inner loop. ──
-      # Intentionally NO `continue-on-error` and an explicit HTTP-code
-      # check: a non-2xx response turns this job red even when every test
-      # passed. A green test-report job without a dashboard artifact
-      # means remote Claude sessions cannot read CI results, which is the
-      # whole point of the loop. Removing or disabling this step is a
-      # CLAUDE.md redline (see "Test Loop" → Redlines).
-      - name: Upload claude-summary bundle to reports.artemon.cloud
+      # Prepare the claude-summary bundle for upload. Fails fast if the
+      # aggregator did not produce the expected JSON.
+      - name: Prepare claude-summary bundle
+        id: prepare-summary
         if: always()
-        env:
-          RD_TOKEN: ${{ secrets.RD_TOKEN }}
-          RUN_ID: ${{ github.run_id }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          GIT_REF: ${{ github.ref_name }}
-          GIT_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           if [ ! -f build/reports/claude-summary.json ]; then
@@ -369,19 +347,25 @@ jobs:
             cp -r build/reports/uiTest/traces claude-summary-bundle/traces
           fi
           (cd claude-summary-bundle && zip -r ../claude-summary-bundle.zip .)
-          STATUS="${{ steps.aggregate.outcome == 'success' && 'passed' || 'failed' }}"
-          URL="https://reports.artemon.cloud/api/v1/upload?suite=claude-summary&run_id=${RUN_ID}&run_url=${RUN_URL}&job_url=${RUN_URL}&git_ref=${GIT_REF}&git_sha=${GIT_SHA}&status=${STATUS}"
-          HTTP_CODE=$(curl -sS -o /tmp/rd-response.txt -w '%{http_code}' -X POST \
-            --connect-timeout 10 --max-time 120 \
-            --retry 3 --retry-connrefused --retry-delay 2 \
-            -H "Authorization: Bearer ${RD_TOKEN}" \
-            -F "report=@claude-summary-bundle.zip" "$URL")
-          echo "Dashboard response: $HTTP_CODE"
-          cat /tmp/rd-response.txt || true
-          if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "201" ]; then
-            echo "::error::claude-summary dashboard upload failed (HTTP $HTTP_CODE) — the remote Claude loop is broken"
-            exit 1
-          fi
+
+      # ── MAIN STEP: enables the remote Claude inner loop. ──
+      # Intentionally NO `continue-on-error`: a failed upload turns this
+      # job red even when every test passed.  A green test-report job
+      # without a dashboard artifact means remote Claude sessions cannot
+      # read CI results, which is the whole point of the loop.  Removing
+      # or disabling this step is a CLAUDE.md redline (see "Test Loop"
+      # → Redlines).
+      #
+      # The composite action retries with health-check polling and a
+      # 5-minute budget to ride through transient network issues.
+      - name: Upload claude-summary bundle to reports.artemon.cloud
+        if: always() && steps.prepare-summary.outcome == 'success'
+        uses: ./.github/actions/upload-report
+        with:
+          file: claude-summary-bundle.zip
+          suite: claude-summary
+          token: ${{ secrets.RD_TOKEN }}
+          status: ${{ steps.aggregate.outcome == 'success' && 'passed' || 'failed' }}
 
       # Best-effort housekeeping — a failed finalize is a warning, not a
       # build failure, because the dashboard tolerates re-finalizes.
@@ -391,9 +375,9 @@ jobs:
           RD_TOKEN: ${{ secrets.RD_TOKEN }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          curl -sS -X POST \
+          curl -4 -sS -X POST \
             --connect-timeout 10 --max-time 30 \
-            --retry 3 --retry-connrefused --retry-delay 2 \
+            --retry 5 --retry-connrefused --retry-delay 5 \
             -H "Authorization: Bearer ${RD_TOKEN}" \
             "https://reports.artemon.cloud/api/v1/executions/${RUN_ID}/finalize" \
             || echo "::warning::finalize call failed — non-fatal"


### PR DESCRIPTION
## Summary
Extracted repetitive report upload logic from CI workflows into a reusable composite GitHub Action with robust retry handling, health-check polling, and exponential backoff. This improves maintainability, consistency, and reliability of dashboard uploads across all test suites.

## Key Changes

- **New composite action** (`.github/actions/upload-report/action.yml`):
  - Accepts file path, suite name, token, and status as inputs
  - Implements two-phase retry strategy: health-check polling followed by upload attempts
  - Uses exponential backoff (capped at 60s) with configurable 5-minute total budget
  - Forces IPv4 (`curl -4`) to work around IPv6 black-holing on some GitHub Actions runners
  - Returns success status, HTTP code, and attempt count as outputs

- **Refactored CI workflow** (`.github/workflows/ci.yml`):
  - Unit tests: Separated zip creation from upload, replaced inline curl with composite action
  - UI tests: Same pattern as unit tests; trace bundle upload now conditional on preparation step success
  - Playwright tests: Extracted zip and upload steps, uses composite action
  - Claude summary: Split preparation (validation) from upload; upload step now depends on preparation success and has no `continue-on-error` to maintain redline requirement for remote Claude loop
  - Finalize step: Added `-4` flag to curl for IPv4 consistency, increased retry count from 3 to 5 with longer delays

## Notable Implementation Details

- **Health-check polling**: Dashboard must return HTTP 200 before upload is attempted, with backoff starting at 5s
- **Upload retry**: Linear backoff (10s × attempt count, capped at 60s) after failed uploads
- **Budget enforcement**: Total 5-minute window across all phases; exits with error if exhausted
- **Conditional uploads**: UI trace bundle and claude-summary uploads now explicitly depend on preparation steps succeeding
- **No silent failures**: claude-summary upload has no `continue-on-error`, ensuring CI fails if the remote Claude loop cannot access results (per CLAUDE.md redlines)

https://claude.ai/code/session_01JNxRavn7xeTngQ7kRQF3cG