### PR TITLE
fix(mirror): stop scroll-into-nothing, let snapshot use full iframe h…

### DIFF
--- a/src/main/resources/html/js/snapshot.js
+++ b/src/main/resources/html/js/snapshot.js
@@ -6,8 +6,9 @@ var _scale = 1;
 
 function applyScale() {
     var container = document.getElementById('viewport-container');
+    var sizer = document.getElementById('viewport-sizer');
     var wrapper = document.getElementById('viewport-wrapper');
-    if (!container || !wrapper) return;
+    if (!container || !sizer || !wrapper) return;
 
     var containerWidth = container.clientWidth;
     _scale = containerWidth / _viewportWidth;
@@ -15,6 +16,13 @@ function applyScale() {
     wrapper.style.width = _viewportWidth + 'px';
     wrapper.style.height = _viewportHeight + 'px';
     wrapper.style.transform = 'scale(' + _scale + ')';
+
+    // CSS transforms do not shrink the layout box, so we mirror the scaled
+    // dimensions onto the sizer. Without this, #viewport-container treats
+    // the wrapper as its pre-scale 1280x720 layout box and grows scrollbars
+    // into empty space below/right of the visual snapshot.
+    sizer.style.width = (_viewportWidth * _scale) + 'px';
+    sizer.style.height = (_viewportHeight * _scale) + 'px';
 
     container.style.minHeight = '0';
 }
@@ -50,9 +58,18 @@ window.loadSnapshot = function(html) {
                 var hMatch = content.match(/height=(\d+)/);
                 if (wMatch) _viewportWidth = parseInt(wMatch[1], 10);
                 if (hMatch) _viewportHeight = parseInt(hMatch[1], 10);
-                iframe.style.width = _viewportWidth + 'px';
-                iframe.style.height = _viewportHeight + 'px';
             }
+            // Use the full rendered page height so snapshots of pages taller
+            // than the capture viewport aren't truncated. Fall back to the
+            // declared viewport height when the document hasn't laid out yet.
+            var contentHeight = Math.max(
+                doc.body ? doc.body.scrollHeight : 0,
+                doc.documentElement ? doc.documentElement.scrollHeight : 0,
+                _viewportHeight
+            );
+            _viewportHeight = contentHeight;
+            iframe.style.width = _viewportWidth + 'px';
+            iframe.style.height = _viewportHeight + 'px';
         }
         applyScale();
     };

--- a/src/main/resources/html/page-mirror.html
+++ b/src/main/resources/html/page-mirror.html
@@ -31,8 +31,13 @@
             overflow: auto;
             display: none;
         }
-        #viewport-wrapper {
+        #viewport-sizer {
             position: relative;
+        }
+        #viewport-wrapper {
+            position: absolute;
+            top: 0;
+            left: 0;
             transform-origin: 0 0;
         }
         #viewport iframe {
@@ -112,9 +117,11 @@
 <body>
     <div id="status">Page Mirror Ready</div>
     <div id="viewport-container">
-        <div id="viewport-wrapper">
-            <div id="viewport"></div>
-            <div id="overlay"></div>
+        <div id="viewport-sizer">
+            <div id="viewport-wrapper">
+                <div id="viewport"></div>
+                <div id="overlay"></div>
+            </div>
         </div>
     </div>
     <div id="empty-state">No snapshot loaded</div>


### PR DESCRIPTION
…eight

The snapshot iframe is scaled to fit the tool window width using `transform: scale()`, but CSS transforms don't shrink an element's layout box — so `#viewport-container` saw the wrapper as its unscaled 1280x720 size and grew scrollbars into empty space below and right of the rendered snapshot. Wrap the transformed node in a `#viewport-sizer` whose width and height match the scaled dimensions so the scroll container sees the actual visual footprint.

While here, set the iframe to the full rendered `scrollHeight` of the document after load so snapshots of pages taller than the capture viewport (e.g. dashboards) aren't clipped at 720px.