### PR TITLE
build: make @pagemirror/snapshot-core publishable, switch consumers t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ node_modules/
 /packages/playwright-snapshot-saver/test-results/
 /.claude/settings.local.json
 .env.claude
+/.intellijPlatform/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,45 @@
 
 ### Removed
 
+## [0.5.0] - 2026-04-16
+
+### ⚠️ Breaking changes
+
+- Snapshot bundle format bumped to **v2**. The plugin now refuses to
+  load bundles whose `manifest.json` declares a version other than `2`.
+  If you see a warning banner inside the Page Mirror tool window after
+  upgrading, regenerate your snapshots with
+  [`playwright-snapshot-saver`](https://www.npmjs.com/package/playwright-snapshot-saver)
+  `≥ 0.7.0` — run `npx playwright test` in your project and the v2
+  bundles will replace the v1 ones. See
+  [docs/migration-v1-to-v2.md](docs/migration-v1-to-v2.md) for the full
+  migration guide.
+
+### Added
+
+- Outdated-bundle banner in the Page Mirror tool window. When the
+  snapshot scanner finds bundle directories whose manifest version is
+  unsupported, the tool window renders an actionable banner above the
+  snapshot iframe with a link to the migration guide. The banner
+  disappears automatically after you regenerate the bundles.
+- Strict v2 snapshot bundle support. The plugin reads CSS sidecars from
+  `resources/<sha1>.css` and inlines them into the HTML before handing
+  it to the JCEF `srcdoc` iframe, so `resources/` references resolve
+  correctly without a base URL.
+- Screenshots are now read from `resources/screenshot.png` or
+  `resources/screenshot.webp` (was top-level in v1).
+
+### Fixed
+
+- Snapshots no longer scroll into empty space below and right of the
+  rendered page when the iframe is scaled to fit the tool window width.
+- Snapshots taller than the capture viewport (e.g. dashboards) are no
+  longer clipped at 720 px — the iframe grows to the document's full
+  rendered height.
+- Switching focus to an already-open editor tab now reloads the matching
+  snapshot. Previously the tool window stayed on whichever snapshot was
+  loaded when the tab was first opened.
+
 ## [0.4.0] - 2026-04-07
 
 ### Changed
@@ -21,6 +60,7 @@
 
 - Previous release.
 
-[Unreleased]: https://github.com/AnewTranduil/PageObjectPlugin/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/AnewTranduil/PageObjectPlugin/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/AnewTranduil/PageObjectPlugin/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/AnewTranduil/PageObjectPlugin/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/AnewTranduil/PageObjectPlugin/commits/v0.3.0

--- a/README.md
+++ b/README.md
@@ -22,15 +22,33 @@ Install the companion npm package in your Playwright project:
 npm install -D playwright-snapshot-saver
 ```
 
-Add a snapshot capture call to your test or global setup:
+The recommended workflow is the marker + reporter. Enable tracing and register the reporter in `playwright.config.ts`:
 
 ```typescript
-import { saveSnapshot } from 'playwright-snapshot-saver';
+import { defineConfig } from '@playwright/test';
 
-await saveSnapshot(page, 'login-page');
+export default defineConfig({
+  use: { trace: 'on' },
+  reporter: [
+    ['html'],
+    ['playwright-snapshot-saver/reporter', { outputDir: '.snapshots' }],
+  ],
+});
 ```
 
-Run your Playwright tests — snapshots are saved to the `.snapshots/` directory.
+Then mark snapshot points inside your tests:
+
+```typescript
+import { test } from '@playwright/test';
+import { snapshot } from 'playwright-snapshot-saver';
+
+test('login page', async ({ page }) => {
+  await page.goto('/login');
+  await snapshot({ page: 'login', state: 'initial' });
+});
+```
+
+Run your Playwright tests — snapshots are extracted from traces into `.snapshots/<page>/<state>/` after the run finishes. See the [package README](packages/playwright-snapshot-saver/README.md) for the direct `saveSnapshot()` API and trace-extraction CLI.
 
 ### 2. Use in the IDE
 
@@ -47,16 +65,18 @@ Open your project in IntelliJ IDEA or WebStorm. The **Page Mirror** tool window 
 
 ## Snapshot Saver (npm package)
 
-The [`playwright-snapshot-saver`](packages/playwright-snapshot-saver/) package captures sanitized HTML snapshots from Playwright pages. It can be used as a programmatic API or as a Playwright reporter.
+The [`playwright-snapshot-saver`](packages/playwright-snapshot-saver/) package captures sanitized HTML snapshots from Playwright pages in the v2 bundle format the plugin consumes. It exposes a Playwright reporter, a direct `saveSnapshot()` API, and an `extract` CLI that pulls snapshots from existing Playwright HTML reports or trace ZIPs.
 
 Key options:
 - `group` — organize snapshots into subdirectories
-- `screenshotFormat` — `png`, `jpeg`, or `webp`
-- `manifest` — include metadata (URL, viewport, timestamp)
+- `screenshot` — `{ format: 'png' | 'webp', fullPage: boolean }` or `false` to disable
+- `manifest` — include metadata (URL, viewport, timestamp, driver version)
 - `extraSelectors` / `excludeSelectors` — control which elements are captured
 - `extraAttributes` — preserve additional HTML attributes in the snapshot
 
-See the [package directory](packages/playwright-snapshot-saver/) for full API documentation.
+The saver is a thin adapter on top of [`@pagemirror/snapshot-core`](packages/snapshot-core/), the framework-agnostic engine that owns HTML assembly, manifest building, and trace rendering. Selenium / Cypress / Appium adapters on the roadmap will reuse it.
+
+See the [saver README](packages/playwright-snapshot-saver/README.md) and [snapshot-core README](packages/snapshot-core/README.md) for full API documentation.
 
 ## Compatibility
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,143 @@
+# Release Runbook
+
+Step-by-step procedure for publishing a new version of the Page Mirror
+plugin and its two npm packages. No CI automation yet — every command
+in this runbook runs on the maintainer's local machine.
+
+The repo produces **three independently versioned artifacts**:
+
+| Artifact | Tag format | Publish target |
+|---|---|---|
+| IntelliJ plugin | `v<version>` (e.g. `v0.5.0`) | JetBrains Marketplace (manual upload) + GitHub Release |
+| `@pagemirror/snapshot-core` (npm) | `@pagemirror/snapshot-core@<version>` | npmjs.com |
+| `playwright-snapshot-saver` (npm) | `playwright-snapshot-saver@<version>` | npmjs.com |
+
+Run the releases in that order — the saver depends on snapshot-core, so
+bumping the saver first leaves users in a broken state until snapshot-core
+is available.
+
+## Preconditions
+
+- You are on `main` with no uncommitted changes.
+- `CHANGELOG.md` (plugin) and `packages/*/CHANGELOG.md` have the new
+  version section at the top, with `### ⚠️ Breaking changes` at the
+  top of each new section if applicable.
+- All `version` fields in `gradle.properties` / `package.json` match
+  the tag you're about to push.
+- The CI `test-report` job is green on `main`.
+
+## Plugin release
+
+1. **Build the plugin locally** (sanity check):
+
+   ```bash
+   ./gradlew buildPlugin
+   ```
+
+   Output: `build/distributions/PageObjectHelper-<version>.zip`.
+
+2. **Patch & verify change-notes** render:
+
+   ```bash
+   ./gradlew patchPluginXml
+   cat build/patchedPluginXmlFiles/plugin.xml | grep -A 40 '<change-notes>'
+   ```
+
+   The breaking-change callout from `CHANGELOG.md` should appear as
+   rendered HTML.
+
+3. **Tag + push**:
+
+   ```bash
+   git tag -a "v<version>" -m "Page Object Helper <version>"
+   git push origin "v<version>"
+   ```
+
+4. **Create the GitHub Release** with the CHANGELOG section as the
+   body and the plugin zip attached:
+
+   ```bash
+   gh release create "v<version>" \
+     build/distributions/PageObjectHelper-<version>.zip \
+     --title "v<version>" \
+     --notes-from-tag
+   ```
+
+5. **Upload to JetBrains Marketplace** (manual). Log in at
+   <https://plugins.jetbrains.com/plugin/edit/com.github.artem.pageobjectplugin>,
+   click **Upload update**, select the zip from step 1, paste the
+   CHANGELOG section into "What's new" (or leave blank — the
+   `<change-notes>` inside `plugin.xml` is the source of truth).
+
+6. **Verify** via a fresh IDE: *Settings → Plugins → Installed → Page
+   Object Helper → Update*. The breaking-change callout should appear
+   in the update dialog.
+
+## npm releases
+
+Requires `NPM_TOKEN` or an active `npm login` session with publish
+rights on the `@pagemirror` scope and on `playwright-snapshot-saver`.
+
+1. **Publish `@pagemirror/snapshot-core` first**:
+
+   ```bash
+   cd packages/snapshot-core
+   npm pack --dry-run                        # sanity: README.md must appear
+   npm publish                               # publishConfig.access: public already set
+   cd ../..
+   git tag -a "@pagemirror/snapshot-core@<version>" -m "snapshot-core <version>"
+   git push origin "@pagemirror/snapshot-core@<version>"
+   ```
+
+2. **Publish `playwright-snapshot-saver` next**:
+
+   ```bash
+   cd packages/playwright-snapshot-saver
+   npm pack --dry-run                        # sanity: README.md must appear
+   npm publish
+   cd ../..
+   git tag -a "playwright-snapshot-saver@<version>" -m "playwright-snapshot-saver <version>"
+   git push origin "playwright-snapshot-saver@<version>"
+   ```
+
+3. **Deprecate old versions that predate the current breaking
+   change**. Run this once after the publish that introduces the
+   break; it adds an install-time warning to every affected version
+   range.
+
+   ```bash
+   # Saver: v2 bundles are required by Page Mirror plugin 0.5+
+   npm deprecate "playwright-snapshot-saver@<0.7" \
+     "v1 bundles are no longer supported by Page Mirror plugin 0.5+. Upgrade to ^0.7 and regenerate your .snapshots/."
+
+   # snapshot-core: no historical range to deprecate today, but
+   # scaffold the command here so the next breaking bump is trivial.
+   # npm deprecate "@pagemirror/snapshot-core@<0.2" \
+   #   "Old snapshot-core output incompatible with Page Mirror plugin X.Y+. Upgrade to ^0.2."
+   ```
+
+   Deprecation is reversible: `npm deprecate "<pkg>@<range>" ""` clears
+   the warning if you need to roll back.
+
+## After the release
+
+- Confirm `npm view playwright-snapshot-saver dist-tags` shows the new
+  `latest`.
+- Confirm the JetBrains Marketplace listing shows the new version as
+  "current".
+- Open a PR bumping `[Unreleased]` in the plugin CHANGELOG to signal
+  the release cycle is complete.
+
+## Rolling back
+
+- **Plugin**: archive the Marketplace listing for the bad version
+  (**Edit plugin → Versions → … → Unapprove**) and push a patch
+  version with the fix. Previously-installed users get the rollback
+  automatically on next IDE update.
+- **npm**: you cannot `npm unpublish` after 72 hours or while other
+  packages depend on the version. Always prefer `npm deprecate` with
+  a clear message pointing at the fixed version.
+- **Tags**: `git tag -d <tag>` then
+  `git push origin :refs/tags/<tag>`. Avoid deleting tags that other
+  clones have already fetched — prefer to move forward with a new
+  version.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Plugin Configuration
 pluginGroup = com.github.artem.pageobjectplugin
 pluginName = PageObjectHelper
-pluginVersion = 0.4.0
+pluginVersion = 0.5.0
 
 # IntelliJ Platform
 platformType = IC

--- a/package-lock.json
+++ b/package-lock.json
@@ -2437,7 +2437,7 @@
       "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
-        "@pagemirror/snapshot-core": "file:../snapshot-core",
+        "@pagemirror/snapshot-core": "^0.1.0",
         "playwright-core": "1.58.2"
       },
       "bin": {
@@ -2472,7 +2472,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "devDependencies": {
-        "@pagemirror/snapshot-core": "file:../snapshot-core",
+        "@pagemirror/snapshot-core": "^0.1.0",
         "@playwright/test": "1.59.0",
         "@types/node": "^24.12.0",
         "playwright-snapshot-saver": "file:../playwright-snapshot-saver",

--- a/packages/playwright-snapshot-saver/CHANGELOG.md
+++ b/packages/playwright-snapshot-saver/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.7.0
+
+### ⚠️ Breaking changes
+
+- Bundles now emit the **v2 layout**: `resources/` directory,
+  `<sha1>.css` stylesheet sidecars referenced by `<link>` tags, and
+  `manifest.json` with `"version": 2`. Older versions of the Page
+  Mirror IntelliJ plugin (< 0.5.0) do **not** load v2 bundles — they'll
+  silently skip them. Upgrade both halves of the stack together, or
+  pin `playwright-snapshot-saver@^0.6` until you're ready to upgrade
+  the plugin. See
+  [`docs/migration-v1-to-v2.md`](https://github.com/AnewTranduil/PageObjectPlugin/blob/main/docs/migration-v1-to-v2.md)
+  for the migration guide.
+- `manifest.json` `version` is now a **fixed schema version** (`2`),
+  not an incrementing write counter. Tools that previously read
+  `version` to detect bundle updates should key off `timestamp` instead.
+- `screenshot.<ext>` moved from the bundle root to
+  `resources/screenshot.<ext>`.
+- CSS is no longer inlined as `<style>` inside `index.html`. The plugin
+  inlines sidecars on read since `<iframe srcdoc>` cannot resolve
+  relative URLs.
+
+### Added
+
+- `@pagemirror/snapshot-core` extracted as the framework-agnostic shared
+  engine; this package is now a thin Playwright adapter on top of it.
+  Selenium / Cypress / Appium adapters are on the roadmap and will reuse
+  the same on-disk format.
+- Trace-extracted bundles are fully self-contained — every `<link>`,
+  `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference
+  points at a real file under `resources/`, and the original `<base>`
+  element is stripped.
+
 ## 0.6.0
 
 ### Breaking Changes

--- a/packages/playwright-snapshot-saver/README.md
+++ b/packages/playwright-snapshot-saver/README.md
@@ -1,6 +1,8 @@
 # playwright-snapshot-saver
 
-Capture Playwright page snapshots (HTML with inlined CSS, screenshots, metadata) for the [Page Mirror](https://github.com/AnewTranduil/PageObjectPlugin) IntelliJ plugin.
+Capture Playwright page snapshots (sanitized HTML, screenshots, metadata) into the Page Mirror v2 bundle format consumed by the [Page Mirror IntelliJ plugin](https://github.com/AnewTranduil/PageObjectPlugin).
+
+This package is a thin Playwright adapter on top of [`@pagemirror/snapshot-core`](../snapshot-core), which owns the actual HTML assembly, manifest building, and trace rendering. Selenium / Cypress / Appium adapters are planned and will produce the same on-disk format.
 
 ## Installation
 
@@ -10,11 +12,11 @@ npm install playwright-snapshot-saver
 
 ## Usage
 
-There are three ways to capture snapshots, from simplest to most flexible.
+Three ways to capture snapshots, from simplest to most flexible.
 
-### 1. Marker + Reporter (recommended)
+### 1. Marker + reporter (recommended)
 
-Mark snapshot points in your tests with `snapshot()`, then let the reporter extract them automatically from Playwright traces.
+Mark snapshot points in your tests with `snapshot()`, then let the reporter extract them from Playwright traces after the run finishes.
 
 **playwright.config.ts**
 
@@ -23,7 +25,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   use: {
-    trace: 'on', // required for snapshot extraction
+    trace: 'on', // required — the reporter reads trace ZIPs
   },
   reporter: [
     ['html'],
@@ -48,26 +50,28 @@ test('login page', async ({ page }) => {
 });
 ```
 
-After `npx playwright test`, the reporter extracts snapshots into:
+After `npx playwright test`, the reporter extracts:
 
 ```
 .snapshots/
   login/
-    initial/  { index.html, screenshot.webp, manifest.json }
-    error/    { index.html, screenshot.webp, manifest.json }
+    initial/  { index.html, manifest.json, resources/… }
+    error/    { index.html, manifest.json, resources/… }
 ```
 
 #### Reporter options
 
-| Option      | Default        | Description                        |
-|-------------|----------------|------------------------------------|
-| `outputDir` | `'.snapshots'` | Base directory for extracted files  |
-| `screenshot`| `true`         | Extract screencast frame as screenshot |
-| `manifest`  | `true`         | Generate `manifest.json`           |
+| Option       | Default        | Description                                         |
+|--------------|----------------|-----------------------------------------------------|
+| `outputDir`  | `'.snapshots'` | Base directory for extracted bundles                 |
+| `screenshot` | `false`        | Extract a screencast frame as `resources/screenshot.webp`. Off by default since trace screencast frames are low-fidelity and frequently blank. |
+| `manifest`   | `true`         | Generate `manifest.json`                            |
+
+> **Changed in 0.6.0:** screenshot extraction is opt-in. Pass `screenshot: true` to re-enable it.
 
 ### 2. Direct API (`saveSnapshot`)
 
-Call `saveSnapshot()` with a live Playwright `Page` to capture a snapshot immediately during test execution.
+Call `saveSnapshot()` with a live Playwright `Page` to capture a snapshot immediately during test execution. This path uses Playwright's real `page.screenshot()`, so screenshots are always sharp.
 
 ```ts
 import { test } from '@playwright/test';
@@ -79,27 +83,33 @@ test('capture snapshot', async ({ page }) => {
   const result = await saveSnapshot(page, {
     outputDir: '.snapshots',
     name: 'initial',
-    group: 'example',          // optional parent directory
-    screenshot: { format: 'png', fullPage: true },
+    group: 'example',                     // optional parent directory
+    screenshot: { fullPage: true },       // or `false` to skip, or omit for defaults
     manifest: true,
   });
 
-  console.log(result.outputDir);  // .snapshots/example/initial
-  console.log(result.files.html); // .snapshots/example/initial/index.html
+  console.log(result.outputDir);         // .snapshots/example/initial
+  console.log(result.files.html);         // .snapshots/example/initial/index.html
+  console.log(result.files.resources);    // [ …/resources/<sha1>.css, …/resources/screenshot.png ]
 });
 ```
 
 #### `SaveSnapshotOptions`
 
-| Option       | Type     | Default  | Description                              |
-|--------------|----------|----------|------------------------------------------|
-| `outputDir`  | `string` | required | Base output directory                    |
-| `name`       | `string` | required | Snapshot name (becomes subdirectory)     |
-| `group`      | `string` | —        | Parent directory (e.g. page name)        |
-| `screenshot.enabled` | `boolean` | `true` | Capture a screenshot               |
-| `screenshot.format`  | `'png' \| 'jpeg'` | `'png'` | Screenshot format        |
-| `screenshot.fullPage`| `boolean` | `false` | Capture the full scrollable page  |
-| `manifest`   | `boolean`| `true`   | Generate `manifest.json`                 |
+| Option              | Type                                 | Default                              | Description                                            |
+|---------------------|--------------------------------------|--------------------------------------|--------------------------------------------------------|
+| `outputDir`         | `string`                             | required                             | Base output directory                                   |
+| `name`              | `string`                             | required                             | Snapshot name — becomes a subdirectory                  |
+| `group`             | `string`                             | —                                    | Parent directory (e.g. page name)                       |
+| `screenshot`        | `Partial<ScreenshotOptions>` \| `false` | `{ format: 'png', fullPage: false }` | Screenshot options. Pass `false` to disable. |
+| `screenshot.format` | `'png'` \| `'webp'`                  | `'png'`                              | Live-capture supports `png` only; `webp` throws. For webp bytes, use the trace-extraction path. |
+| `screenshot.fullPage` | `boolean`                          | `false`                              | Capture the full scrollable page                        |
+| `manifest`          | `boolean`                            | `true`                               | Generate `manifest.json`                                |
+| `extraSelectors`    | `string[]`                           | —                                    | Extra selectors the collector keeps                     |
+| `excludeSelectors`  | `string[]`                           | —                                    | Selectors the collector drops                           |
+| `extraAttributes`   | `string[]`                           | —                                    | Extra attributes the collector preserves                |
+
+`saveSnapshot()` is **skip-write-if-unchanged**: when the assembled HTML matches the existing `index.html`, nothing is rewritten, but the returned `files` still references the existing paths.
 
 ### 3. Extract from existing traces (CLI or API)
 
@@ -123,19 +133,20 @@ npx playwright-snapshot-saver extract \
   --output .snapshots \
   --page login \
   --state initial \
-  --no-screenshot
+  --screenshot
 ```
 
 #### CLI options
 
-| Option            | Description                                      |
-|-------------------|--------------------------------------------------|
-| `--source <path>` | Report directory, trace ZIP, or URL (required)   |
-| `--output <dir>`  | Output directory (default: `.snapshots`)         |
-| `--page <name>`   | Filter by page name                              |
-| `--state <name>`  | Filter by state name                             |
-| `--no-screenshot` | Skip screenshot extraction                       |
-| `--no-manifest`   | Skip manifest generation                         |
+| Option            | Description                                                 |
+|-------------------|-------------------------------------------------------------|
+| `--source <path>` | Report directory, trace ZIP, or URL (required)              |
+| `--output <dir>`  | Output directory (default: `.snapshots`)                    |
+| `--page <name>`   | Filter by page name                                         |
+| `--state <name>`  | Filter by state name                                        |
+| `--screenshot`    | Opt in to `resources/screenshot.webp` extraction (off by default) |
+| `--no-screenshot` | Explicitly disable (accepted for backwards compatibility)    |
+| `--no-manifest`   | Skip `manifest.json` generation                             |
 
 #### `extractSnapshots` API
 
@@ -145,38 +156,55 @@ import { extractSnapshots } from 'playwright-snapshot-saver';
 const result = await extractSnapshots({
   source: 'playwright-report',  // directory, .zip path, or URL
   outputDir: '.snapshots',
-  screenshot: true,
+  screenshot: true,              // default is false since 0.6.0
   manifest: true,
   filter: { page: 'login' },
 });
 
 for (const snap of result.snapshots) {
   console.log(`${snap.page}/${snap.state} -> ${snap.outputDir}`);
+  console.log(snap.files.html);          // always present
+  console.log(snap.files.manifest);       // when manifest: true
+  console.log(snap.files.screenshot);     // when screenshot: true and a frame was available
 }
 ```
 
-## Snapshot bundle format
+Trace-extracted bundles are **fully self-contained**: every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference in the source page is rewritten to point at a file under `resources/`, and the original `<base>` element is stripped. Open the bundle anywhere — it renders without network access.
+
+## Snapshot bundle format (v2)
 
 Each snapshot is a directory containing:
 
 ```
 <name>/
-  index.html       # DOM with all CSS inlined
-  screenshot.webp   # Visual reference (optional)
-  manifest.json     # Metadata (optional)
+  index.html                   # Sanitized DOM referencing resources/ (REQUIRED)
+  manifest.json                # Metadata, schema version 2 (REQUIRED)
+  resources/
+    screenshot.png|webp        # Visual reference (optional)
+    <sha1>.css                 # Stylesheet sidecars referenced by <link>
+    <sha1>.woff2|png|jpg|…     # Fonts, images, media (trace-extracted bundles)
 ```
+
+`index.html` references every resource via a relative `resources/<filename>` path. The plugin inlines CSS sidecars before passing the HTML to the JCEF `<iframe srcdoc>` because `srcdoc` iframes cannot resolve relative URLs. Producers ship sidecars — **do not pre-inline CSS.**
 
 ### manifest.json
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "userAgent": "Mozilla/5.0 …",
+  "playwright": "1.58.0"
 }
 ```
+
+Exactly one driver field (`playwright` / `selenium` / `cypress` / `appium`) is populated per manifest, matching the driver that produced the bundle. The Playwright version is auto-detected from your installed `@playwright/test`.
+
+The v1 format is **not backwards compatible** — the plugin refuses to load v1 bundles with a user-visible error. Regenerate them by re-running your tests.
+
+See [`docs/snapshot-bundle-spec.md`](../../docs/snapshot-bundle-spec.md) for the authoritative spec.
 
 ## Requirements
 

--- a/packages/playwright-snapshot-saver/package.json
+++ b/packages/playwright-snapshot-saver/package.json
@@ -20,7 +20,7 @@
     "test": "playwright test"
   },
   "dependencies": {
-    "@pagemirror/snapshot-core": "file:../snapshot-core",
+    "@pagemirror/snapshot-core": "^0.1.0",
     "playwright-core": "1.58.2"
   },
   "peerDependencies": {

--- a/packages/playwright-snapshot-saver/package.json
+++ b/packages/playwright-snapshot-saver/package.json
@@ -13,7 +13,10 @@
   },
   "files": [
     "dist/",
-    "bin/"
+    "bin/",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE"
   ],
   "scripts": {
     "build": "tsc",

--- a/packages/playwright-snapshot-saver/package.json
+++ b/packages/playwright-snapshot-saver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-snapshot-saver",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Capture Playwright page snapshots for Page Mirror IntelliJ plugin",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/snapshot-core/README.md
+++ b/packages/snapshot-core/README.md
@@ -1,0 +1,254 @@
+# @pagemirror/snapshot-core
+
+Framework-agnostic core for building [Page Mirror](https://github.com/AnewTranduil/PageObjectPlugin) snapshot bundles. This package contains no driver-specific code — it's the shared engine that Playwright, Selenium, Cypress, and Appium adapters all build on.
+
+If you just want to capture Playwright snapshots, use [`playwright-snapshot-saver`](https://www.npmjs.com/package/playwright-snapshot-saver) instead. Reach for this package when you're:
+
+- Writing a **new driver adapter** for a framework Page Mirror doesn't support yet.
+- Building a **custom reporter** that post-processes captured pages.
+- Consuming raw Playwright trace data and want the rendering pipeline without the Playwright-specific glue.
+
+## Installation
+
+```bash
+npm install @pagemirror/snapshot-core
+```
+
+## What this package provides
+
+A small set of pure functions plus a couple of interfaces. Everything is stateless; you orchestrate.
+
+### Live capture
+
+1. **`collectorSource`** / **`collectPage`** — browser-side collector that serializes `document.documentElement`, pulls in every `<link rel="stylesheet">` + `<style>`, and returns a `CollectedPayload`.
+2. **`assembleHtml(captured)`** — rewrites the collected HTML to reference CSS sidecars under `resources/<sha1>.css`.
+3. **`buildManifest(captured, driver?)`** — produces a schema-v2 `manifest.json` object.
+4. **`saveSnapshot(adapter, options)`** — orchestrator that writes the full bundle to disk. Takes a `PageAdapter` you implement.
+
+### Trace pipeline (framework-agnostic)
+
+1. **`TraceBackend`** — the single interface you implement to give core access to your driver's trace data (frame snapshots, resources, screencast frames, resource-by-sha1).
+2. **`renderSnapshot(backend, pageOrFrameId, snapshotName)`** — pure renderer that turns a `FrameSnapshot` plus its resource overrides into HTML.
+3. **`inlineResources(rendered)`** — resolves every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference against the backend's sha1 store, emitting files under `resources/` and rewriting the HTML to match. Strips any `<base>` element.
+4. **`extractFromBackend(backend, markers, options)`** — orchestrator that takes a list of `TraceMarker`s and writes one v2 bundle per marker.
+
+## Writing a new driver adapter
+
+A driver adapter is a class that implements `PageAdapter`. It has one job: run the collector inside a live page and hand core a `CapturedPage`.
+
+```ts
+import {
+  PageAdapter,
+  CaptureRequest,
+  CapturedPage,
+  collectorSource,
+} from '@pagemirror/snapshot-core';
+
+export class MyDriverAdapter implements PageAdapter {
+  constructor(private readonly page: MyDriverPage) {}
+
+  async capture(request: CaptureRequest): Promise<CapturedPage> {
+    // 1. Run `collectorSource` inside the page. Every adapter ships the
+    //    same stringified source so the collector behaves identically
+    //    everywhere. Most drivers need to eval the source inside the
+    //    page rather than passing the function directly — serializers
+    //    often mangle nested async function bodies.
+    const payload = await this.page.evaluate(
+      async ({ src, opts }) => {
+        // eslint-disable-next-line no-eval
+        const fn = eval(`(${src})`) as (o: unknown) => Promise<unknown>;
+        return fn(opts);
+      },
+      {
+        src: collectorSource,
+        opts: {
+          extraSelectors: request.extraSelectors,
+          excludeSelectors: request.excludeSelectors,
+          extraAttributes: request.extraAttributes,
+        },
+      },
+    );
+
+    // 2. Fill in driver-specific metadata.
+    const captured: CapturedPage = {
+      html: payload.html,
+      stylesheets: payload.stylesheets,
+      resources: [],
+      url: this.page.url(),
+      viewport: await this.page.viewportSize(),
+      userAgent: await this.page.userAgent(),
+    };
+
+    // 3. Optional screenshot — push it into `resources` with the final filename.
+    if (request.screenshot) {
+      const bytes = await this.page.screenshot({
+        format: request.screenshot.format,
+        fullPage: request.screenshot.fullPage,
+      });
+      captured.resources.push({
+        filename: `screenshot.${request.screenshot.format}`,
+        bytes,
+      });
+    }
+
+    return captured;
+  }
+}
+```
+
+Consumers then call `saveSnapshot`:
+
+```ts
+import { saveSnapshot } from '@pagemirror/snapshot-core';
+
+await saveSnapshot(new MyDriverAdapter(page), {
+  outputDir: '.snapshots',
+  name: 'initial',
+  group: 'login',
+  driver: { name: 'my-driver', version: '1.2.3' },
+});
+```
+
+The `driver.name` becomes the key in `manifest.json` — e.g. `{ "my-driver": "1.2.3" }` — so downstream tooling can distinguish bundles by producer.
+
+## Writing a new trace backend
+
+A trace backend lets you reuse the entire extraction pipeline with any trace format. Implement `TraceBackend`:
+
+```ts
+import { TraceBackend, FrameSnapshot, ResourceEntry, ScreencastFrame } from '@pagemirror/snapshot-core';
+
+export class MyTraceBackend implements TraceBackend {
+  getFrameSnapshots(pageOrFrameId: string): FrameSnapshot[] {
+    // Return frame snapshots in trace order. Shape matches Playwright's
+    // internal snapshot format — see docs on `FrameSnapshot`.
+  }
+
+  getResources(): ResourceEntry[] {
+    // All network-resource entries, sorted by monotonicTime ascending.
+  }
+
+  getScreencastFrames(pageId: string): ScreencastFrame[] {
+    // Optional — omit if your trace format has no screencast.
+  }
+
+  async readResource(sha1: string): Promise<Uint8Array | undefined> {
+    // The single I/O primitive. Return bytes for the given sha1, or
+    // undefined when unknown.
+  }
+}
+```
+
+Then extract:
+
+```ts
+import { extractFromBackend, TraceMarker } from '@pagemirror/snapshot-core';
+
+const markers: TraceMarker[] = [
+  {
+    page: 'login',
+    state: 'initial',
+    pageOrFrameId: 'page@abc123',
+    snapshotName: 'after@call42',
+    timestamp: 1.234,
+    wallTime: 1705312345678,
+  },
+];
+
+const result = await extractFromBackend(backend, markers, {
+  outputDir: '.snapshots',
+  screenshot: true,          // emits resources/screenshot.webp when available
+  manifest: true,
+  driver: { name: 'my-driver', version: '1.2.3' },
+});
+
+for (const info of result.snapshots) {
+  console.log(`${info.page}/${info.state} -> ${info.outputDir}`);
+}
+```
+
+`extractFromBackend` is the only orchestrator you need. It calls `renderSnapshot` and `inlineResources` internally, writes the v2 bundle layout to disk, and returns the paths.
+
+## Bundle format (v2)
+
+```
+<name>/
+  index.html                   # Sanitized DOM referencing resources/
+  manifest.json                # Schema version 2
+  resources/
+    screenshot.png|webp        # Optional
+    <sha1>.css                 # Stylesheet sidecars
+    <sha1>.woff2|png|jpg|…     # Fonts, images, media (trace-extracted bundles)
+```
+
+`manifest.json`:
+
+```json
+{
+  "version": 2,
+  "url": "https://example.com/login",
+  "viewport": { "width": 1280, "height": 720 },
+  "timestamp": "2025-01-15T10:30:00Z",
+  "userAgent": "Mozilla/5.0 …",
+  "playwright": "1.58.0"
+}
+```
+
+Exactly one driver field is populated per manifest, matching `DriverInfo.name`. The v1 format is **not backwards compatible** and is refused by the plugin.
+
+See [`docs/snapshot-bundle-spec.md`](../../docs/snapshot-bundle-spec.md) in the main repo for the authoritative spec.
+
+## Public API reference
+
+### Types
+
+| Type                       | Purpose                                                                          |
+|----------------------------|----------------------------------------------------------------------------------|
+| `StylesheetData`           | One stylesheet (`href?`, `source`) as produced by the collector                   |
+| `Resource`                 | A file to be written under `resources/` (`filename`, `bytes`)                     |
+| `CapturedPage`             | Output of a `PageAdapter.capture()` call                                         |
+| `CollectorOptions`         | `extraSelectors` / `excludeSelectors` / `extraAttributes`                         |
+| `ScreenshotOptions`        | `{ format: 'png' \| 'webp', fullPage: boolean }`                                  |
+| `CaptureRequest`           | `CollectorOptions & { screenshot?: ScreenshotOptions }`                           |
+| `PageAdapter`              | The driver abstraction — `capture(request): Promise<CapturedPage>`                |
+| `DriverInfo`               | `{ name, version }` written into the manifest                                    |
+| `SaveSnapshotOptions`      | Options for `saveSnapshot`                                                       |
+| `SnapshotResult`           | `{ outputDir, files: { html, manifest?, resources } }`                           |
+| `ManifestJson`             | Schema-v2 manifest shape                                                         |
+| `MANIFEST_VERSION`         | Constant `2`                                                                     |
+
+### Trace types
+
+| Type                       | Purpose                                                                          |
+|----------------------------|----------------------------------------------------------------------------------|
+| `NodeSnapshot`             | Recursive DOM tuple layout matching Playwright's internal format                 |
+| `FrameSnapshot`            | One captured DOM state for a frame                                               |
+| `ResourceEntry`            | Network-resource log entry                                                       |
+| `ResourceOverride`         | Per-snapshot URL → sha1 override                                                 |
+| `ScreencastFrame`          | One screencast frame (sha1 + timestamp)                                          |
+| `TraceBackend`             | The trace-data abstraction you implement                                         |
+| `TraceMarker`              | Snapshot marker consumed by `extractFromBackend`                                 |
+| `ExtractFromBackendOptions`| Options for `extractFromBackend`                                                 |
+| `ExtractFromBackendResult` | `{ snapshots: ExtractedSnapshotInfo[] }`                                         |
+
+### Functions
+
+| Function                  | Description                                                                       |
+|---------------------------|-----------------------------------------------------------------------------------|
+| `collectPage(opts)`       | Runs the browser-side collector. Call inside the page.                             |
+| `collectorSource`         | Stringified version of `collectPage`, suitable for `page.evaluate(source, opts)`.  |
+| `assembleHtml(captured)`  | Rewrites captured HTML, returns `{ html, cssResources }`.                          |
+| `buildManifest(captured, driver?, now?)` | Produces a v2 `ManifestJson`.                                      |
+| `saveSnapshot(adapter, options)` | Full live-capture orchestrator.                                             |
+| `renderSnapshot(backend, pageOrFrameId, snapshotName)` | Renders a single `FrameSnapshot` to HTML.            |
+| `inlineResources(rendered)` | Resolves all resource references, emitting files under `resources/`.            |
+| `extractFromBackend(backend, markers, options)` | Full trace-extraction orchestrator.                       |
+| `extensionFromContentType(mimeType)` | Maps a MIME type to a canonical file extension.                      |
+
+## Requirements
+
+- Node.js 18+
+
+## License
+
+MIT

--- a/packages/snapshot-core/package.json
+++ b/packages/snapshot-core/package.json
@@ -8,7 +8,8 @@
     ".": "./dist/index.js"
   },
   "files": [
-    "dist/"
+    "dist/",
+    "README.md"
   ],
   "scripts": {
     "prebuild": "tsc --build --clean",

--- a/packages/snapshot-core/package.json
+++ b/packages/snapshot-core/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@pagemirror/snapshot-core",
   "version": "0.1.0",
-  "private": true,
   "description": "Framework-agnostic core for Page Mirror snapshot bundles: browser collector, HTML assembler, manifest builder, save orchestration.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -26,5 +25,8 @@
     "typescript": "^5.3.0",
     "vitest": "^2.1.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/packages/test-project/.gitignore
+++ b/packages/test-project/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 test-results/
 /playwright-report/
+/localUrl/

--- a/packages/test-project/package.json
+++ b/packages/test-project/package.json
@@ -7,7 +7,7 @@
     "postinstall": "npx playwright install chromium || true"
   },
   "devDependencies": {
-    "@pagemirror/snapshot-core": "file:../snapshot-core",
+    "@pagemirror/snapshot-core": "^0.1.0",
     "@playwright/test": "1.59.0",
     "@types/node": "^24.12.0",
     "playwright-snapshot-saver": "file:../playwright-snapshot-saver",

--- a/src/main/kotlin/com/github/artem/pageobjectplugin/listeners/SnapshotDiscoveryListener.kt
+++ b/src/main/kotlin/com/github/artem/pageobjectplugin/listeners/SnapshotDiscoveryListener.kt
@@ -1,5 +1,6 @@
 package com.github.artem.pageobjectplugin.listeners
 
+import com.github.artem.pageobjectplugin.model.BundleLoadResult
 import com.github.artem.pageobjectplugin.model.SnapshotBundle
 import com.github.artem.pageobjectplugin.services.SnapshotService
 import com.github.artem.pageobjectplugin.settings.PageMirrorSettings
@@ -12,6 +13,27 @@ import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 import kotlin.io.path.listDirectoryEntries
+
+/**
+ * One snapshot bundle directory the scanner found but the plugin
+ * refused to load (usually because `manifest.version` is not v2).
+ * Surfaced via [ScanResult.rejected] so the Page Mirror tool window
+ * can warn the user instead of silently showing nothing.
+ */
+data class RejectedBundle(val dir: Path, val declaredVersion: Int)
+
+/**
+ * Result of a snapshot-directory scan. `loaded` is what the tool
+ * window renders; `rejected` drives the outdated-bundle banner.
+ */
+data class ScanResult(
+    val loaded: List<SnapshotBundle>,
+    val rejected: List<RejectedBundle>,
+) {
+    companion object {
+        val EMPTY = ScanResult(emptyList(), emptyList())
+    }
+}
 
 class SnapshotDiscoveryListener(private val project: Project) : FileEditorManagerListener {
 
@@ -41,10 +63,10 @@ class SnapshotDiscoveryListener(private val project: Project) : FileEditorManage
         val projectRoot = project.basePath?.let { Path.of(it) } ?: return
         val snapshotGroupDir = projectRoot.resolve(settings.snapshotsRoot).resolve(pageName)
 
-        val bundles = scanForBundles(snapshotGroupDir, settings.snapshotSearchDepth)
+        val scan = scanBundles(snapshotGroupDir, settings.snapshotSearchDepth)
 
         val service = SnapshotService.getInstance(project)
-        service.updateAvailableSnapshots(bundles)
+        service.updateAvailableSnapshots(scan)
     }
 
     companion object {
@@ -58,36 +80,54 @@ class SnapshotDiscoveryListener(private val project: Project) : FileEditorManage
             }
         }
 
-        fun scanForBundles(dir: Path, maxDepth: Int = 3): List<SnapshotBundle> {
-            if (!dir.exists() || !dir.isDirectory()) return emptyList()
+        /**
+         * Canonical scan — returns both loaded and rejected bundles.
+         * The Page Mirror banner reads `rejected` to warn the user
+         * their v1 snapshots are on disk but un-loadable.
+         */
+        fun scanBundles(dir: Path, maxDepth: Int = 3): ScanResult {
+            if (!dir.exists() || !dir.isDirectory()) return ScanResult.EMPTY
 
-            val bundles = mutableListOf<SnapshotBundle>()
+            val loaded = mutableListOf<SnapshotBundle>()
+            val rejected = mutableListOf<RejectedBundle>()
             val seen = mutableSetOf<Path>()
-            scanRecursive(dir, 0, maxDepth, bundles, seen)
-            return bundles
+            scanRecursive(dir, 0, maxDepth, loaded, rejected, seen)
+            return ScanResult(loaded, rejected)
         }
+
+        /**
+         * Backwards-compatible convenience — returns only the loaded
+         * bundles, preserving the existing public signature. Prefer
+         * [scanBundles] for new call sites that care about rejected
+         * bundles.
+         */
+        fun scanForBundles(dir: Path, maxDepth: Int = 3): List<SnapshotBundle> =
+            scanBundles(dir, maxDepth).loaded
 
         private fun scanRecursive(
             dir: Path,
             depth: Int,
             maxDepth: Int,
-            results: MutableList<SnapshotBundle>,
-            seen: MutableSet<Path>
+            loaded: MutableList<SnapshotBundle>,
+            rejected: MutableList<RejectedBundle>,
+            seen: MutableSet<Path>,
         ) {
             if (depth > maxDepth) return
             val realDir = dir.toRealPath()
             if (!seen.add(realDir)) return
 
-            val bundle = SnapshotBundle.fromDirectory(dir)
-            if (bundle != null) {
-                results.add(bundle)
+            when (val result = SnapshotBundle.load(dir)) {
+                is BundleLoadResult.Loaded -> loaded.add(result.bundle)
+                is BundleLoadResult.UnsupportedVersion ->
+                    rejected.add(RejectedBundle(result.dir, result.declared))
+                BundleLoadResult.Empty -> { /* not a bundle dir */ }
             }
 
             if (depth < maxDepth) {
                 try {
                     for (child in dir.listDirectoryEntries()) {
                         if (child.isDirectory()) {
-                            scanRecursive(child, depth + 1, maxDepth, results, seen)
+                            scanRecursive(child, depth + 1, maxDepth, loaded, rejected, seen)
                         }
                     }
                 } catch (_: Exception) {

--- a/src/main/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundle.kt
+++ b/src/main/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundle.kt
@@ -15,6 +15,31 @@ private val LOG = logger<SnapshotBundle>()
  */
 const val SUPPORTED_BUNDLE_VERSION = 2
 
+/**
+ * Result of attempting to load a snapshot bundle from a directory.
+ *
+ * The loader splits three outcomes rather than returning a nullable
+ * bundle so the discovery scanner can distinguish "dir isn't a bundle"
+ * from "dir IS a bundle but the plugin can't use it because of a
+ * version mismatch". The banner in the Page Mirror tool window is
+ * driven by [UnsupportedVersion] observations.
+ */
+sealed class BundleLoadResult {
+    data class Loaded(val bundle: SnapshotBundle) : BundleLoadResult()
+    /**
+     * The directory contains a valid-looking bundle but declares an
+     * unsupported `manifest.version`. `declared` is the integer the
+     * manifest carried (preserved so the banner can surface the exact
+     * value the user hit).
+     */
+    data class UnsupportedVersion(val dir: Path, val declared: Int) : BundleLoadResult()
+    /**
+     * The directory is missing or doesn't contain a bundle (no
+     * index.html). Nothing to surface.
+     */
+    object Empty : BundleLoadResult()
+}
+
 data class SnapshotBundle(
     val name: String,
     /** Absolute path to the snapshot directory. */
@@ -27,29 +52,52 @@ data class SnapshotBundle(
     val manifestPath: Path?,
 ) {
     companion object {
-        fun fromDirectory(dir: Path): SnapshotBundle? {
-            if (!dir.exists() || !dir.isDirectory()) return null
+        /**
+         * Canonical entry point: classify a directory into a
+         * [BundleLoadResult]. Use [fromDirectory] for the legacy
+         * nullable-bundle convenience.
+         */
+        fun load(dir: Path): BundleLoadResult {
+            if (!dir.exists() || !dir.isDirectory()) return BundleLoadResult.Empty
 
             val html = dir.resolve("index.html")
-            if (!html.exists()) return null
+            if (!html.exists()) return BundleLoadResult.Empty
 
             val manifest = dir.resolve("manifest.json").takeIf { it.exists() }
-            if (manifest != null && !isSupportedVersion(manifest, dir)) {
-                return null
+            if (manifest != null) {
+                val declared = readDeclaredVersion(manifest)
+                if (declared != null && declared != SUPPORTED_BUNDLE_VERSION) {
+                    LOG.warn(
+                        "Refusing snapshot bundle at $dir: manifest.version=$declared, " +
+                            "plugin supports version=$SUPPORTED_BUNDLE_VERSION. " +
+                            "Re-run your snapshot saver to regenerate bundles in the v2 layout."
+                    )
+                    return BundleLoadResult.UnsupportedVersion(dir, declared)
+                }
             }
 
             val resourcesDir = dir.resolve("resources").takeIf { it.exists() && it.isDirectory() }
             val screenshot = resourcesDir?.let { findScreenshot(it) }
 
-            return SnapshotBundle(
-                name = dir.fileName.toString(),
-                dir = dir,
-                htmlPath = html,
-                resourcesDir = resourcesDir,
-                screenshotPath = screenshot,
-                manifestPath = manifest,
+            return BundleLoadResult.Loaded(
+                SnapshotBundle(
+                    name = dir.fileName.toString(),
+                    dir = dir,
+                    htmlPath = html,
+                    resourcesDir = resourcesDir,
+                    screenshotPath = screenshot,
+                    manifestPath = manifest,
+                )
             )
         }
+
+        /**
+         * Backwards-compatible convenience — returns the loaded bundle
+         * or null. Rejections and empty dirs both collapse to null, so
+         * prefer [load] for new code.
+         */
+        fun fromDirectory(dir: Path): SnapshotBundle? =
+            (load(dir) as? BundleLoadResult.Loaded)?.bundle
 
         private fun findScreenshot(resourcesDir: Path): Path? {
             val png = resourcesDir.resolve("screenshot.png").takeIf { it.exists() }
@@ -60,41 +108,28 @@ data class SnapshotBundle(
         }
 
         /**
-         * Parse the manifest for its `version` field and verify it
-         * matches [SUPPORTED_BUNDLE_VERSION]. Unparseable or missing
-         * version is treated permissively — the plugin still has enough
-         * info from index.html alone to render. Only a mismatched
-         * integer version is fatal.
+         * Parse the manifest for its `version` field. Uses a tight
+         * regex on the manifest JSON text to avoid pulling in a JSON
+         * library for a single field. Manifest files are small,
+         * well-formed, and produced by our own savers, so false-positive
+         * risk is negligible.
          *
-         * Uses a tight regex on the manifest JSON text to avoid pulling
-         * in a JSON library for a single field. Manifest files are
-         * small, well-formed, and produced by our own savers, so
-         * false-positive risk is negligible.
+         * Returns the declared integer version, or `null` when the
+         * field is missing / unparseable / the file can't be read. A
+         * `null` result is treated permissively by [load] — absent
+         * version means "unknown, render anyway".
          */
         private val VERSION_PATTERN = Regex("\"version\"\\s*:\\s*(\\d+)")
 
-        private fun isSupportedVersion(manifest: Path, dir: Path): Boolean {
+        private fun readDeclaredVersion(manifest: Path): Int? {
             val text = try {
                 manifest.readText()
             } catch (e: Exception) {
                 LOG.warn("Bundle manifest at $manifest could not be read; treating as versionless", e)
-                return true
+                return null
             }
-            val match = VERSION_PATTERN.find(text)
-            if (match == null) {
-                // Absent "version" field — treat as versionless, acceptable.
-                return true
-            }
-            val declared = match.groupValues[1].toIntOrNull() ?: return true
-            if (declared == SUPPORTED_BUNDLE_VERSION) {
-                return true
-            }
-            LOG.warn(
-                "Refusing snapshot bundle at $dir: manifest.version=$declared, " +
-                    "plugin supports version=$SUPPORTED_BUNDLE_VERSION. " +
-                    "Re-run your snapshot saver to regenerate bundles in the v2 layout."
-            )
-            return false
+            val match = VERSION_PATTERN.find(text) ?: return null
+            return match.groupValues[1].toIntOrNull()
         }
     }
 }

--- a/src/main/kotlin/com/github/artem/pageobjectplugin/services/SnapshotService.kt
+++ b/src/main/kotlin/com/github/artem/pageobjectplugin/services/SnapshotService.kt
@@ -1,5 +1,6 @@
 package com.github.artem.pageobjectplugin.services
 
+import com.github.artem.pageobjectplugin.listeners.ScanResult
 import com.github.artem.pageobjectplugin.locators.PickerResultHandler
 import com.github.artem.pageobjectplugin.model.SnapshotBundle
 import com.github.artem.pageobjectplugin.settings.PageMirrorSettings
@@ -53,6 +54,15 @@ class SnapshotService(private val project: Project) {
 
     var isHighlightAllActive: Boolean = false
 
+    /**
+     * Mirrors the most recent outdated-bundle banner state emitted to
+     * JCEF. Queryable from UI tests via the plugin classloader bridge
+     * the same way `isHighlightAllActive` is — keeps assertions off
+     * the JS side so we don't need a JCEF DOM probe.
+     */
+    var isOutdatedBannerActive: Boolean = false
+        private set
+
     private var jsQuery: JBCefJSQuery? = null
     private val snapshotListeners = mutableListOf<() -> Unit>()
     private var onPageReadyCallback: (() -> Unit)? = null
@@ -80,13 +90,77 @@ class SnapshotService(private val project: Project) {
         availableSnapshots = emptyList()
         snapshotListeners.clear()
         isHighlightAllActive = false
+        isOutdatedBannerActive = false
     }
 
-    fun updateAvailableSnapshots(bundles: List<SnapshotBundle>) {
-        LOG.info("updateAvailableSnapshots: ${bundles.size} bundle(s) found")
+    /**
+     * UI-test seam: simulate a snapshot-directory scan that turned up
+     * `declaredVersions.size` rejected bundles, each declaring the
+     * given version. Routes through the same [updateAvailableSnapshots]
+     * path production code uses, so the banner JS call + the
+     * [isOutdatedBannerActive] flag both flip identically. Used by
+     * `OutdatedBundleBannerUiTest` to exercise the wiring without
+     * seeding v1 bundles on disk.
+     */
+    internal fun simulateRejectedBundlesForTesting(declaredVersions: List<Int>) {
+        val rejected = declaredVersions.mapIndexed { i, v ->
+            com.github.artem.pageobjectplugin.listeners.RejectedBundle(
+                dir = java.nio.file.Paths.get(
+                    System.getProperty("java.io.tmpdir"),
+                    "pm-ui-banner-fake-v$v-$i",
+                ),
+                declaredVersion = v,
+            )
+        }
+        updateAvailableSnapshots(
+            com.github.artem.pageobjectplugin.listeners.ScanResult(
+                loaded = emptyList(),
+                rejected = rejected,
+            )
+        )
+    }
+
+    /** UI-test seam: simulate a clean scan — hides the banner. */
+    internal fun simulateCleanScanForTesting() {
+        updateAvailableSnapshots(com.github.artem.pageobjectplugin.listeners.ScanResult.EMPTY)
+    }
+
+    /**
+     * Canonical entry point used by the discovery listener. Receives
+     * both the loaded bundles and the rejected-bundle records so the
+     * tool window can drive the outdated-bundle banner.
+     */
+    fun updateAvailableSnapshots(result: ScanResult) {
+        val bundles = result.loaded
+        LOG.info(
+            "updateAvailableSnapshots: ${bundles.size} loaded, " +
+                "${result.rejected.size} rejected"
+        )
         bundles.forEach { LOG.info("  bundle: ${it.htmlPath}") }
+        result.rejected.forEach {
+            LOG.info("  rejected: ${it.dir} (declared v${it.declaredVersion})")
+        }
         availableSnapshots = bundles
         snapshotListeners.forEach { it() }
+
+        // Drive the outdated-bundle banner in the tool window. The
+        // banner is a pure function of the latest scan — it appears
+        // when any bundle under the scanned directory declared an
+        // unsupported version, and disappears as soon as the next scan
+        // is clean (e.g. after the user regenerates bundles).
+        if (result.rejected.isNotEmpty()) {
+            val versions = result.rejected
+                .map { it.declaredVersion }
+                .distinct()
+                .sorted()
+                .joinToString(",", "[", "]")
+            val count = result.rejected.size
+            jsExecutor("window.showOutdatedBanner({count:$count,versions:$versions});")
+            isOutdatedBannerActive = true
+        } else {
+            jsExecutor("window.hideOutdatedBanner();")
+            isOutdatedBannerActive = false
+        }
 
         if (bundles.isEmpty()) {
             clearSnapshot()
@@ -94,6 +168,15 @@ class SnapshotService(private val project: Project) {
             LOG.info("No current bundle, auto-loading first: ${bundles.first().htmlPath}")
             loadSnapshot(bundles.first())
         }
+    }
+
+    /**
+     * Backwards-compatible convenience for callers that don't carry
+     * rejection information. Delegates to the [ScanResult] overload
+     * with an empty rejection list.
+     */
+    fun updateAvailableSnapshots(bundles: List<SnapshotBundle>) {
+        updateAvailableSnapshots(ScanResult(bundles, emptyList()))
     }
 
     fun clearSnapshot() {

--- a/src/main/kotlin/com/github/artem/pageobjectplugin/services/SnapshotService.kt
+++ b/src/main/kotlin/com/github/artem/pageobjectplugin/services/SnapshotService.kt
@@ -94,43 +94,38 @@ class SnapshotService(private val project: Project) {
     }
 
     /**
-     * UI-test seam: simulate a snapshot-directory scan that turned up
-     * `declaredVersions.size` rejected bundles, each declaring the
-     * given version. Routes through the same [updateAvailableSnapshots]
-     * path production code uses, so the banner JS call + the
-     * [isOutdatedBannerActive] flag both flip identically. Used by
-     * `OutdatedBundleBannerUiTest` to exercise the wiring without
-     * seeding v1 bundles on disk.
+     * UI-test seam: drive the outdated-bundle banner directly, without
+     * touching [availableSnapshots] or [currentBundle]. The routing
+     * from `ScanResult.rejected` into this banner state is covered by
+     * `SnapshotServiceTest`; this seam exists only so
+     * `OutdatedBundleBannerUiTest` can exercise the JCEF rendering
+     * path under a real sandboxed IDE without polluting snapshot
+     * state that the next UI-test class's `@BeforeAll` depends on.
      *
-     * Public, not `internal`, because the Remote Robot JS bridge calls
-     * this via the JVM symbol name — `internal` would mangle it into
-     * `simulateRejectedBundlesForTesting$production_sources_for_module_<hash>`
+     * Public, not `internal`, because the Remote Robot JS bridge
+     * looks the method up by its plain JVM name — `internal` would
+     * mangle it into `…ForTesting$production_sources_for_module_<hash>`
      * and break the bridge lookup.
      */
     fun simulateRejectedBundlesForTesting(declaredVersions: List<Int>) {
-        val rejected = declaredVersions.mapIndexed { i, v ->
-            com.github.artem.pageobjectplugin.listeners.RejectedBundle(
-                dir = java.nio.file.Paths.get(
-                    System.getProperty("java.io.tmpdir"),
-                    "pm-ui-banner-fake-v$v-$i",
-                ),
-                declaredVersion = v,
-            )
+        if (declaredVersions.isEmpty()) {
+            jsExecutor("window.hideOutdatedBanner();")
+            isOutdatedBannerActive = false
+            return
         }
-        updateAvailableSnapshots(
-            com.github.artem.pageobjectplugin.listeners.ScanResult(
-                loaded = emptyList(),
-                rejected = rejected,
-            )
-        )
+        val versionsJson = declaredVersions.distinct().sorted().joinToString(",", "[", "]")
+        val count = declaredVersions.size
+        jsExecutor("window.showOutdatedBanner({count:$count,versions:$versionsJson});")
+        isOutdatedBannerActive = true
     }
 
     /**
-     * UI-test seam: simulate a clean scan — hides the banner. Public
-     * for the same JS-bridge reason as [simulateRejectedBundlesForTesting].
+     * UI-test seam: hide the outdated-bundle banner. Public for the
+     * same JS-bridge reason as [simulateRejectedBundlesForTesting].
      */
     fun simulateCleanScanForTesting() {
-        updateAvailableSnapshots(com.github.artem.pageobjectplugin.listeners.ScanResult.EMPTY)
+        jsExecutor("window.hideOutdatedBanner();")
+        isOutdatedBannerActive = false
     }
 
     /**

--- a/src/main/kotlin/com/github/artem/pageobjectplugin/services/SnapshotService.kt
+++ b/src/main/kotlin/com/github/artem/pageobjectplugin/services/SnapshotService.kt
@@ -101,8 +101,13 @@ class SnapshotService(private val project: Project) {
      * [isOutdatedBannerActive] flag both flip identically. Used by
      * `OutdatedBundleBannerUiTest` to exercise the wiring without
      * seeding v1 bundles on disk.
+     *
+     * Public, not `internal`, because the Remote Robot JS bridge calls
+     * this via the JVM symbol name — `internal` would mangle it into
+     * `simulateRejectedBundlesForTesting$production_sources_for_module_<hash>`
+     * and break the bridge lookup.
      */
-    internal fun simulateRejectedBundlesForTesting(declaredVersions: List<Int>) {
+    fun simulateRejectedBundlesForTesting(declaredVersions: List<Int>) {
         val rejected = declaredVersions.mapIndexed { i, v ->
             com.github.artem.pageobjectplugin.listeners.RejectedBundle(
                 dir = java.nio.file.Paths.get(
@@ -120,8 +125,11 @@ class SnapshotService(private val project: Project) {
         )
     }
 
-    /** UI-test seam: simulate a clean scan — hides the banner. */
-    internal fun simulateCleanScanForTesting() {
+    /**
+     * UI-test seam: simulate a clean scan — hides the banner. Public
+     * for the same JS-bridge reason as [simulateRejectedBundlesForTesting].
+     */
+    fun simulateCleanScanForTesting() {
         updateAvailableSnapshots(com.github.artem.pageobjectplugin.listeners.ScanResult.EMPTY)
     }
 

--- a/src/main/resources/html/js/snapshot.js
+++ b/src/main/resources/html/js/snapshot.js
@@ -94,3 +94,41 @@ window.clearSnapshot = function() {
     status.textContent = 'No snapshot loaded';
     window.clearHighlight();
 };
+
+// Outdated-bundle banner — shown when the snapshot scanner finds
+// bundle directories on disk whose manifest.version != 2 (i.e. v1
+// bundles left over from before the breaking v2 upgrade). The Kotlin
+// side drives visibility via showOutdatedBanner / hideOutdatedBanner;
+// the user can also temporarily dismiss it via the × button.
+(function () {
+    var dismissBtn = document.getElementById('banner-dismiss');
+    if (dismissBtn) {
+        dismissBtn.addEventListener('click', function () {
+            window.hideOutdatedBanner();
+        });
+    }
+})();
+
+window.showOutdatedBanner = function (payload) {
+    var banner = document.getElementById('banner');
+    var text = document.getElementById('banner-text');
+    if (!banner || !text) return;
+
+    var count = (payload && payload.count) || 0;
+    var versions = (payload && payload.versions) || [];
+    var versionList = versions.length
+        ? 'v' + versions.join(', v')
+        : 'an unsupported version';
+    var plural = count === 1 ? '' : 's';
+
+    text.textContent =
+        'Found ' + count + ' outdated snapshot bundle' + plural + ' (' +
+        versionList + '). This plugin requires v2. Regenerate with ' +
+        'playwright-snapshot-saver >= 0.7.0 to refresh them.';
+    banner.classList.remove('hidden');
+};
+
+window.hideOutdatedBanner = function () {
+    var banner = document.getElementById('banner');
+    if (banner) banner.classList.add('hidden');
+};

--- a/src/main/resources/html/page-mirror.html
+++ b/src/main/resources/html/page-mirror.html
@@ -25,6 +25,44 @@
             border-bottom: 1px solid #333;
             flex-shrink: 0;
         }
+        #banner {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 8px 12px;
+            font-size: 12px;
+            background: #4a3b12;
+            color: #f6c343;
+            border-bottom: 1px solid #6b5010;
+            flex-shrink: 0;
+        }
+        #banner.hidden {
+            display: none;
+        }
+        #banner-text {
+            flex: 1;
+            line-height: 1.4;
+        }
+        #banner-link {
+            color: #f6c343;
+            text-decoration: underline;
+            white-space: nowrap;
+        }
+        #banner-link:hover {
+            color: #fde68a;
+        }
+        #banner-dismiss {
+            background: transparent;
+            border: none;
+            color: #f6c343;
+            font-size: 18px;
+            line-height: 1;
+            cursor: pointer;
+            padding: 0 4px;
+        }
+        #banner-dismiss:hover {
+            color: #fde68a;
+        }
         #viewport-container {
             flex: 1;
             position: relative;
@@ -112,9 +150,32 @@
         body.theme-light #empty-state {
             color: #999;
         }
+        body.theme-light #banner {
+            background: #fef3c7;
+            color: #78350f;
+            border-bottom-color: #fcd34d;
+        }
+        body.theme-light #banner-link {
+            color: #78350f;
+        }
+        body.theme-light #banner-link:hover {
+            color: #431407;
+        }
+        body.theme-light #banner-dismiss {
+            color: #78350f;
+        }
+        body.theme-light #banner-dismiss:hover {
+            color: #431407;
+        }
     </style>
 </head>
 <body>
+    <div id="banner" class="hidden" role="alert">
+        <span id="banner-text"></span>
+        <a id="banner-link" target="_blank" rel="noopener"
+           href="https://github.com/AnewTranduil/PageObjectPlugin/blob/main/docs/migration-v1-to-v2.md">View migration guide</a>
+        <button id="banner-dismiss" aria-label="Dismiss">&times;</button>
+    </div>
     <div id="status">Page Mirror Ready</div>
     <div id="viewport-container">
         <div id="viewport-sizer">

--- a/src/test/kotlin/com/github/artem/pageobjectplugin/integration/SnapshotDiscoveryTest.kt
+++ b/src/test/kotlin/com/github/artem/pageobjectplugin/integration/SnapshotDiscoveryTest.kt
@@ -122,4 +122,107 @@ class SnapshotDiscoveryTest : BasePlatformTestCase() {
             root.toFile().deleteRecursively()
         }
     }
+
+    // --- scanBundles: rejected-bundle propagation ---
+
+    fun `test scanBundles classifies v1 directories as rejected`() {
+        val root = Files.createTempDirectory("pm-scan-rejected-")
+        try {
+            val v1Dir = root.resolve("initial")
+            Files.createDirectories(v1Dir)
+            Files.writeString(v1Dir.resolve("index.html"), "<html/>")
+            Files.writeString(v1Dir.resolve("manifest.json"), """{"version": 1, "url": ""}""")
+
+            val result = SnapshotDiscoveryListener.scanBundles(root, 3)
+
+            assertTrue("no v2 bundles should load", result.loaded.isEmpty())
+            assertEquals(1, result.rejected.size)
+            val rejected = result.rejected.single()
+            assertEquals(v1Dir, rejected.dir)
+            assertEquals(1, rejected.declaredVersion)
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    fun `test scanBundles returns both loaded and rejected when mixed`() {
+        val root = Files.createTempDirectory("pm-scan-mixed-")
+        try {
+            val v2Dir = root.resolve("initial")
+            Files.createDirectories(v2Dir)
+            Files.writeString(v2Dir.resolve("index.html"), "<html/>")
+            Files.writeString(v2Dir.resolve("manifest.json"), V2_MANIFEST)
+
+            val v1Dir = root.resolve("error-state")
+            Files.createDirectories(v1Dir)
+            Files.writeString(v1Dir.resolve("index.html"), "<html/>")
+            Files.writeString(v1Dir.resolve("manifest.json"), """{"version": 1}""")
+
+            val result = SnapshotDiscoveryListener.scanBundles(root, 3)
+
+            assertEquals(1, result.loaded.size)
+            assertEquals("initial", result.loaded.single().name)
+            assertEquals(1, result.rejected.size)
+            assertEquals(v1Dir, result.rejected.single().dir)
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    fun `test scanBundles all v2 returns empty rejected list`() {
+        val root = Files.createTempDirectory("pm-scan-v2-only-")
+        try {
+            val dir = root.resolve("initial")
+            Files.createDirectories(dir)
+            Files.writeString(dir.resolve("index.html"), "<html/>")
+            Files.writeString(dir.resolve("manifest.json"), V2_MANIFEST)
+
+            val result = SnapshotDiscoveryListener.scanBundles(root, 3)
+
+            assertEquals(1, result.loaded.size)
+            assertTrue(result.rejected.isEmpty())
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    fun `test scanBundles on missing dir returns fully empty result`() {
+        val nonExistent = Files.createTempDirectory("pm-scan-missing-")
+            .resolve("does-not-exist")
+
+        val result = SnapshotDiscoveryListener.scanBundles(nonExistent, 3)
+
+        assertTrue(result.loaded.isEmpty())
+        assertTrue(result.rejected.isEmpty())
+    }
+
+    fun `test scanForBundles hides rejected bundles for backwards compatibility`() {
+        val root = Files.createTempDirectory("pm-scan-compat-")
+        try {
+            val v1Dir = root.resolve("initial")
+            Files.createDirectories(v1Dir)
+            Files.writeString(v1Dir.resolve("index.html"), "<html/>")
+            Files.writeString(v1Dir.resolve("manifest.json"), """{"version": 1}""")
+
+            val bundles = SnapshotDiscoveryListener.scanForBundles(root, 3)
+
+            assertTrue(
+                "legacy scanForBundles must keep returning only loaded bundles",
+                bundles.isEmpty(),
+            )
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    companion object {
+        private val V2_MANIFEST = """
+            {
+              "version": 2,
+              "url": "about:blank",
+              "viewport": { "width": 1280, "height": 720 },
+              "timestamp": "2026-04-16T00:00:00Z"
+            }
+        """.trimIndent()
+    }
 }

--- a/src/test/kotlin/com/github/artem/pageobjectplugin/integration/SnapshotServiceTest.kt
+++ b/src/test/kotlin/com/github/artem/pageobjectplugin/integration/SnapshotServiceTest.kt
@@ -1,6 +1,8 @@
 package com.github.artem.pageobjectplugin.integration
 
 import com.github.artem.pageobjectplugin.fixtures.SnapshotFixtures
+import com.github.artem.pageobjectplugin.listeners.RejectedBundle
+import com.github.artem.pageobjectplugin.listeners.ScanResult
 import com.github.artem.pageobjectplugin.model.SnapshotBundle
 import com.github.artem.pageobjectplugin.services.SnapshotService
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
@@ -171,5 +173,96 @@ class SnapshotServiceTest : BasePlatformTestCase() {
         val bundle = SnapshotBundle.fromDirectory(dir)
 
         assertNull("v1 bundles must be refused", bundle)
+    }
+
+    // --- Outdated-bundle banner ------------------------------------
+
+    fun `test updateAvailableSnapshots emits showOutdatedBanner when rejections present`() {
+        val v1Dir = Files.createTempDirectory("pm-banner-v1-")
+        val scan = ScanResult(
+            loaded = emptyList(),
+            rejected = listOf(RejectedBundle(v1Dir, 1)),
+        )
+
+        service.updateAvailableSnapshots(scan)
+
+        val bannerCall = capturedJs.lastOrNull { it.startsWith("window.showOutdatedBanner(") }
+        assertNotNull(
+            "expected window.showOutdatedBanner to be emitted, captured: $capturedJs",
+            bannerCall,
+        )
+        assertTrue(
+            "banner payload should include count:1: $bannerCall",
+            bannerCall!!.contains("count:1"),
+        )
+        assertTrue(
+            "banner payload should include versions:[1]: $bannerCall",
+            bannerCall.contains("versions:[1]"),
+        )
+    }
+
+    fun `test updateAvailableSnapshots hides banner when scan is clean`() {
+        val bundle = SnapshotFixtures.createMinimalSnapshotDir()
+        val scan = ScanResult(loaded = listOf(bundle), rejected = emptyList())
+
+        service.updateAvailableSnapshots(scan)
+
+        assertTrue(
+            "expected window.hideOutdatedBanner(); in $capturedJs",
+            capturedJs.any { it.trim() == "window.hideOutdatedBanner();" },
+        )
+    }
+
+    fun `test updateAvailableSnapshots emits both load and banner when mixed`() {
+        val v2Bundle = SnapshotFixtures.createMinimalSnapshotDir()
+        val v1Dir = Files.createTempDirectory("pm-banner-mixed-v1-")
+        val scan = ScanResult(
+            loaded = listOf(v2Bundle),
+            rejected = listOf(RejectedBundle(v1Dir, 1)),
+        )
+
+        service.updateAvailableSnapshots(scan)
+
+        assertTrue(
+            "v2 bundle should auto-load: $capturedJs",
+            capturedJs.any { it.startsWith("window.loadSnapshot(") },
+        )
+        assertTrue(
+            "banner should warn about v1: $capturedJs",
+            capturedJs.any { it.startsWith("window.showOutdatedBanner(") && it.contains("versions:[1]") },
+        )
+    }
+
+    fun `test updateAvailableSnapshots dedupes and sorts declared versions`() {
+        val dirA = Files.createTempDirectory("pm-banner-v3a-")
+        val dirB = Files.createTempDirectory("pm-banner-v3b-")
+        val dirC = Files.createTempDirectory("pm-banner-v1-")
+        val scan = ScanResult(
+            loaded = emptyList(),
+            rejected = listOf(
+                RejectedBundle(dirA, 3),
+                RejectedBundle(dirB, 3),
+                RejectedBundle(dirC, 1),
+            ),
+        )
+
+        service.updateAvailableSnapshots(scan)
+
+        val bannerCall = capturedJs.last { it.startsWith("window.showOutdatedBanner(") }
+        assertTrue(
+            "expected count:3 (total rejected), versions:[1,3] (deduped/sorted): $bannerCall",
+            bannerCall.contains("count:3") && bannerCall.contains("versions:[1,3]"),
+        )
+    }
+
+    fun `test legacy list overload hides banner`() {
+        val bundle = SnapshotFixtures.createMinimalSnapshotDir()
+
+        service.updateAvailableSnapshots(listOf(bundle))
+
+        assertTrue(
+            "list overload should route through ScanResult and hide banner: $capturedJs",
+            capturedJs.any { it.trim() == "window.hideOutdatedBanner();" },
+        )
     }
 }

--- a/src/test/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundleTest.kt
+++ b/src/test/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundleTest.kt
@@ -1,0 +1,161 @@
+package com.github.artem.pageobjectplugin.model
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.writeText
+
+/**
+ * Unit tests for the [SnapshotBundle.load] classification, the sealed
+ * [BundleLoadResult] hierarchy, and the legacy-compatible
+ * [SnapshotBundle.fromDirectory] convenience.
+ *
+ * These tests are the canonical guardrail for the v1 bundle refusal:
+ * any regression that drops the [BundleLoadResult.UnsupportedVersion]
+ * signal will break the Page Mirror tool window's outdated-bundle
+ * banner.
+ */
+class SnapshotBundleTest : BasePlatformTestCase() {
+
+    private lateinit var tmpRoot: Path
+
+    override fun setUp() {
+        super.setUp()
+        tmpRoot = Files.createTempDirectory("pm-bundle-load-")
+    }
+
+    override fun tearDown() {
+        try {
+            tmpRoot.toFile().deleteRecursively()
+        } finally {
+            super.tearDown()
+        }
+    }
+
+    fun `test load returns Loaded for v2 bundle`() {
+        val dir = tmpRoot.resolve("initial")
+        Files.createDirectories(dir)
+        dir.resolve("index.html").writeText("<html><body/></html>")
+        dir.resolve("manifest.json").writeText(MANIFEST_V2)
+
+        val result = SnapshotBundle.load(dir)
+
+        assertTrue("expected Loaded, was $result", result is BundleLoadResult.Loaded)
+        val loaded = (result as BundleLoadResult.Loaded).bundle
+        assertEquals("initial", loaded.name)
+        assertEquals(dir.resolve("index.html"), loaded.htmlPath)
+    }
+
+    fun `test load returns UnsupportedVersion for v1 manifest`() {
+        val dir = tmpRoot.resolve("initial")
+        Files.createDirectories(dir)
+        dir.resolve("index.html").writeText("<html><body/></html>")
+        dir.resolve("manifest.json").writeText("""{"version": 1, "url": ""}""")
+
+        val result = SnapshotBundle.load(dir)
+
+        assertTrue(
+            "expected UnsupportedVersion, was $result",
+            result is BundleLoadResult.UnsupportedVersion,
+        )
+        val rejection = result as BundleLoadResult.UnsupportedVersion
+        assertEquals(dir, rejection.dir)
+        assertEquals(1, rejection.declared)
+    }
+
+    fun `test load returns UnsupportedVersion preserving the declared integer`() {
+        val dir = tmpRoot.resolve("weird")
+        Files.createDirectories(dir)
+        dir.resolve("index.html").writeText("<html/>")
+        dir.resolve("manifest.json").writeText("""{"version": 7}""")
+
+        val result = SnapshotBundle.load(dir)
+
+        assertTrue(result is BundleLoadResult.UnsupportedVersion)
+        assertEquals(7, (result as BundleLoadResult.UnsupportedVersion).declared)
+    }
+
+    fun `test load returns Empty for missing directory`() {
+        val absent = tmpRoot.resolve("nope")
+
+        assertEquals(BundleLoadResult.Empty, SnapshotBundle.load(absent))
+    }
+
+    fun `test load returns Empty when index html is missing`() {
+        val dir = tmpRoot.resolve("no-html")
+        Files.createDirectories(dir)
+        dir.resolve("manifest.json").writeText(MANIFEST_V2)
+
+        assertEquals(BundleLoadResult.Empty, SnapshotBundle.load(dir))
+    }
+
+    fun `test load is permissive when manifest is absent`() {
+        val dir = tmpRoot.resolve("no-manifest")
+        Files.createDirectories(dir)
+        dir.resolve("index.html").writeText("<html/>")
+
+        val result = SnapshotBundle.load(dir)
+
+        assertTrue(
+            "absent manifest should NOT be treated as an unsupported version",
+            result is BundleLoadResult.Loaded,
+        )
+    }
+
+    fun `test load is permissive when manifest has no version field`() {
+        val dir = tmpRoot.resolve("no-version")
+        Files.createDirectories(dir)
+        dir.resolve("index.html").writeText("<html/>")
+        dir.resolve("manifest.json").writeText("""{"url": "about:blank"}""")
+
+        val result = SnapshotBundle.load(dir)
+
+        assertTrue(result is BundleLoadResult.Loaded)
+    }
+
+    fun `test fromDirectory returns null for v1 bundles`() {
+        val dir = tmpRoot.resolve("initial")
+        Files.createDirectories(dir)
+        dir.resolve("index.html").writeText("<html/>")
+        dir.resolve("manifest.json").writeText("""{"version": 1}""")
+
+        assertNull(SnapshotBundle.fromDirectory(dir))
+    }
+
+    fun `test fromDirectory returns bundle for v2`() {
+        val dir = tmpRoot.resolve("initial")
+        Files.createDirectories(dir)
+        dir.resolve("index.html").writeText("<html/>")
+        dir.resolve("manifest.json").writeText(MANIFEST_V2)
+
+        val bundle = SnapshotBundle.fromDirectory(dir)
+
+        assertNotNull(bundle)
+        assertEquals("initial", bundle!!.name)
+    }
+
+    fun `test load resolves resources screenshot when present`() {
+        val dir = tmpRoot.resolve("with-screenshot")
+        Files.createDirectories(dir.resolve("resources"))
+        dir.resolve("index.html").writeText("<html/>")
+        dir.resolve("manifest.json").writeText(MANIFEST_V2)
+        dir.resolve("resources/screenshot.png").writeText("fake")
+
+        val result = SnapshotBundle.load(dir)
+
+        assertTrue(result is BundleLoadResult.Loaded)
+        val bundle = (result as BundleLoadResult.Loaded).bundle
+        assertEquals(dir.resolve("resources/screenshot.png"), bundle.screenshotPath)
+    }
+
+    companion object {
+        private val MANIFEST_V2 = """
+            {
+              "version": 2,
+              "url": "about:blank",
+              "viewport": { "width": 1280, "height": 720 },
+              "timestamp": "2026-04-16T00:00:00Z"
+            }
+        """.trimIndent()
+    }
+}

--- a/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/OutdatedBundleBannerUiTest.kt
+++ b/src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/OutdatedBundleBannerUiTest.kt
@@ -1,0 +1,145 @@
+package com.github.artem.pageobjectplugin.ui.tests
+
+import com.github.artem.pageobjectplugin.ui.BaseUiTest
+import com.github.artem.pageobjectplugin.ui.annotations.Feature
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * UI tests: outdated-bundle banner.
+ *
+ * The banner is the in-tool-window signal that the snapshot scanner
+ * found directories on disk that _look_ like snapshot bundles but
+ * declare an unsupported `manifest.version`. These tests verify the
+ * end-to-end wiring that drives the banner:
+ *
+ *   scanBundles classifies v1 → rejected
+ *     → SnapshotService.updateAvailableSnapshots(ScanResult(..., rejected=[…]))
+ *     → jsExecutor emits window.showOutdatedBanner
+ *     → isOutdatedBannerActive flips to true
+ *
+ * We drive the service via the
+ * [com.github.artem.pageobjectplugin.services.SnapshotService.simulateRejectedBundlesForTesting]
+ * seam rather than seeding v1 bundles on the test project's disk —
+ * that isolates this test from the filesystem state other UI tests
+ * rely on and keeps it fast and deterministic.
+ */
+@Feature("outdated-bundle-banner")
+class OutdatedBundleBannerUiTest : BaseUiTest() {
+
+    @AfterEach
+    fun resetBanner() {
+        // Keep the following test from inheriting banner-visible state
+        // — the SnapshotService is project-scoped and the sandbox IDE
+        // reuses the project across tests.
+        simulateCleanScan()
+    }
+
+    /**
+     * Core assertion: a scan that found one v1 bundle routes through
+     * the service and flips the banner flag on. This is the canonical
+     * "bundle version is not expected → banner is shown" test.
+     */
+    @Test
+    fun `v1 rejected bundle shows banner`() {
+        takeScreenshot("banner-before")
+
+        simulateRejectedBundles(listOf(1))
+
+        takeScreenshot("banner-after-show")
+
+        assertTrue(
+            isBannerActive(),
+            "isOutdatedBannerActive should be true after scan with a v1 rejection",
+        )
+    }
+
+    /**
+     * Clean scan after a dirty scan clears the banner. Verifies the
+     * "signal, not nag" property — the banner is a pure function of
+     * the latest scan, not a sticky modal.
+     */
+    @Test
+    fun `clean scan hides the banner`() {
+        simulateRejectedBundles(listOf(1))
+        assertTrue(isBannerActive(), "setup precondition failed")
+
+        simulateCleanScan()
+
+        takeScreenshot("banner-hidden")
+
+        assertFalse(
+            isBannerActive(),
+            "isOutdatedBannerActive should be false after a clean scan",
+        )
+    }
+
+    /**
+     * Multiple declared versions deduplicate. Any mix of rejected
+     * versions should still surface the banner.
+     */
+    @Test
+    fun `mixed declared versions keep the banner visible`() {
+        simulateRejectedBundles(listOf(1, 3, 3))
+
+        takeScreenshot("banner-mixed-versions")
+
+        assertTrue(
+            isBannerActive(),
+            "isOutdatedBannerActive should be true when multiple unsupported versions exist",
+        )
+    }
+
+    // --- Service bridge ---------------------------------------------
+
+    private val getServiceJs = """
+        var __pluginId = com.intellij.openapi.extensions.PluginId.getId("com.github.artem.pageobjectplugin")
+        var __plugin = com.intellij.ide.plugins.PluginManagerCore.getPlugin(__pluginId)
+        var __cl = __plugin.getPluginClassLoader()
+        var __svcClass = __cl.loadClass("com.github.artem.pageobjectplugin.services.SnapshotService")
+        var __project = com.intellij.openapi.project.ProjectManager.getInstance().getOpenProjects()[0]
+        var __service = __project.getService(__svcClass)
+    """.trimIndent()
+
+    private fun simulateRejectedBundles(versions: List<Int>) {
+        // Build the list element-by-element so we don't rely on the
+        // IDE's JS engine coercing a JS array literal to `Object[]` for
+        // Arrays.asList — that conversion is fragile across Nashorn /
+        // GraalJS.
+        val adds = versions.joinToString("\n") {
+            "__versions.add(java.lang.Integer.valueOf($it))"
+        }
+        ideFrame().callJs<Boolean>(
+            """
+            $getServiceJs
+            var __versions = new java.util.ArrayList()
+            $adds
+            __service.simulateRejectedBundlesForTesting(__versions)
+            true
+            """,
+            runInEdt = true,
+        )
+    }
+
+    private fun simulateCleanScan() {
+        ideFrame().callJs<Boolean>(
+            """
+            $getServiceJs
+            __service.simulateCleanScanForTesting()
+            true
+            """,
+            runInEdt = true,
+        )
+    }
+
+    private fun isBannerActive(): Boolean =
+        ideFrame().callJs<Boolean>(
+            """
+            $getServiceJs
+            new java.lang.Boolean(__service.isOutdatedBannerActive())
+            """,
+            runInEdt = true,
+        )
+}


### PR DESCRIPTION
…o semver

- @pagemirror/snapshot-core: drop `"private": true`, add `publishConfig.access = "public"` so the scoped package publishes as public on first release.
- playwright-snapshot-saver: replace `file:../snapshot-core` with `^0.1.0`. Once the core is on the registry, published consumers can resolve the dep; in-monorepo dev still links to the local workspace copy because 0.1.0 satisfies the caret.
- test-project: same `file:` -> `^0.1.0` swap for its snapshot-core dep; the `file:../playwright-snapshot-saver` dep stays because test-project is private and monorepo-only.
- Regenerated package-lock.json.

Verified: workspace symlinks intact, both builds succeed, snapshot-core's 48 vitest tests pass, and `npm publish --dry-run` reports `public access` for @pagemirror/snapshot-core.