### PR TITLE
docs: align CLAUDE.md with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +80,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -130,9 +134,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published alongside the framework-agnostic
+`@pagemirror/snapshot-core` package, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -149,8 +154,9 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped on `main` as
+`packages/snapshot-core/` (published to npm and consumed by
+`playwright-snapshot-saver` via semver). It bumped the snapshot bundle
 format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
 as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
 inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
@@ -277,9 +283,10 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow` — it
+  was re-enabled after `PageMirrorConfigurable` was given explicit
+  accessible names on its four testable fields and the settings
+  locators in `PageMirrorLocators` were rewritten to match them.
 
 ## Report Dashboard Access
 


### PR DESCRIPTION
## Summary

Audit of `CLAUDE.md` against the code on `main` surfaced several
drifts. This PR is docs-only and brings the project charter back
in sync.

### Fixes

- **Plugin ID / package prefix.** The table listed the plugin ID as
  `com.example.pagemirror` and the Plugin Source Layout tree used
  `com/example/pagemirror/...`. The real id in
  `src/main/resources/META-INF/plugin.xml` is
  `com.github.artem.pageobjectplugin` and every Kotlin source lives
  under `src/main/kotlin/com/github/artem/pageobjectplugin/`.
- **Plugin Source Layout tree.** Added files that actually ship
  (`PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`,
  `actions/HighlightCurrentSelectorAction.kt`,
  `widgets/PageMirrorStatusBarWidgetFactory.kt`) and removed the
  never-shipped `actions/InsertLocatorAction.kt`.
- **Task 15 status.** `CLAUDE.md` claimed Task 15 was "in progress on
  branch `claude/check-task-statuses-C7rh9`". That branch no longer
  exists; `@pagemirror/snapshot-core` is merged on `main`, published
  to npm, and consumed by `playwright-snapshot-saver` via semver
  (see commits `cbc75f1`, `7b808a0`, `949b026`). Updated the header
  line and the Task 15 paragraph accordingly.
- **SettingsUiTest.** Doc said it is "currently `@Disabled` for
  unrelated reasons (UI DSL component wrapping)". The file has no
  `@Disabled` annotation — the test is active. Replaced with the
  accurate history (re-enabled after `PageMirrorConfigurable` got
  accessible names and `PageMirrorLocators` was rewritten).

### Not changed

- Min Platform line still reads `2024.3+`, which matches
  `build.gradle.kts` `sinceBuild = "243"`. `gradle.properties` pins
  the sandbox to `platformVersion = 2025.1.3`, but that is the
  tested version, not the minimum — left as-is.
- `docs/snapshot-bundle-spec.md`, `docs/tasks/*`, and the Report
  Dashboard Access section all matched reality on spot-check.

## Test plan

- [x] `plugin.xml` `<id>` matches the table.
- [x] Every path in the Plugin Source Layout tree resolves to a real
      file; no listed file is missing.
- [x] `packages/snapshot-core/src/trace/{types,renderer,inline,extract,runtime-script,content-type}.ts` all exist.
- [x] `src/uiTest/.../tests/SettingsUiTest.kt` has no `@Disabled`.
- [x] No branch `claude/check-task-statuses-C7rh9` in `git branch -a`.
