### PR TITLE
docs: align CLAUDE.md with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | Page Object Helper (tool window: Page Mirror) |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +81,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -100,16 +105,31 @@ src/main/
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  fixtures/
+    login.html
+    app.html
+    styles/
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/
+      initial/      {index.html, manifest.json, resources/}
+      error-state/  {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+All packages are managed as npm workspaces under `packages/`:
+`snapshot-core/`, `playwright-snapshot-saver/`, and `test-project/`.
 
 ## Task Sequence
 
@@ -130,11 +150,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core`
+owns the framework-agnostic HTML assembly + trace rendering pipeline,
+the UI test suite runs under a layered Page Object structure, CI
+aggregates test results into a single `claude-summary.{json,md}` bundle,
+and a Playwright-style trace viewer is auto-generated on PRs tagged
+`demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +171,15 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** — shipped. The snapshot
+bundle format is v2: `screenshot.<ext>` lives under `resources/`, CSS is
+written as `resources/<sha1>.css` sidecars referenced by `<link>`, and
+the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't
+resolve relative URLs). v1 bundles are refused with a clear error
+message — regenerate via `npx playwright test` in
+`packages/test-project/`. `@pagemirror/snapshot-core` is published at
+version 0.1.0; `playwright-snapshot-saver` (0.7.0) consumes it via
+semver.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a


### PR DESCRIPTION
## Summary

CLAUDE.md had several stale references that did not match the code on `main`. This PR brings the doc back in sync — no code changes.

### What was wrong

- **Plugin ID / package path.** Doc listed `com.example.pagemirror`, but `plugin.xml`, `gradle.properties`, and the Kotlin source tree all use `com.github.artem.pageobjectplugin`.
- **Plugin source layout.** Listing was missing files that exist today (`PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`) and still referenced a stale `actions/InsertLocatorAction.kt` — the real file is `HighlightCurrentSelectorAction.kt`.
- **Test project layout.** Showed `test-project/` at the repo root with a non-existent `utils/save-state.ts`. After the npm-workspace consolidation (commit `0f43157`), the project lives under `packages/test-project/` with `fixtures/`, `dashboard.page.ts`, and `dashboard.spec.ts`.
- **Task 15 status.** Doc said Task 15 (`@pagemirror/snapshot-core` extraction) was "in progress on branch `claude/check-task-statuses-C7rh9`". That branch was merged via PR #30 (`dac7042`), and Task 15.5 also shipped (`7b808a0`). The current-state summary now reflects that.

### What this PR changes

- `CLAUDE.md` only — project config table, plugin source layout, test project layout, and the Current State / Task 15 blurbs updated to match what's on disk.

## Test plan

- [x] `CLAUDE.md` plugin ID matches `src/main/resources/META-INF/plugin.xml` and `gradle.properties` (`com.github.artem.pageobjectplugin`).
- [x] Every file under the Plugin Source Layout tree exists at the listed path.
- [x] Every file under the Test Project Layout tree exists under `packages/test-project/`.
- [x] No remaining references to the stale `claude/check-task-statuses-C7rh9` branch or the `InsertLocatorAction` name.
