### PR TITLE
docs: align CLAUDE.md, README, and USE with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,13 @@
-# Page Mirror — IntelliJ Plugin for Playwright
+# Page Object Helper — IntelliJ Plugin for Playwright
 
 ## What This Project Is
 
 An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool Window (JCEF browser). When a developer places their cursor on a Playwright locator in their TypeScript code, the corresponding element highlights in the snapshot view. Developers can also click elements in the snapshot to generate locator code.
+
+The plugin is registered as **Page Object Helper** (the `<name>` in
+`plugin.xml`); the docked tool window it provides is labeled **Page
+Mirror**. Both names appear throughout the codebase and refer to the
+same plugin.
 
 ## Project Configuration
 
@@ -12,7 +17,9 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | `Page Object Helper`                       |
+| Tool Window ID  | `Page Mirror`                              |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +70,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +87,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -95,6 +106,10 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
@@ -130,11 +145,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core` is
+published as a separate npm package and consumed by the saver, the UI
+test suite runs under a layered Page Object structure, CI aggregates
+test results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +165,15 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped: the package
+lives at `packages/snapshot-core/` (`@pagemirror/snapshot-core`,
+currently `0.1.0`) and is consumed by `playwright-snapshot-saver` via
+semver. The work also bumped the snapshot bundle format to v2:
+`screenshot.<ext>` moved under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a
@@ -256,7 +274,10 @@ and run against a sandboxed IDE launched by `./gradlew runIdeForUiTests`.
 The layout was overhauled in Task 13 — follow these rules.
 
 - **Layering rule.** Tests call Flows or Pages, never raw fixtures.
-  Flows orchestrate multiple Pages. Pages compose Fixtures and call
+  Flows orchestrate multiple Pages. Pages compose Fixtures (under
+  `ui/fixtures/`, e.g. `PageMirrorToolWindowFixture`,
+  `PageMirrorSettingsFixture`, `SnapshotBrowserFixture`,
+  `StatusBarFixture`, `GutterFixture`) and call
   `StepRecorder.step("...")` for each logical action so the action
   shows up in `trace.json`. Fixtures contain no literal XPath strings —
   every locator comes from `ui/locators/`.
@@ -277,9 +298,8 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow` and is
+  active (`@Feature("settings")`).
 
 ## Report Dashboard Access
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight current selector** — press `Alt+Shift+H` to re-highlight the locator on the line under your caret without scrolling the editor.
+- **Highlight all (Show All)** — toolbar button on the Page Mirror panel that highlights every locator in the current file at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -224,6 +224,10 @@ The editor gutter shows a badge next to each locator with the number of matching
 - **0** — no match (broken selector)
 - **2+** — multiple matches (ambiguous selector)
 
-### Highlight All
+### Highlight current selector
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Press `Alt+Shift+H` to re-highlight the locator on the line under your caret. Useful when the snapshot has been cleared, the highlight has timed out, or you want to flash the current selector without moving the caret.
+
+### Highlight all (Show All)
+
+Click the **Show All** button on the Page Mirror toolbar to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges. Click the button again to clear.


### PR DESCRIPTION
## Summary

Audits `CLAUDE.md`, `README.md`, and `USE.md` against the actual `main` source tree and brings them back in sync. The codebase has moved on (root package renamed, `widgets/` added, action set changed, Tasks 15 / 15.5 shipped, `SettingsUiTest` re-enabled), but the docs still describe an earlier state.

### `CLAUDE.md`

- **Plugin ID and name.** `com.example.pagemirror` → `com.github.artem.pageobjectplugin` to match `src/main/resources/META-INF/plugin.xml`. Added explicit `Plugin Name` (`Page Object Helper`) and `Tool Window ID` (`Page Mirror`) rows so the dual naming is no longer confusing. Title now says "Page Object Helper" with a one-paragraph note explaining the two names.
- **Plugin Source Layout.** Root path `src/main/kotlin/com/example/pagemirror/` → `src/main/kotlin/com/github/artem/pageobjectplugin/`. Added `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, and `resources/demo-viewer/`. Replaced the nonexistent `actions/InsertLocatorAction.kt` with the actual `actions/HighlightCurrentSelectorAction.kt`.
- **Current State.** Task 15 is no longer "in progress on branch `claude/check-task-statuses-C7rh9`" — it's shipped. `@pagemirror/snapshot-core` is at `0.1.0` in `packages/snapshot-core/` and is consumed by `playwright-snapshot-saver` (currently `0.7.0`) via semver. Headline summary now reads "Tasks 0–15, 15.5, and 19 are complete."
- **UI Test Conventions.** Added `fixtures/` (with the actual fixture class names) to the layering rule. Updated the SettingsUiTest reference: it has `@Feature("settings")` and is active — there is no `@Disabled` anywhere in `src/uiTest/`.

### `README.md` and `USE.md`

- `Alt+Shift+H` is bound to `HighlightCurrentSelectorAction` (highlights the locator on the line under the caret), not "Highlight All". The "Highlight all" feature is the **Show All** button on the Page Mirror toolbar with no keyboard shortcut. Both docs split the feature into two entries that match what the code actually does.

## Test plan

- [x] `grep -n "com.example.pagemirror\|InsertLocatorAction\|claude/check-task-statuses" CLAUDE.md README.md USE.md` returns no hits.
- [x] Source layout in `CLAUDE.md` matches `find src/main/kotlin -name '*.kt'` (root package, all subpackages, every file).
- [x] `Alt+Shift+H` description matches `META-INF/plugin.xml` action wiring + `HighlightCurrentSelectorAction.kt` behavior.
- [x] `Show All` description matches `PageMirrorToolWindowFactory.kt:70-90`.
- [x] `SettingsUiTest.kt` confirmed active (`@Feature("settings")`, no `@Disabled`).
- [x] `packages/snapshot-core/package.json` confirms `@pagemirror/snapshot-core@0.1.0` is shipped.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JCngj4Q3nqtPDWy8fZyB4j)_