### PR TITLE
docs: align CLAUDE.md, Roadmap and task docs with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,28 +63,32 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt          # i18n / resource bundle accessor
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt    # inlines resources/<sha1>.css sidecars before JCEF
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
       CaretHighlightListener.kt
     locators/
       LocatorExtractor.kt
-      PickerResultHandler.kt
+      PickerResultHandler.kt     # owns "Insert Locator" popup + code generation
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -99,16 +103,27 @@ src/main/
 
 ## Test Project Layout
 
+Lives at `packages/test-project/` (workspace member, no `node_modules` of its own — `npm install` at the repo root wires it up).
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  fixtures/                  # fixture HTML pages served to the browser under test
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/
+      initial/         {index.html, manifest.json, resources/}
+      error-state/     {index.html, manifest.json, resources/}
+    dashboard/
+      initial/         {index.html, manifest.json, resources/}
+      ticket-filled/   {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,9 +145,11 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core` is
+extracted as a framework-agnostic library, trace-extracted bundles are
+self-contained, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -147,28 +164,31 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped (PR #30, plus
+  PRs #33/#34 for follow-up packaging fixes). The package lives at
+  `packages/snapshot-core/` and is published from there; `playwright-snapshot-saver`
+  is now a thin adapter that depends on `@pagemirror/snapshot-core` via
+  semver. The bundle format is bumped to v2: `screenshot.<ext>` moves
+  under `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+  referenced by `<link>`, and `services/SnapshotHtmlResolver.kt` inlines
+  sidecar CSS on read (since `srcdoc` iframes can't resolve relative
+  URLs). Bundles whose `manifest.version` is anything other than `2`
+  are refused with a user-visible banner — regenerate via
+  `npx playwright test` in `packages/test-project/`. See
+  `docs/migration-v1-to-v2.md`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` now owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the framework-agnostic `@pagemirror/snapshot-core`, trace-extracted bundles are self-contained (no `/snapshot/<sha1>` dead links), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The plugin is still tightly coupled to TypeScript on the locator-extraction side (regex), so Track A and the remaining Track B adapters (16–18, 20) layer Python / JVM / Selenium / Cypress / Appium support on top of `snapshot-core` without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `manifest.json` + `resources/`) defined in `CLAUDE.md` and frozen at v2 in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ shipped (PR #30) plus follow-up resource inlining `task-15.5-trace-resource-inlining.md` ✅ shipped
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B2 and B3 layer new adapters on top of the now-extracted core.
 
 ---
 

--- a/docs/UI_tests/test-run-status.md
+++ b/docs/UI_tests/test-run-status.md
@@ -26,7 +26,7 @@
 - **Programmatic IDE actions:** Replaced keyboard-shortcut-driven `openFileInEditor()`, `goToLine()`, and `openToolWindow()` with `callJs` that invokes IDE APIs directly (`FileEditorManager`, `ToolWindowManager`, `LogicalPosition`). Keyboard shortcuts failed because the IDE window could be minimized/iconified.
 - **Window focus:** Added `bringIdeToFront()` that de-iconifies the IDE frame and calls `toFront()`/`requestFocus()`.
 - **Plugin classloader isolation:** Remote Robot's Rhino JS engine runs under the robot-server-plugin classloader, which cannot see plugin classes via `Class.forName()`. All service access uses `PluginManagerCore.getPlugin(pluginId).getPluginClassLoader().loadClass(...)`.
-- **Plugin ID:** Actual ID is `com.github.artem.pageobjectplugin` (not `com.example.pagemirror` from CLAUDE.md).
+- **Plugin ID:** Tests load the plugin classloader by its real ID `com.github.artem.pageobjectplugin`.
 
 ### PageMirrorToolWindowFixture
 

--- a/docs/tasks/task-1-plugin-shell.md
+++ b/docs/tasks/task-1-plugin-shell.md
@@ -6,7 +6,7 @@
 
 ## Prompt
 
-I have an IntelliJ Platform Plugin project (Gradle Plugin 2.x, Kotlin, min platform 2024.3). The plugin ID is `com.example.pagemirror`.
+I have an IntelliJ Platform Plugin project (Gradle Plugin 2.x, Kotlin, min platform 2024.3). The plugin ID is `com.github.artem.pageobjectplugin`.
 
 Create the plugin shell with these requirements:
 

--- a/docs/tasks/task-16-python-playwright-support.md
+++ b/docs/tasks/task-16-python-playwright-support.md
@@ -76,7 +76,7 @@ The pytest plugin (`pytest_plugin.py`) provides auto-capture on test failure whe
 4. Add `.py` to default `fileExtensions` in settings; update `PageMirrorConfigurable` if the default needs to be surfaced.
 5. Scaffold `packages/playwright-snapshot-saver-python/` with modern `pyproject.toml` (PEP 621) and `hatchling` or `poetry` build.
 6. Port `html-inliner.ts` to Python using `beautifulsoup4` + stdlib `urllib` — produce output matching the TS version for the shared fixture page (verified by golden-file test).
-7. Port `manifest-generator.ts` — emit spec-v1 compliant `manifest.json` per `docs/snapshot-bundle-spec.md`.
+7. Port `manifest-generator.ts` — emit spec-v2 compliant `manifest.json` per `docs/snapshot-bundle-spec.md`.
 8. Implement `save_snapshot` / `save_snapshot_async` for `playwright.sync_api.Page` and `playwright.async_api.Page`.
 9. Implement `pytest_plugin.py` reporter (fixture + hook) analogous to `playwright-snapshot-saver`'s Playwright reporter.
 10. Integration tests: `pytest` suite that launches a headless Chromium, visits a fixture page, calls `save_snapshot`, and asserts bundle layout + manifest contents.

--- a/docs/tasks/task-18-jvm-playwright-support.md
+++ b/docs/tasks/task-18-jvm-playwright-support.md
@@ -1,6 +1,6 @@
 # Task 18: Java/Kotlin Playwright Support
 
-> **Goal:** Recognize Playwright Java API locators in `.java` and `.kt` files (highlight + gutter) AND ship `snapshot-saver-jvm` — a Kotlin JVM library that produces spec-v1 bundles from `com.microsoft.playwright.Page`.
+> **Goal:** Recognize Playwright Java API locators in `.java` and `.kt` files (highlight + gutter) AND ship `snapshot-saver-jvm` — a Kotlin JVM library that produces spec-v2 bundles from `com.microsoft.playwright.Page`.
 > **Depends on:** Task 16 (introduces `LocatorExtractor` interface + registry), `docs/snapshot-bundle-spec.md`.
 > **Output:** `JvmLocatorExtractor.kt`, new Gradle artifact `packages/playwright-snapshot-saver-jvm/`.
 
@@ -18,7 +18,7 @@ Playwright's Java API is used by a substantial Selenium-migration crowd and shar
 
 ### Saver package
 - New: `packages/playwright-snapshot-saver-jvm/` (own `build.gradle.kts`, included via `settings.gradle.kts`).
-  - Published coordinates: `com.example.pagemirror:snapshot-saver-jvm`
+  - Published coordinates: `com.github.artem.pageobjectplugin:snapshot-saver-jvm`
   - `src/main/kotlin/.../SnapshotSaver.kt` — `SnapshotSaver.save(page, name, options)`
   - `src/main/kotlin/.../HtmlInliner.kt` — Jsoup-based inliner
   - `src/main/kotlin/.../ManifestGenerator.kt`
@@ -57,7 +57,7 @@ SnapshotSaver.save(page, "login/initial", new SaveOptions().setOutputDir(new Fil
 3. Add `.java`, `.kt` to default `fileExtensions` in settings.
 4. Scaffold `packages/playwright-snapshot-saver-jvm/` as a sibling Gradle project, included via root `settings.gradle.kts`. Kotlin JVM, Java 17 target.
 5. Implement `HtmlInliner` in Kotlin using Jsoup (port of TS version, verified against the shared fixture page via golden-file test).
-6. Implement `ManifestGenerator` emitting spec-v1 JSON via `kotlinx.serialization`.
+6. Implement `ManifestGenerator` emitting spec-v2 JSON via `kotlinx.serialization`.
 7. Implement `SnapshotSaver.save()` against `com.microsoft.playwright.Page`. Options class mirrors the TS API.
 8. Implement `SnapshotSaverExtension` as a JUnit 5 `TestWatcher` + `ParameterResolver` — auto-captures on failure when registered.
 9. Integration tests: JUnit 5 suite that launches Playwright Java, visits a fixture page, calls the saver, asserts bundle layout.

--- a/docs/tasks/task-20-appium-mobile-support.md
+++ b/docs/tasks/task-20-appium-mobile-support.md
@@ -1,6 +1,6 @@
 # Task 20: Appium Mobile Snapshot Saver
 
-> **Goal:** Ship `appium-snapshot-saver` — a `PageAdapter` over Appium that captures native mobile page source + screenshot into a spec-v1 bundle, extending the manifest `viewport` with platform + device metadata.
+> **Goal:** Ship `appium-snapshot-saver` — a `PageAdapter` over Appium that captures native mobile page source + screenshot into a spec-v2 bundle, extending the manifest `viewport` with platform + device metadata.
 > **Depends on:** Task 15 (`snapshot-core`), Task 17 (pattern for adapter packages).
 > **Output:** New `packages/appium-snapshot-saver/`, decision on HTML-vs-XML rendering fallback tracked as follow-up.
 


### PR DESCRIPTION
## Summary

Walked the `main` worktree and audited the docs against the actual code. Found a handful of mismatches and corrected them — no code changes, docs only.

## Mismatches found

| Doc | What was stale | What it should be |
|---|---|---|
| `CLAUDE.md` Plugin ID | `com.example.pagemirror` (placeholder) | `com.github.artem.pageobjectplugin` (actual ID in `plugin.xml` and on disk) |
| `CLAUDE.md` Plugin Source Layout | `kotlin/com/example/pagemirror/`, listed phantom `actions/InsertLocatorAction.kt`, missing `widgets/PageMirrorStatusBarWidgetFactory.kt`, missing `services/SnapshotHtmlResolver.kt`, missing `PageObjectBundle.kt`, missing `actions/HighlightCurrentSelectorAction.kt` | Path is `com/github/artem/pageobjectplugin/`; locator-insertion is owned by `locators/PickerResultHandler.kt`; the missing files are listed |
| `CLAUDE.md` Current State header | "Tasks 0–14 and 19 are complete" | "Tasks 0–15, 15.5, and 19 are complete" — Task 15 was merged via PR #30 and follow-ups #33/#34, and 15.5 shipped before that |
| `CLAUDE.md` Task 15 paragraph | "in progress on branch `claude/check-task-statuses-C7rh9`" | shipped, with `packages/snapshot-core/` published from there and `playwright-snapshot-saver` depending on it via semver |
| `CLAUDE.md` Test Project Layout | `test-project/` with only `login/` and a non-existent `utils/save-state.ts` | `packages/test-project/` (workspace member) with `fixtures/`, `tsconfig.json`, both `login/` and `dashboard/` page objects/specs/snapshots |
| `docs/Roadmap.md` Context | "Tasks 0–14 plus 19 are complete" + "Task 15 below extracts…" | Tasks 0–15, 15.5, and 19 are complete; remaining adapters layer on top of the now-extracted core |
| `docs/Roadmap.md` Track A intro | "`index.html` + `screenshot.webp` + `manifest.json`" | "`index.html` + `manifest.json` + `resources/`" — v2 layout |
| `docs/Roadmap.md` Track B1 | unmarked | "✅ shipped" with PR #30 reference and 15.5 follow-up |
| `docs/tasks/task-1-plugin-shell.md` | `com.example.pagemirror` in the historical prompt | actual plugin ID |
| `docs/tasks/task-16-python-playwright-support.md` | "spec-v1 compliant `manifest.json`" | spec-v2 |
| `docs/tasks/task-18-jvm-playwright-support.md` | "spec-v1 bundles" + planned coords `com.example.pagemirror:snapshot-saver-jvm` | spec-v2 + `com.github.artem.pageobjectplugin:snapshot-saver-jvm` |
| `docs/tasks/task-20-appium-mobile-support.md` | "spec-v1 bundle" | spec-v2 bundle |
| `docs/UI_tests/test-run-status.md` | parenthetical "(not `com.example.pagemirror` from CLAUDE.md)" describing a stale CLAUDE.md | rephrased to just describe what BaseUiTest does, since CLAUDE.md is now correct |

## Test plan

- [ ] Re-read CLAUDE.md and confirm the Plugin Source Layout matches `find src/main/kotlin -name "*.kt"`
- [ ] Confirm `packages/test-project/` snapshot states (`login/{initial,error-state}`, `dashboard/{initial,ticket-filled}`) match the doc
- [ ] No remaining occurrences of `com.example.pagemirror` or `com/example/pagemirror` anywhere in the repo (`grep -rn` is clean)
- [ ] No code or build changes; no CI run required beyond doc lint if applicable

---
_Generated by [Claude Code](https://claude.ai/code/session_0165W1R92TtnMSkRf97JqK6n)_