### PR TITLE
docs: align CLAUDE.md with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +80,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -100,15 +104,27 @@ src/main/
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/
+    login.html
+    app.html
+    styles/{reset.css, layout.css, components.css, theme.css}
+  .snapshots/
+    login/
+      initial/      {index.html, manifest.json, resources/}
+      error-state/  {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,11 +146,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published alongside the framework-agnostic
+`@pagemirror/snapshot-core`, the UI test suite runs under a layered Page
+Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+auto-generated on PRs tagged `demo`. (The Task Sequence table above
+covers Tasks 0–9; Tasks 10–19 are summarized in the bullets that follow.)
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +167,15 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete** and
+merged to main. `@pagemirror/snapshot-core` is published as its own
+workspace package and consumed via semver from
+`packages/playwright-snapshot-saver/`. The snapshot bundle format moved
+to v2: `screenshot.<ext>` lives under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a


### PR DESCRIPTION
## Summary

Audited `CLAUDE.md` against the actual state of `main` (HEAD `7101aad`) and updated the doc to match. Other docs (`README.md`, `USE.md`, `CHANGELOG.md`, `docs/snapshot-bundle-spec.md`, `docs/migration-v1-to-v2.md`, `docs/Roadmap.md`) were checked and are accurate — no changes needed there.

### Mismatches fixed in CLAUDE.md

- **Plugin ID** corrected from `com.example.pagemirror` to `com.github.artem.pageobjectplugin` (matches `src/main/resources/META-INF/plugin.xml:2`).
- **Plugin Source Layout** rooted at `kotlin/com/github/artem/pageobjectplugin/` (was `com/example/pagemirror/`); added the files that actually ship and removed one that doesn't:
  - added `PageObjectBundle.kt` (root package)
  - added `services/SnapshotHtmlResolver.kt`
  - added `actions/HighlightCurrentSelectorAction.kt`
  - added `widgets/PageMirrorStatusBarWidgetFactory.kt` (entire `widgets/` subtree was missing)
  - removed `actions/InsertLocatorAction.kt` (never shipped under that name)
- **Test Project Layout** repointed from `test-project/` to `packages/test-project/` and updated to list the real fixtures, page objects, specs, and both snapshot bundles (`login/`, `dashboard/`).
- **Task 15 / 15.5 status** — was described as "in progress on branch `claude/check-task-statuses-C7rh9`" (a branch that no longer exists). Git history confirms `@pagemirror/snapshot-core` was extracted, made publishable, and is consumed via semver. Updated to "complete and merged."
- **Current State header** updated from "Tasks 0–14 and 19" to "Tasks 0–15.5 and 19" with a note that the Task Sequence table covers Tasks 0–9 and the rest are in the bullets that follow.

## Test plan

- [x] Verified `plugin.xml` plugin id
- [x] Listed every file under `src/main/kotlin/com/github/artem/pageobjectplugin/` and cross-checked against the doc tree
- [x] Listed `packages/test-project/` contents and cross-checked the layout
- [x] Confirmed the stale Task 15 branch is absent locally (only `main` and the working branch remain)
- [x] Confirmed Task 15 / 15.5 work is in `main` history (`4d5a586`, `7b808a0`, `cbc75f1`, etc.)
- [x] Skimmed `README.md`, `USE.md`, `CHANGELOG.md`, `docs/snapshot-bundle-spec.md`, `docs/migration-v1-to-v2.md`, `docs/Roadmap.md` — no mismatches found

Docs-only change; no code or build configuration is touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XQUsDpumMPajMkBfKeBuXL)_