### PR TITLE
docs: align CLAUDE.md and Roadmap with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | Page Object Helper                         |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +81,18 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
     html/
       page-mirror.html
       js/
@@ -95,21 +101,44 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
+The test project is an npm workspace under `packages/test-project/`:
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/
+    app.html
+    login.html
+    styles/
+  .snapshots/
+    login/
+      initial/      {index.html, manifest.json, resources/}
+      error-state/  {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+The other npm workspaces under `packages/` are
+`@pagemirror/snapshot-core` (framework-agnostic core) and
+`playwright-snapshot-saver` (the Playwright adapter that consumes
+snapshot-core).
 
 ## Task Sequence
 
@@ -130,11 +159,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, snapshot bundle assembly has
+been split into a framework-agnostic `@pagemirror/snapshot-core`
+workspace plus a thin `playwright-snapshot-saver` adapter, the UI test
+suite runs under a layered Page Object structure, CI aggregates test
+results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -143,32 +174,34 @@ auto-generated on PRs tagged `demo`.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
 - **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
-- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
+- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created; `ClaudeSummaryModel.kt` deliberately drops the field rather than carrying a perpetually-empty placeholder (see the comment at the top of that file).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** the framework-agnostic
+  core lives at `packages/snapshot-core/` (browser collector, HTML
+  assembler, manifest builder, `saveSnapshot()` orchestration);
+  `packages/playwright-snapshot-saver/` is now a thin adapter that
+  depends on `@pagemirror/snapshot-core` via semver. Bundle format
+  bumped to v2: `screenshot.<ext>` moves under `resources/`, CSS is
+  written as `resources/<sha1>.css` sidecars referenced by `<link>`,
+  and the plugin inlines sidecar CSS on read (since `srcdoc` iframes
+  can't resolve relative URLs). v1 bundles are refused with a clear
+  error message — regenerate via `npx playwright test` in
+  `packages/test-project/`. Migration guide: `docs/migration-v1-to-v2.md`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, snapshot bundle assembly has been split into a framework-agnostic `@pagemirror/snapshot-core` workspace plus a thin Playwright adapter (Task 15) and the trace-extraction pipeline now produces fully self-contained v2 bundles (Task 15.5), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`); Selenium / Cypress / Appium / Python / JVM adapters (Tasks 16–18, 20) layer on top of the extracted core without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -60,7 +60,7 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 - **A1/A2**: new unit tests in `src/test/kotlin/.../locators/` pass; open a `.py`/`.java` file with locators and confirm gutter badges and caret-driven highlight in the tool window.
 - **B1**: `npm test` in both `snapshot-core` and `playwright-snapshot-saver` passes; no regression in `test-project/` snapshots.
 - **B2/B3**: each new package has its own integration test target green in CI.
-- **C1**: `./gradlew runIdeForUiTests` boots; all 30 existing UI scenarios run; failing tests produce trace bundles; refactored tests contain zero literal XPaths.
+- **C1**: `./gradlew runIdeForUiTests` boots; the existing UI scenarios under `src/uiTest/kotlin/.../ui/tests/` (~40 `@Test` methods across 11 test classes as of 2026-04) run; failing tests produce trace bundles; refactored tests contain zero literal XPaths.
 - **C2**: `./gradlew testReport` produces `build/reports/claude-summary.{json,md}`; CI uploads them as artifacts.
 - **C3**: `./gradlew demoReport -PfeatureName=<tag>` produces a self-contained trace viewer; PR with `demo` label auto-comments a link.
 


### PR DESCRIPTION
## Summary

Audited `CLAUDE.md` against the actual `main` branch and corrected several drifts. No code changes — docs only.

### Mismatches fixed

- **Plugin ID & source package.** `CLAUDE.md` still listed
  `com.example.pagemirror` as the plugin ID and used
  `src/main/kotlin/com/example/pagemirror/` in the source-layout block.
  `plugin.xml` and the actual on-disk layout use
  `com.github.artem.pageobjectplugin` (plugin name "Page Object Helper").
- **Source layout drift.** The block now matches what's on disk:
  - Adds `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`,
    `actions/HighlightCurrentSelectorAction.kt`,
    `widgets/PageMirrorStatusBarWidgetFactory.kt`,
    `resources/messages/`, `resources/demo-viewer/`.
  - Drops `actions/InsertLocatorAction.kt` (never shipped).
- **Test Project Layout.** Now reflects the npm-workspace move to
  `packages/test-project/` and the dashboard snapshots that exist
  alongside login (`.snapshots/dashboard/{initial,ticket-filled}/`).
  Removes the obsolete `utils/save-state.ts` reference.
- **Current State.** Tasks 15 and 15.5 are both merged into `main`
  (commits `949b026`, `4d5a586`, `7b808a0`, `cbc75f1`, …). Their
  status is moved out of "in progress on branch
  claude/check-task-statuses-C7rh9" and into the completed bullets.
- **Quarantine field note.** `ClaudeSummaryModel.kt` now explicitly
  drops the `quarantined` field (per its own header comment); the
  CLAUDE.md note that said it was "tracked as a reporting field"
  is updated to match.
- **Roadmap.** Same Task-15/15.5 status alignment; the stale
  "all 30 existing UI scenarios" wording is loosened to ~40 across
  11 test classes (actual count today).

## Test plan

- [x] Re-read `CLAUDE.md`/`docs/Roadmap.md` end-to-end after edits.
- [x] Cross-check every claim against `plugin.xml`, `src/main/kotlin/com/github/artem/pageobjectplugin/`, `packages/`, and `git log`.
- [ ] Docs-only change; CI's `unit-tests` / `ui-tests` / `playwright-tests` should be unaffected, but let the `test-report` job confirm green before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CboAxfVYzv6FiXHEHsc4Fa)_