### PR TITLE
docs: align CLAUDE.md with current code state on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt          # i18n message bundle accessor
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt    # inlines resources/<sha1>.css sidecars before JCEF
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -100,16 +106,35 @@ src/main/
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
+  tsconfig.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  fixtures/             # Static HTML pages served to the browser under test
+    login.html
+    app.html
+    styles/
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+Snapshots are produced by the workspace package
+`packages/playwright-snapshot-saver` (consumed via
+`file:../playwright-snapshot-saver`); the saver itself depends on
+`@pagemirror/snapshot-core` for HTML assembly. There is no in-tree
+`utils/save-state.ts` — that lived in v1 and was extracted into the
+`playwright-snapshot-saver` npm package.
 
 ## Task Sequence
 
@@ -130,11 +155,15 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+`@pagemirror/snapshot-core` and `playwright-snapshot-saver` npm packages
+are published, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+auto-generated on PRs tagged `demo`. The plugin only loads bundles whose
+`manifest.version == 2`; v1 bundles surface an actionable
+"Outdated bundle" banner inside the Page Mirror tool window pointing at
+`docs/migration-v1-to-v2.md`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -147,28 +176,13 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** new `packages/snapshot-core/` workspace owns the framework-agnostic core (browser collector, HTML assembler, manifest builder, `saveSnapshot` orchestrator). `playwright-snapshot-saver` is now a thin Playwright adapter that depends on `@pagemirror/snapshot-core`. Bundle format bumped to **v2**: `screenshot.<ext>` lives under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused — `model/SnapshotBundle.kt` returns `BundleLoadResult.UnsupportedVersion` and `PageMirrorToolWindow` surfaces the outdated banner. Re-run your snapshot saver to regenerate.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+**In-flight tracks (open / not started):** Task 16 (Python Playwright
+support), Task 17 (Selenium + Cypress adapters), Task 18 (JVM Playwright
+support), Task 20 (Appium / mobile). See `docs/Roadmap.md` for ordering.
 
 ## Working with the Build
 


### PR DESCRIPTION
## Summary

CLAUDE.md drifted from what's actually in `main` after Tasks 15 and 15.5 shipped. This PR realigns it so future Claude Code sessions get an accurate map of the codebase from the start.

## What changed

- **Plugin ID** corrected to `com.github.artem.pageobjectplugin` (was the legacy `com.example.pagemirror` — actual ID in `src/main/resources/META-INF/plugin.xml:2`).
- **Plugin Source Layout** rewritten under `kotlin/com/github/artem/pageobjectplugin/`:
  - Adds `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `resources/messages/PageObjectBundle.properties`.
  - Replaces the never-existed `actions/InsertLocatorAction.kt` with the real `actions/HighlightCurrentSelectorAction.kt`.
- **Test Project Layout** updated to the npm-workspace path `packages/test-project/` with the actual subdirectories (`fixtures/`, `page-objects/{login,dashboard}.page.ts`, `tests/{login,dashboard}.spec.ts`, `tsconfig.json`). Drops the long-gone `utils/save-state.ts` (extracted into `playwright-snapshot-saver` in Task 9). Snapshots show real `login/{initial,error-state}` and `dashboard/{initial,ticket-filled}` directories.
- **Current State** marks Tasks 15 and 15.5 as complete (snapshot-core workspace shipped, trace rendering moved into snapshot-core, v1 bundles surface an outdated-bundle banner). Previous text said Task 15 was "in progress on branch `claude/check-task-statuses-C7rh9`" — that branch merged long ago and the work is on `main`. Adds a short pointer to in-flight tracks (Tasks 16, 17, 18, 20).

No code changes — docs only.

## Test plan

- [ ] CI green on `test-report` job for this branch.
- [ ] Spot-read CLAUDE.md against `src/main/kotlin/com/github/artem/pageobjectplugin/` and `packages/test-project/` to confirm every file/path now matches reality.


---
_Generated by [Claude Code](https://claude.ai/code/session_011AaJNmnb6A6mCF12KJBrPZ)_