### PR TITLE
docs: align CLAUDE.md, USE.md, Roadmap with current code on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | Page Object Helper (tool window: "Page Mirror") |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +81,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -99,17 +104,33 @@ src/main/
 
 ## Test Project Layout
 
+The repo uses npm workspaces; the Playwright sample project lives under
+`packages/test-project/` and consumes the local `@pagemirror/snapshot-core`
+and `playwright-snapshot-saver` packages.
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  fixtures/                  # Local HTML/CSS served on localhost during tests
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+`resources/` contains CSS sidecars (`<sha1>.css`) and screenshots when
+the captured page references external stylesheets or assets; bundles
+for pages without external CSS may have no `resources/` directory.
 
 ## Task Sequence
 
@@ -130,11 +151,14 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete and live on `main`.** All plugin
+features ship, both npm packages (`@pagemirror/snapshot-core` and
+`playwright-snapshot-saver`) are publishable from the consolidated
+workspace under `packages/`, plugin v0.5.0 (2026-04-16) is the first
+release that loads only v2 bundles, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
+`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer
+is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +173,16 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete** and
+shipped in plugin 0.5.0. It bumped the snapshot bundle format to v2:
+`screenshot.<ext>` moved under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error banner inside
+the Page Mirror tool window — regenerate via `npx playwright test` in
+`packages/test-project/` (or your own project after upgrading
+`playwright-snapshot-saver` to ≥ 0.7.0). See
+`docs/migration-v1-to-v2.md`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/USE.md
+++ b/USE.md
@@ -146,39 +146,51 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory containing (v2 format — see
+[`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md) for the
+authoritative spec):
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html              # Sanitized DOM, references resources/
+│   │   ├── manifest.json           # Metadata, schema version 2
+│   │   └── resources/              # Optional, present when the page references external CSS/images
+│   │       ├── screenshot.webp     # Visual reference
+│   │       └── <sha1>.css          # Stylesheet sidecars
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
-├── dashboard/
-│   └── main/
-│       └── ...
+│       ├── manifest.json
+│       └── resources/
+└── dashboard/
+    └── main/
+        └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the page DOM, with `<link rel="stylesheet">`
+references pointing into `resources/`. The plugin inlines those
+sidecars on read because the `srcdoc` iframe it renders into has no
+base URL and cannot resolve relative paths.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the
+page at capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "playwright": "1.48.0"
 }
 ```
+
+The plugin only loads bundles whose `manifest.version` is `2`. If you
+upgrade the plugin and see an "outdated bundle" banner, regenerate your
+snapshots — see [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md).
 
 ## Stage 2: Load in the IDE
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete and live on `main`: the plugin works end-to-end for Playwright + TypeScript, both `@pagemirror/snapshot-core` and `playwright-snapshot-saver` are publishable from the consolidated workspace under `packages/`, plugin v0.5.0 (2026-04-16) is the first release that loads only v2 bundles, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). The framework-agnostic `@pagemirror/snapshot-core` package extracted in Task 15 lets Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) layer on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (v2 — `index.html` + `manifest.json` + optional `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`


### PR DESCRIPTION
## Summary

Audited the docs against the actual code on `main` (HEAD `7101aad`) and found a small set of stale references. This PR fixes only those — task docs (which are historical implementation records) are left alone.

### CLAUDE.md
- **Plugin ID** said `com.example.pagemirror`; actual is `com.github.artem.pageobjectplugin` per `META-INF/plugin.xml:2`. Added a row for the human-facing plugin name (Page Object Helper) and tool window name (Page Mirror) since these don't match either.
- **Plugin Source Layout** used the old `kotlin/com/example/pagemirror/` tree and listed `actions/InsertLocatorAction.kt`. Real tree is `kotlin/com/github/artem/pageobjectplugin/` with `HighlightCurrentSelectorAction.kt`. Added missing files: `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`.
- **Test Project Layout** showed `test-project/` with a `utils/save-state.ts`. The repo moved to npm workspaces (`packages/test-project/`), the snapshot saver is now its own npm package, and `utils/save-state.ts` is gone. Updated to reflect the actual layout (`fixtures/`, `dashboard.page.ts`/`spec.ts`) and the optional `resources/` directory that v2 bundles produce.
- **Current State** said Task 15 was "in progress on branch `claude/check-task-statuses-C7rh9`". That branch does not exist; Task 15 and 15.5 are merged on `main` and shipped in plugin 0.5.0 (`CHANGELOG.md`). Reworded.

### USE.md
- The "Snapshot Bundle Format" section still described the **v1** layout (top-level `screenshot.webp`, `"version": 1`). Plugin 0.5.0 only loads v2 bundles. Rewrote to match `docs/snapshot-bundle-spec.md` and added a pointer to `docs/migration-v1-to-v2.md`.

### docs/Roadmap.md
- Both the Context paragraph and the Track A intro cited the v1 bundle shape (top-level `screenshot.webp`) and described Tasks 0–14+19 as the completed surface. Updated to v2 and to include Tasks 15/15.5 in the completed list.

## Test plan

- [ ] CI green on this branch (no code changes — docs only, but the test-report CI gate still runs).
- [x] Verified against real code: `META-INF/plugin.xml`, `src/main/kotlin/com/github/artem/pageobjectplugin/` tree, `packages/test-project/` layout, `packages/snapshot-core/`, `CHANGELOG.md` 0.5.0 entry, `docs/snapshot-bundle-spec.md`.

## Note on duplicates

There are already 14 open PRs on this repo (#37–#51) doing this same audit, one per day. They all target slightly different doc paragraphs and largely overlap. The maintainer may want to either merge one and close the rest, or pause whatever automation is generating them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSivia2FWhSWmjc2EXnQfy)_