### PR TITLE
docs: align CLAUDE.md to current code (plugin id, layout, task statuses)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,21 +101,37 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
+The plugin repo is an npm workspaces monorepo. Snapshot fixtures live
+under `packages/test-project/.snapshots/` and are produced by running
+the Playwright suite there.
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
+  page-objects/{login,dashboard}.page.ts
+  tests/{login,dashboard}.spec.ts
+  fixtures/                # static HTML fixtures served during tests
   .snapshots/login/
     initial/      {index.html, manifest.json, resources/}
     error-state/  {index.html, manifest.json, resources/}
+  .snapshots/dashboard/
+    initial/      {index.html, manifest.json, resources/}
+    ticket-filled/{index.html, manifest.json, resources/}
 ```
+
+The other workspaces are `packages/snapshot-core/` (framework-agnostic
+core, published as `@pagemirror/snapshot-core`) and
+`packages/playwright-snapshot-saver/` (the Playwright adapter, published
+as `playwright-snapshot-saver`).
 
 ## Task Sequence
 
@@ -130,11 +152,14 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the snapshot bundle format is
+v2, `@pagemirror/snapshot-core` is published as a framework-agnostic
+core that also owns trace rendering, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a
+single `claude-summary.{json,md}` bundle, and a Playwright-style trace
+viewer is auto-generated on PRs tagged `demo`. The latest plugin
+release is **0.5.0** (see `CHANGELOG.md`).
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -142,33 +167,14 @@ auto-generated on PRs tagged `demo`.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
-- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
+- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL in `build.gradle.kts`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
-- **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` and `testReport`; `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (`@pagemirror/snapshot-core` extraction):** shipped on `main`. The package is published to npm; live capture moved into `@pagemirror/snapshot-core` and the saver became a thin Playwright adapter. The bundle format bumped to v2: `screenshot.<ext>` moved under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused; the plugin shows an outdated-bundle banner with a link to `docs/migration-v1-to-v2.md`. Regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/UI_tests/test-run-status.md
+++ b/docs/UI_tests/test-run-status.md
@@ -26,7 +26,7 @@
 - **Programmatic IDE actions:** Replaced keyboard-shortcut-driven `openFileInEditor()`, `goToLine()`, and `openToolWindow()` with `callJs` that invokes IDE APIs directly (`FileEditorManager`, `ToolWindowManager`, `LogicalPosition`). Keyboard shortcuts failed because the IDE window could be minimized/iconified.
 - **Window focus:** Added `bringIdeToFront()` that de-iconifies the IDE frame and calls `toFront()`/`requestFocus()`.
 - **Plugin classloader isolation:** Remote Robot's Rhino JS engine runs under the robot-server-plugin classloader, which cannot see plugin classes via `Class.forName()`. All service access uses `PluginManagerCore.getPlugin(pluginId).getPluginClassLoader().loadClass(...)`.
-- **Plugin ID:** Actual ID is `com.github.artem.pageobjectplugin` (not `com.example.pagemirror` from CLAUDE.md).
+- **Plugin ID:** `com.github.artem.pageobjectplugin` (used when looking up the plugin classloader from Remote Robot's Rhino sandbox).
 
 ### PageMirrorToolWindowFixture
 


### PR DESCRIPTION
## Summary

Audit of `main` against `CLAUDE.md` and the rest of `docs/` surfaced a
handful of mismatches that have accumulated since the file was last
touched. This PR realigns the docs with what the code actually does
today (plugin v0.5.0 on `main`).

### `CLAUDE.md`

- **Plugin ID**: `com.example.pagemirror` -> `com.github.artem.pageobjectplugin`
  (matches `plugin.xml` `<id>` and `gradle.properties` `pluginGroup`).
- **Plugin Source Layout**: switch the package path to
  `kotlin/com/github/artem/pageobjectplugin/` and add the files that
  actually ship today but were missing from the tree:
  `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`,
  `actions/HighlightCurrentSelectorAction.kt` (replaces the never-shipped
  `InsertLocatorAction.kt`), `widgets/PageMirrorStatusBarWidgetFactory.kt`,
  `resources/messages/PageObjectBundle.properties`, and
  `resources/demo-viewer/` (Task 19 viewer).
- **Test Project Layout**: move `test-project/` under
  `packages/test-project/` to reflect the npm-workspaces consolidation,
  add the `dashboard` snapshot fixtures, and call out the sibling
  workspaces `packages/snapshot-core/` and
  `packages/playwright-snapshot-saver/`.
- **Current State**: mark **Task 15** + **Task 15.5** as shipped on
  `main` (they had been described as "in progress on branch
  claude/check-task-statuses-C7rh9") and reference the **0.5.0**
  release in `CHANGELOG.md`.

### `docs/UI_tests/test-run-status.md`

- Drop the standalone note pointing out that the actual plugin ID
  diverges from `CLAUDE.md`. Now that `CLAUDE.md` carries the correct
  ID, the note would actively mislead.

## Test plan

- [x] `grep -n "com.example" CLAUDE.md docs/UI_tests/` returns nothing.
- [x] Source files referenced in the new layout exist
      (`ls src/main/kotlin/com/github/artem/pageobjectplugin/...`).
- [x] `packages/test-project/.snapshots/{login,dashboard}/` directories
      match the layout block.
- [x] `cat src/main/resources/META-INF/plugin.xml` confirms the plugin
      ID; `cat CHANGELOG.md` confirms the v0.5.0 release.
- [ ] Doc-only change; CI test-report job should be green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQoWxGZcjvbuCxz7EQnpSA)_