### PR TITLE
docs: align CLAUDE.md, README, USE, Roadmap with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Plugin SDK      | IntelliJ Platform Gradle Plugin 2.x        |
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
-| Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Min Platform    | 2024.3+ (`sinceBuild = "243"`)             |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | Page Object Helper                         |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +81,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/                 # i18n bundles for PageObjectBundle.kt
+    demo-viewer/              # Trace viewer assets (Task 19)
     html/
       page-mirror.html
       js/
@@ -97,19 +104,44 @@ src/main/
         theme.js
 ```
 
+The Java package root is `com.github.artem.pageobjectplugin` (not
+`com.example.pagemirror` — that's a leftover from an earlier draft of
+this doc). The `pluginGroup` in `gradle.properties` and the `<id>` in
+`plugin.xml` both match it.
+
 ## Test Project Layout
 
+The test project is an npm workspace under `packages/test-project/`. It
+exists to feed real `.snapshots/` bundles into the plugin's UI tests
+and the JVM unit tests.
+
 ```
-test-project/
+packages/test-project/
   package.json
+  tsconfig.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  fixtures/                            # static HTML pages served to Playwright
+    login.html
+    app.html
+    styles/
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/
+      initial/        {index.html, manifest.json, resources/}
+      error-state/    {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+Snapshots are produced by the `playwright-snapshot-saver` reporter
+(registered in `playwright.config.ts`) — running `npx playwright test`
+inside `packages/test-project/` regenerates every bundle.
 
 ## Task Sequence
 
@@ -130,11 +162,15 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship,
+the snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` is extracted and consumed via semver, the
+UI test suite runs under a layered Page Object structure, CI aggregates
+test results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
+The snapshot bundle format is **v2** (see "Snapshot Bundle Format"
+above and `docs/snapshot-bundle-spec.md`); v1 bundles are refused with
+a user-visible banner pointing at `docs/migration-v1-to-v2.md`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,17 +185,26 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** — complete and merged.
+The `@pagemirror/snapshot-core` workspace package
+(`packages/snapshot-core/`) owns bundle assembly: the browser-side
+collector, the Node-side HTML assembler, the manifest builder, and the
+`saveSnapshot(adapter, options)` orchestration. The
+`playwright-snapshot-saver` package now ships only Playwright-specific
+glue (`playwright-adapter.ts`, `reporter.ts`, `snapshot-marker.ts`,
+`extractor.ts`, `sources/`) and depends on `@pagemirror/snapshot-core`
+via semver (`^0.1.0`). Task 15 also bumped the bundle format to **v2**:
+`screenshot.<ext>` moves under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`. The
+`PageMirrorToolWindowFactory` surfaces an outdated-bundle banner above
+the iframe when the discovery scanner finds v1 directories.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+complete. `@pagemirror/snapshot-core` now owns trace rendering behind
+a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
 renderer, inline, extract, runtime-script, content-type}.ts`). The
 Playwright package (`packages/playwright-snapshot-saver/src/trace/
 playwright-backend.ts`) reshapes `TraceLoader.storage()` into that

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 
 - **Page Mirror panel** — displays captured page snapshots in an embedded browser (JCEF), docked to the right side of the IDE.
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
-- **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
+- **Element picker** — toggle inspect mode (`Alt+Shift+I`) and click any element in the snapshot to generate a locator and insert it at your cursor.
+- **Highlight current selector** — `Alt+Shift+H` re-runs the highlight for the locator on the current line (handy after the snapshot reloads or you scroll the iframe).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight All** — the **Show All** toolbar button in the Page Mirror panel highlights every locator in the current file at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -146,39 +146,58 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Snapshots use the **v2** bundle layout. Each snapshot directory is
+self-contained and references every external resource through a
+`resources/` sidecar:
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html              # Sanitized DOM, references resources/<file>
+│   │   ├── manifest.json           # Metadata (schema version 2)
+│   │   └── resources/
+│   │       ├── screenshot.webp     # Visual reference
+│   │       └── <sha1>.css          # Stylesheet sidecars referenced by <link>
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
-├── dashboard/
-│   └── main/
-│       └── ...
+│       ├── manifest.json
+│       └── resources/
+└── dashboard/
+    └── main/
+        └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the sanitized page DOM. Stylesheets are kept as
+external `<link rel="stylesheet" href="resources/<sha1>.css">` sidecars
+(or inline `<style>` blocks); the plugin inlines sidecar CSS on the
+Kotlin side before handing the HTML to the JCEF `srcdoc` iframe, since
+`srcdoc` has no base URL and cannot resolve relative paths.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the
+page at capture time. v1 placed this at the top level; v2 moved it
+under `resources/` so all captured assets live in one flat directory.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "playwright": "1.58.2",
+  "userAgent": "Mozilla/5.0 ..."
 }
 ```
+
+`version` is the **schema** version, not a write counter — it's always
+`2` for bundles produced by current savers. The plugin refuses to load
+bundles whose `manifest.version` is anything else, surfacing an
+outdated-bundle banner that links to
+[`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md). See
+[`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md) for the
+authoritative spec.
 
 ## Stage 2: Load in the IDE
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships v2 snapshot bundles from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` is extracted (with `playwright-snapshot-saver` depending on it via semver) and owns trace rendering + resource inlining, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (the saver and trace backend live in `playwright-snapshot-saver`). With B1 (snapshot-core) done, Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can now be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,12 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` *(done)*
+- **B1.5. Trace rendering + resource inlining in core** — `task-15.5-trace-resource-inlining.md` *(done)*
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1/B1.5 were the refactor enabler; B2 and B3 layer new adapters on top of the extracted core (`extractFromBackend` + `PageAdapter`).
 
 ---
 
@@ -43,14 +44,16 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+Items marked *(done)* shipped on `main`. Remaining work, in priority order:
+
+1. *(done)* **C1a** — unblock UI tests (everything else benefits).
+2. *(done)* **C1b–d** — reliability, diagnostics, page-object refactor.
+3. *(done)* **C2** — get the Claude inner loop solid before adding scope.
+4. *(done)* **B1 / B1.5** — refactor snapshot core + own trace rendering (enables B2/B3).
+5. *(done)* **C3** — demo reporting (Task 19, shipped early; PRs tagged `demo` auto-render a trace viewer).
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

Documentation-only PR. Several docs on `main` had drifted from the post-Task-15/15.5 state of the code; this commit makes them describe what's actually shipped without touching plugin behavior.

### What was wrong

- **`CLAUDE.md`** advertised a plugin ID of `com.example.pagemirror` and a source tree under `com/example/pagemirror/`. The actual ID (in `gradle.properties` and `plugin.xml`) is `com.github.artem.pageobjectplugin`, and sources live under `com/github/artem/pageobjectplugin/`.
- The Plugin Source Layout listed `actions/InsertLocatorAction.kt` (never shipped under that name) and was missing real files: `HighlightCurrentSelectorAction.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `services/SnapshotHtmlResolver.kt`, `PageObjectBundle.kt`, `resources/messages/`, `resources/demo-viewer/`.
- The Test Project Layout described `test-project/` with a single `login` snapshot and `utils/save-state.ts`. The real layout is `packages/test-project/` (npm workspace) with both `login` and `dashboard` page objects/specs and snapshots in `initial` + `error-state` / `initial` + `ticket-filled` states.
- The Current State / Task 15 sections claimed Task 15 was *in progress on `claude/check-task-statuses-C7rh9`*. Task 15 + 15.5 are merged into `main`, the v2 bundle format is live, `@pagemirror/snapshot-core` is published, and `playwright-snapshot-saver` consumes it via semver.
- **`README.md`** advertised `Alt+Shift+H` as "Highlight All". The shortcut actually invokes `HighlightCurrentSelectorAction`, which re-highlights the locator on the current line. The real "Highlight All" feature is the **Show All** toolbar button in the Page Mirror panel.
- **`USE.md`** still showed a v1 bundle layout (`screenshot.webp` at top level, `"version": 1`). The plugin refuses anything but `manifest.version == 2` and now expects every captured asset under `resources/`.
- **`docs/Roadmap.md`** said Tasks 0–14 + 19 are complete and listed B1 / B1.5 as future work. Both are shipped.

### What this PR changes

- `CLAUDE.md` — fix plugin ID, package paths, source layout, test-project layout, and Current State (Task 15 / 15.5 marked complete with notes on what landed).
- `README.md` — split the "Highlight All" bullet into two: keyboard `Alt+Shift+H` for current-line highlight, **Show All** toolbar button for whole-file highlight.
- `USE.md` — rewrite the Snapshot Bundle Format section for v2, with screenshot + CSS sidecars under `resources/`, `manifest.version: 2`, and pointers to `docs/snapshot-bundle-spec.md` + `docs/migration-v1-to-v2.md`.
- `docs/Roadmap.md` — mark B1 / B1.5 as done in Track B, mark the corresponding execution-order entries done, and update the prose context paragraph.

No code changes; the plugin, npm packages, and CI are untouched.

## Test plan

- [ ] `git diff origin/main..HEAD -- '*.md'` — confirm only the four doc files changed.
- [ ] Spot-check that the layout described in `CLAUDE.md` matches `find src/main/kotlin -name '*.kt'` and `ls packages/test-project/.snapshots/*/`.
- [ ] Open the Page Mirror tool window in a sandboxed IDE: confirm the **Show All** toolbar button matches the README description, and `Alt+Shift+H` highlights only the current line's locator.
- [ ] Open a v2 bundle's `manifest.json` and confirm the schema in `USE.md` matches.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TEmXJGsKSF9rWdwEbVoFTg)_