### PR TITLE
docs: align CLAUDE.md, USE.md, Roadmap.md with current main state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,18 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,20 +100,27 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
+  page-objects/{login,dashboard}.page.ts
+  tests/{login,dashboard}.spec.ts
+  fixtures/{app.html, login.html, styles/}
   .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
+    initial/      {index.html, manifest.json}
     error-state/  {index.html, manifest.json, resources/}
+  .snapshots/dashboard/
+    initial/        {index.html, manifest.json, resources/}
+    ticket-filled/  {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,45 +142,31 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship on
+`main`, both `playwright-snapshot-saver` and `@pagemirror/snapshot-core`
+are published to npm, the v2 snapshot bundle format is the only
+supported format, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
+`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer
+is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
   Highlight All, and the `playwright-snapshot-saver` npm package.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
-- **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
+- **Task 11 (Manifest fixes):** timestamp, change detection, version field.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
 - **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
-- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
+- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** the `@Quarantine` annotation was never shipped, and `ClaudeSummaryModel.kt` intentionally omits a `quarantined` field rather than carrying a perpetually-empty placeholder (see the model docstring).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped on `main`. Snapshot bundle format is now **v2**: `screenshot.<ext>` lives under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a user-visible banner — regenerate via `npx playwright test` in `packages/test-project/` or follow `docs/migration-v1-to-v2.md`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** shipped on `main`. `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+Tasks 16 (Python Playwright), 17 (Selenium/Cypress adapters), 18 (JVM
+Playwright), and 20 (Appium) remain on the roadmap — see `docs/Roadmap.md`.
 
 ## Working with the Build
 

--- a/USE.md
+++ b/USE.md
@@ -65,14 +65,14 @@ npx playwright test
 | Option | Default | Description |
 |--------|---------|-------------|
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace screencast |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp`. Off by default since trace screencast frames are low-fidelity and often blank. |
 | `manifest` | `true` | Generate `manifest.json` with metadata |
 
 ```typescript
 reporter: [
   ['playwright-snapshot-saver/reporter', {
     outputDir: './my-snapshots',
-    screenshot: false,
+    screenshot: true,
   }]
 ]
 ```
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false },  // or `false` to skip
   manifest: true,
 });
 ```
@@ -98,8 +98,8 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` or `jpeg` |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Screenshot options. Pass `false` to skip. |
+| `screenshot.format` | `png` | `png` or `webp`. Live capture supports `png` only — `webp` throws. For webp bytes, use the trace-extraction path. |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -139,12 +139,12 @@ const result = await extractSnapshots({
 |--------|---------|-------------|
 | `source` | (required) | Report directory, trace ZIP path, or URL |
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp` (off by default since 0.6.0) |
 | `manifest` | `true` | Generate `manifest.json` |
 | `filter.page` | — | Only extract this page |
 | `filter.state` | — | Only extract this state |
 
-## Snapshot Bundle Format
+## Snapshot Bundle Format (v2)
 
 Each snapshot is a directory containing:
 
@@ -152,33 +152,51 @@ Each snapshot is a directory containing:
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html              # Sanitized DOM referencing resources/
+│   │   ├── manifest.json           # Metadata, schema version 2
+│   │   └── resources/
+│   │       ├── screenshot.webp     # Visual reference (optional)
+│   │       └── <sha1>.css          # Stylesheet sidecars
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
+│           ├── screenshot.webp
+│           └── <sha1>.css
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the sanitized page DOM. CSS is referenced as
+`<link rel="stylesheet" href="resources/<sha1>.css">` sidecars rather
+than inlined. The plugin inlines those sidecars into `<style>` blocks
+on read because `<iframe srcdoc>` cannot resolve relative URLs.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the
+page at capture time.
+
+**`resources/<sha1>.css`** — one file per stylesheet, named by a
+16-hex-char prefix of `sha1(css_source)` so identical stylesheets across
+snapshots de-duplicate naturally.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "userAgent": "Mozilla/5.0 ...",
+  "playwright": "1.58.0"
 }
 ```
+
+The plugin refuses to load bundles whose `manifest.version` is anything
+other than `2`. See [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md)
+for the migration guide and [`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md)
+for the authoritative spec.
 
 ## Stage 2: Load in the IDE
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, both `playwright-snapshot-saver` and `@pagemirror/snapshot-core` are published to npm and ship snapshots in the v2 bundle format from real Playwright runs (live capture and trace extraction), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) on the IDE side. With `@pagemirror/snapshot-core` extracted (Task 15) and trace rendering owned by core (Task 15.5), Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top by implementing the `PageAdapter` and/or `TraceBackend` interfaces without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same v2 on-disk bundle format (`index.html` + `manifest.json` + `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`


### PR DESCRIPTION
## Summary

Audit of `main` against the project docs surfaced several stale claims. This PR updates the three docs that were out of sync without touching any code.

### `CLAUDE.md`
- **Plugin ID** corrected to `com.github.artem.pageobjectplugin` (was `com.example.pagemirror`, which never matched `plugin.xml` or `gradle.properties`).
- **Plugin Source Layout** repointed to the real package path `com/github/artem/pageobjectplugin/` and updated to list the files that actually ship: `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `actions/HighlightCurrentSelectorAction.kt` (replacing the never-shipped `InsertLocatorAction.kt`), `widgets/PageMirrorStatusBarWidgetFactory.kt`, `resources/messages/PageObjectBundle.properties`, and `resources/demo-viewer/`.
- **Test Project Layout** repointed to `packages/test-project/`, removed the non-existent `utils/save-state.ts`, added the `dashboard` page-object/spec/snapshots and the `fixtures/` directory.
- **Current State**: Tasks 15 and 15.5 are now reflected as shipped on `main` (not in-progress on a feature branch). Task 13b bullet corrected to match `ClaudeSummaryModel.kt`'s actual decision (no `quarantined` field).

### `USE.md`
- **Snapshot Bundle Format** rewritten for v2: `resources/` subdirectory, CSS sidecars (`resources/<sha1>.css`), screenshot moved under `resources/`, `manifest.version = 2`, plus a pointer to the migration guide and authoritative spec.
- **Reporter / extract / `saveSnapshot` option tables** updated to match the shipped API: `screenshot` defaults to `false` in the reporter and extractor (since 0.6.0); `saveSnapshot` uses `ScreenshotOptions` (`{ format, fullPage }`) with no `enabled` field; `format` is `png|webp` (live capture is `png` only).

### `docs/Roadmap.md`
- Context bumped to "Tasks 0–15.5 plus 19 are complete" and rephrased to describe the shipped `@pagemirror/snapshot-core` + `TraceBackend` factoring instead of presenting Task 15 as upcoming.
- Track A bundle-format reference now matches v2 (`index.html` + `manifest.json` + `resources/`) instead of the old top-level layout.

## Test plan

- [x] `git diff` reviewed line by line — only the three doc files change, no code touched.
- [x] Cross-checked every replaced fact against the source: `plugin.xml`, `gradle.properties`, `src/main/kotlin/com/github/artem/pageobjectplugin/**`, `packages/test-project/`, `packages/snapshot-core/src/types.ts`, `packages/snapshot-core/src/save-snapshot.ts`, `packages/playwright-snapshot-saver/README.md`, `docs/snapshot-bundle-spec.md`, `docs/migration-v1-to-v2.md`, and `CHANGELOG.md`.
- [x] No code changes ⇒ CI's existing test surfaces (unit, UI, Playwright) should be a no-op signal here; aggregator + dashboard upload are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_017VSbP21cSmV2gPzxpHXPE4)_