### PR TITLE
docs: align CLAUDE.md, README.md, USE.md with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,8 @@
-# Page Mirror — IntelliJ Plugin for Playwright
+# Page Object Helper — IntelliJ Plugin for Playwright
 
 ## What This Project Is
 
-An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool Window (JCEF browser). When a developer places their cursor on a Playwright locator in their TypeScript code, the corresponding element highlights in the snapshot view. Developers can also click elements in the snapshot to generate locator code.
+An IntelliJ plugin (display name **Page Object Helper**, tool window **Page Mirror**) that renders Playwright page snapshots inside a docked Tool Window (JCEF browser). When a developer places their cursor on a Playwright locator in their TypeScript code, the corresponding element highlights in the snapshot view. Developers can also click elements in the snapshot to generate locator code.
 
 ## Project Configuration
 
@@ -12,7 +12,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Tool Window ID  | `Page Mirror`                              |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +81,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,20 +102,31 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
+The fixture project lives under `packages/test-project/` as part of the
+npm workspace (alongside `packages/snapshot-core/` and
+`packages/playwright-snapshot-saver/`).
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
+  page-objects/
+  tests/
+  fixtures/
   .snapshots/login/
     initial/      {index.html, manifest.json, resources/}
     error-state/  {index.html, manifest.json, resources/}
+  .snapshots/dashboard/
+    initial/      {index.html, manifest.json, resources/}
+    ticket-filled/ {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,15 +148,16 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published on top of a framework-agnostic
+core, the UI test suite runs under a layered Page Object structure, CI
+aggregates test results into a single `claude-summary.{json,md}` bundle,
+and a Playwright-style trace viewer is auto-generated on PRs tagged
+`demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
-  Highlight All, and the `playwright-snapshot-saver` npm package.
+  Highlight All plumbing, and the `playwright-snapshot-saver` npm package.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
@@ -147,28 +166,31 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped. The
+  framework-agnostic core lives in `packages/snapshot-core/` (published
+  as `@pagemirror/snapshot-core@0.1.0`); `packages/playwright-snapshot-saver/`
+  (v0.7.0) is now a thin Playwright adapter that depends on it via
+  semver. The snapshot bundle format was bumped to **v2**: `screenshot.<ext>`
+  moved under `resources/`, CSS is written as `resources/<sha1>.css`
+  sidecars referenced by `<link>`, and the plugin inlines sidecar CSS
+  on read (since `srcdoc` iframes can't resolve relative URLs). The
+  tool window renders an in-app banner directing users to
+  `docs/migration-v1-to-v2.md` when v1 bundles are detected; the plugin
+  refuses to load anything whose `manifest.version` is neither `2` nor
+  absent. Regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 
@@ -276,10 +298,10 @@ The layout was overhauled in Task 13 — follow these rules.
   idempotent. Tests should always be in working shape — fix flakiness,
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
-  Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  Page/Flow example. `tests/SettingsUiTest.kt` is the canonical example
+  for tests that compose `SettingsChangeFlow` and is enabled — it
+  exercises UT-21 to UT-25 against `PageMirrorConfigurable`'s
+  accessible-name-tagged fields.
 
 ## Report Dashboard Access
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 
 - **Page Mirror panel** — displays captured page snapshots in an embedded browser (JCEF), docked to the right side of the IDE.
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
-- **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
+- **Element picker** — toggle inspect mode (`Alt+Shift+I`) and click any element in the snapshot to generate a locator and insert it into your code.
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight current selector** — `Alt+Shift+H` re-highlights the locator on the current line in the snapshot (useful after the cursor-driven highlight has been dismissed).
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -99,7 +99,7 @@ await saveSnapshot(page, {
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
 | `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` or `jpeg` |
+| `screenshot.format` | `png` | `png` or `webp` |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -146,39 +146,59 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory in the **v2** bundle format. See
+[`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md) for the
+authoritative spec and [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md)
+for the migration guide.
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html                  # Sanitized DOM referencing resources/
+│   │   ├── manifest.json               # Metadata (schema version 2)
+│   │   └── resources/
+│   │       ├── screenshot.webp         # Visual reference (.webp or .png)
+│   │       └── <sha1>.css              # Stylesheet sidecars
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
+│           └── ...
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — sanitized page DOM. References every stylesheet,
+image, and font via a relative `resources/<filename>` path. The plugin
+inlines sidecar CSS into `<style>` blocks before handing the HTML to
+JCEF, because `<iframe srcdoc>` has no base URL and cannot resolve
+relative paths on its own.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the
+page at capture time.
+
+**`resources/<sha1>.css`** — stylesheet sidecars. Identical stylesheets
+across snapshots de-duplicate naturally because the filename is a
+content hash.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "playwright": "1.48.0"
 }
 ```
+
+The plugin reads `manifest.version` and refuses to load any bundle whose
+version is neither `2` nor absent. v1 bundles trigger an in-app banner
+with a link to the migration guide; regenerate them by re-running your
+Playwright tests with `playwright-snapshot-saver` ≥ 0.7.0.
 
 ## Stage 2: Load in the IDE
 


### PR DESCRIPTION
## Summary

Audit of `main` against the docs found several stale or outright wrong claims. This PR aligns the docs to the code without touching any source.

### CLAUDE.md
- Plugin ID was `com.example.pagemirror`; actual `plugin.xml:2` says `com.github.artem.pageobjectplugin`. Project title updated to **Page Object Helper** (display name) with **Page Mirror** noted as the tool window ID.
- Plugin Source Layout was rooted at `com/example/pagemirror/`; corrected to `com/github/artem/pageobjectplugin/`.
- Plugin Source Layout listed a nonexistent `actions/InsertLocatorAction.kt`. Replaced with the real `HighlightCurrentSelectorAction.kt`.
- Added missing files that ship on `main`: `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `resources/messages/PageObjectBundle.properties`, `resources/demo-viewer/`.
- Test Project Layout moved from `test-project/` (top-level) to `packages/test-project/` (npm workspace). Added `dashboard` snapshots.
- "Current State" said Task 15 was "in progress on branch `claude/check-task-statuses-C7rh9`". On `main`, `packages/snapshot-core/` is published as `@pagemirror/snapshot-core@0.1.0`, `playwright-snapshot-saver@0.7.0` depends on it via semver, and `test-project/.snapshots/` already use the v2 layout — Task 15 is shipped. Promoted Task 15 + 15.5 to the completed list and updated the headline to "Tasks 0–15, 15.5, and 19 are complete."
- Removed the claim that `tests/SettingsUiTest.kt` is `@Disabled` — the file has no `@Disabled` annotation on `main` and runs the UT-21..UT-25 scenarios.

### README.md
- Dropped the "Highlight All — every locator … (`Alt+Shift+H`)" bullet. The `Alt+Shift+H` keystroke in `plugin.xml:46-52` binds `HighlightCurrentSelectorAction`, which highlights only the locator on the current line. There is no user-facing "highlight all" action: `SnapshotService.highlightAllLocators()` and `window.highlightAll` exist as plumbing but no action, button, or shortcut wires them up. Replaced with an accurate "Highlight current selector" bullet.

### USE.md
- "Snapshot Bundle Format" still showed v1: `screenshot.webp` at the bundle top level and `manifest.json` with `"version": 1`. Plugin and saver have been on v2 since the 0.5.0 release (see CHANGELOG and `docs/snapshot-bundle-spec.md`). Updated the directory diagram to show the `resources/` subdirectory, bumped the manifest example to `"version": 2`, added pointers to `docs/snapshot-bundle-spec.md` and `docs/migration-v1-to-v2.md`, and noted the in-app v1 banner.
- `screenshot.format` table claimed `png` or `jpeg`; the real types in `packages/snapshot-core/src/types.ts:65` are `'webp' | 'png'`. Fixed.

## Test plan

- [x] `git diff` reviewed — only docs touched; no source changes.
- [x] Cross-checked every doc claim against `plugin.xml`, the Kotlin source under `src/main/kotlin/com/github/artem/pageobjectplugin/`, the npm workspace under `packages/`, and the existing `docs/snapshot-bundle-spec.md`.
- [x] Confirmed Task 15 is shipped: `packages/snapshot-core/package.json` ships `@pagemirror/snapshot-core@0.1.0` and `packages/playwright-snapshot-saver/package.json` declares `"@pagemirror/snapshot-core": "^0.1.0"` as a runtime dep.
- [x] Confirmed `SettingsUiTest` is enabled (no `@Disabled` annotation in `src/uiTest/kotlin/.../ui/tests/SettingsUiTest.kt`).
- [x] Confirmed `Alt+Shift+H` is `HighlightCurrentSelectorAction`, not a "highlight all" action.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XKWS1yPfzgsnhm6rmMgCVp)_