### PR TITLE
docs: align CLAUDE.md, USE.md, Roadmap.md with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,18 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,6 +100,10 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
@@ -130,45 +139,35 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete and shipped on `main`.** All
+plugin features ship, the snapshot saver npm package is published, the
+framework-agnostic `@pagemirror/snapshot-core` package owns HTML
+assembly + manifest building + trace rendering, the UI test suite runs
+under a layered Page Object structure, CI aggregates test results into
+a single `claude-summary.{json,md}` bundle, and a Playwright-style
+trace viewer is auto-generated on PRs tagged `demo`. Plugin release
+**0.5.0** (2026-04-16) shipped strict v2 bundle support and the
+outdated-bundle banner — see `CHANGELOG.md`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
   Highlight All, and the `playwright-snapshot-saver` npm package.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
-- **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
+- **Task 11 (Manifest fixes):** timestamp, change detection, version increment. Superseded by Task 15 (the v1 monotonic write counter is gone — `manifest.version` is strictly the schema version `2`).
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
 - **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (`@pagemirror/snapshot-core` extraction):** `packages/snapshot-core/` ships HTML assembly, manifest building, and the v2 bundle format (`screenshot.<ext>` moved under `resources/`, CSS written as `resources/<sha1>.css` sidecars referenced by `<link>`, plugin inlines sidecars on read via `services/SnapshotHtmlResolver.kt`). v1 bundles are refused with a clear error message and the tool window surfaces an outdated-bundle banner pointing at `docs/migration-v1-to-v2.md`. Plugin gate lives in `model/SnapshotBundle.kt` (`SUPPORTED_BUNDLE_VERSION = 2`).
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` now owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+**Next up (not yet started):** Tasks 16 (Python Playwright support),
+17 (Selenium + Cypress adapters via `TraceBackend`), 18 (JVM Playwright
+support), and 20 (Appium / mobile). See `docs/Roadmap.md` for the full
+sequencing.
 
 ## Working with the Build
 

--- a/USE.md
+++ b/USE.md
@@ -65,14 +65,14 @@ npx playwright test
 | Option | Default | Description |
 |--------|---------|-------------|
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace screencast |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp`. Off by default since trace screencast frames are low-fidelity and frequently blank. |
 | `manifest` | `true` | Generate `manifest.json` with metadata |
 
 ```typescript
 reporter: [
   ['playwright-snapshot-saver/reporter', {
     outputDir: './my-snapshots',
-    screenshot: false,
+    screenshot: true,
   }]
 ]
 ```
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false },
   manifest: true,
 });
 ```
@@ -98,8 +98,7 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` or `jpeg` |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Object to enable, `false` to skip. The Playwright adapter only supports `format: 'png'`; use the trace-extraction path for `webp`. |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -146,39 +145,59 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory in the **v2 bundle layout**. Top-level files
+are just `index.html` and `manifest.json`; everything they reference
+(CSS sidecars, screenshots, fonts, images) lives under `resources/`:
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html          # Sanitized DOM referencing resources/
+│   │   ├── manifest.json       # Schema version 2 — URL, viewport, timestamp, driver
+│   │   └── resources/
+│   │       ├── screenshot.webp # Visual reference (or .png)
+│   │       └── <sha1>.css      # Stylesheet sidecars referenced by <link> tags
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
+│           ├── screenshot.webp
+│           └── <sha1>.css
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — sanitized page DOM. Every `<link rel="stylesheet">`
+points at a `resources/<sha1>.css` sidecar; the plugin inlines those
+sidecars into `<style>` blocks before handing the HTML to the JCEF
+`srcdoc` iframe (the iframe's `about:srcdoc` base URL cannot resolve
+relative filesystem paths). Trace-extracted bundles also reference
+fonts, images, and SVG sprites under `resources/` — every external URL
+is rewritten to a sidecar so the bundle is fully self-contained.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the
+page at capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "playwright": "1.58.0",
+  "userAgent": "Mozilla/5.0 ..."
 }
 ```
+
+`manifest.version` is the **schema** version and is always `2`. The
+plugin refuses to load any bundle with a different version and surfaces
+an outdated-bundle banner inside the tool window pointing at the
+migration guide. See [`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md)
+for the authoritative format spec.
 
 ## Stage 2: Load in the IDE
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,23 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete and shipped on `main`: the
+plugin works end-to-end for Playwright + TypeScript, the
+`playwright-snapshot-saver` npm package ships snapshots from real
+Playwright runs in the v2 bundle format, the framework-agnostic
+`@pagemirror/snapshot-core` package owns HTML assembly + manifest
+building + trace rendering (so future Selenium / Cypress / Appium /
+Python / JVM adapters can plug in via `PageAdapter` and `TraceBackend`
+without duplicating bundle logic), the settings UI is on Kotlin UI
+DSL v2, the UI test suite runs under a layered Page Object structure
+with polling / retry / trace-bundle diagnostics, CI aggregates unit +
+UI + Playwright results into a single `claude-summary.{json,md}`
+bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo`
+auto-render a Playwright-style trace viewer. The remaining
+architectural coupling is on the IDE side — locator extraction is
+regex-based and currently scoped to TypeScript, so Tasks 16 (Python),
+17 (Selenium/Cypress), 18 (JVM), and 20 (Appium / mobile) layer
+language- and driver-specific adapters on top of the now-stable core.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,7 +37,7 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ shipped (plus Task 15.5: trace rendering + resource inlining moved into `@pagemirror/snapshot-core`).
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
@@ -43,25 +59,23 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
-9. **B3** — mobile/Appium (largest unknowns).
+C1, C2, B1, and C3 are done and shipped on `main`. The remaining
+language- and driver-adapter tracks can proceed in roughly this order:
+
+1. **A1** — Python Playwright (highest user demand for language expansion).
+2. **B2** — Selenium/Cypress adapters.
+3. **A2** — Java/Kotlin Playwright.
+4. **B3** — mobile/Appium (largest unknowns).
 
 ---
 
 ## High-Level Verification
 
 - **A1/A2**: new unit tests in `src/test/kotlin/.../locators/` pass; open a `.py`/`.java` file with locators and confirm gutter badges and caret-driven highlight in the tool window.
-- **B1**: `npm test` in both `snapshot-core` and `playwright-snapshot-saver` passes; no regression in `test-project/` snapshots.
+- **B1** *(shipped)*: `npm test` in both `snapshot-core` and `playwright-snapshot-saver` passes; no regression in `packages/test-project/` snapshots.
 - **B2/B3**: each new package has its own integration test target green in CI.
-- **C1**: `./gradlew runIdeForUiTests` boots; all 30 existing UI scenarios run; failing tests produce trace bundles; refactored tests contain zero literal XPaths.
-- **C2**: `./gradlew testReport` produces `build/reports/claude-summary.{json,md}`; CI uploads them as artifacts.
-- **C3**: `./gradlew demoReport -PfeatureName=<tag>` produces a self-contained trace viewer; PR with `demo` label auto-comments a link.
+- **C1** *(shipped)*: `./gradlew runIdeForUiTests` boots; existing UI scenarios run; failing tests produce trace bundles; refactored tests contain zero literal XPaths.
+- **C2** *(shipped)*: `./gradlew testReport` produces `build/reports/claude-summary.{json,md}`; CI uploads them as artifacts and to `reports.artemon.cloud`.
+- **C3** *(shipped)*: `./gradlew demoReport -PfeatureName=<tag>` produces a self-contained trace viewer; PR with `demo` label auto-comments a link.
 
 See each task doc for its own detailed verification.


### PR DESCRIPTION
## Summary

Audited the top-level docs against `main` (`7101aad`) and fixed three drifted files. No code changes — docs only.

### CLAUDE.md
- **Plugin ID**: was `com.example.pagemirror`; the real id wired through `src/main/resources/META-INF/plugin.xml` and the Kotlin package tree is `com.github.artem.pageobjectplugin`.
- **Plugin Source Layout**: listed a non-existent `InsertLocatorAction.kt`, missed `HighlightCurrentSelectorAction.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `PageObjectBundle.kt`, the `messages/` resource bundle, and the `demo-viewer/` resources Task 19 ships.
- **Current State**: still flagged Task 15 as in-progress on a feature branch, even though it shipped in plugin 0.5.0 (`CHANGELOG.md` 2026-04-16) and Task 15.5 followed it. Updated the headline + per-task notes and added a "Next up" pointer to the unstarted language / driver adapter tasks.

### USE.md
- **Snapshot Bundle Format diagram**: showed the v1 layout (top-level `screenshot.webp`, no `resources/`, `manifest.version: 1`, CSS inlined as `<style>`). The plugin only loads v2 bundles and refuses everything else (`SnapshotBundle.kt:16` — `SUPPORTED_BUNDLE_VERSION = 2`).
- **Reporter options**: `screenshot` default flipped to `false` in saver 0.6.0 — the table still claimed `true`.
- **`saveSnapshot` options**: referenced `screenshot.enabled` (not in the public API) and listed `jpeg` as a valid format. Real types are `'png' | 'webp'`, and the Playwright adapter only accepts `png` (`playwright-adapter.ts` throws otherwise).

### Roadmap.md
- Context paragraph, Suggested Execution Order, and Verification list all treated B1 / C1 / C2 / C3 as future work, but they're all shipped. Marked them as done and trimmed the remaining order to the actually-unfinished tracks (A1, A2, B2, B3).

## Test plan

- [x] `git diff main` shows only `CLAUDE.md`, `USE.md`, `docs/Roadmap.md` modified.
- [x] Updated package id matches `plugin.xml`.
- [x] Updated source layout matches `find src/main/kotlin -name '*.kt'` + `find src/main/resources -type f`.
- [x] Updated bundle layout matches `docs/snapshot-bundle-spec.md` (the authoritative spec, already correct).
- [x] Updated reporter / `saveSnapshot` defaults match `packages/playwright-snapshot-saver/README.md` and `packages/snapshot-core/src/save-snapshot.ts`.


---
_Generated by [Claude Code](https://claude.ai/code/session_019HfYd5iyHxRV7qrt3YLPUm)_