### PR TITLE
docs: align CLAUDE.md, README, USE.md, Roadmap with shipped state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | "Page Object Helper" (tool window: "Page Mirror") |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt   # Inlines v2 sidecar CSS into srcdoc HTML
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +81,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
-      ToggleInspectAction.kt
+      ToggleInspectAction.kt              # Bound to Alt+Shift+I
+      HighlightCurrentSelectorAction.kt   # Bound to Alt+Shift+H (current locator only)
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,7 +102,16 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/                # Per-PR Playwright-style trace viewer (Task 19)
+      index.html
+      app.js
+      styles.css
 ```
+
+The "Highlight All / Show All" feature is exposed via the **Show All**
+toolbar button in the Page Mirror tool window — it has no keyboard
+shortcut. `HighlightCurrentSelectorAction` (Alt+Shift+H) only highlights
+the locator on the caret line.
 
 ## Test Project Layout
 
@@ -130,11 +146,14 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship,
+the snapshot saver npm package is published, `@pagemirror/snapshot-core`
+is extracted and ships v2 bundles (released as plugin `0.5.0`,
+`playwright-snapshot-saver@0.7.0`, `@pagemirror/snapshot-core@0.1.0`),
+the UI test suite runs under a layered Page Object structure, CI
+aggregates test results into a single `claude-summary.{json,md}` bundle,
+and a Playwright-style trace viewer is auto-generated on PRs tagged
+`demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +168,19 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped in plugin
+`0.5.0` (see `CHANGELOG.md`). The snapshot bundle format is now v2:
+`screenshot.<ext>` lives under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>` (live capture
+truncates the sha1 to 16 hex chars; trace-extracted bundles use the
+full 40-hex sha1 from the playwright trace store), and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error and the
+Page Mirror tool window surfaces an "outdated bundle" banner —
+regenerate via `npx playwright test` in `packages/test-project/`. The
+loader entry point is `SnapshotBundle.load(dir)` returning
+`BundleLoadResult.{Loaded, UnsupportedVersion, Empty}`; the supported
+schema integer lives in the `SUPPORTED_BUNDLE_VERSION` constant.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight current selector** — `Alt+Shift+H` manually highlights the locator on the caret line in the snapshot.
+- **Highlight All** — highlight every locator in the current file at once with color-coded overlays and duplicate detection. Triggered via the **Show All** button in the Page Mirror tool window toolbar.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -146,37 +146,50 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory containing the **v2** layout:
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html              # Sanitized DOM, references resources/
+│   │   ├── manifest.json           # Metadata (version=2, viewport, timestamp, ...)
+│   │   └── resources/
+│   │       ├── screenshot.webp     # Visual reference
+│   │       └── <sha1>.css          # Stylesheet sidecars referenced by <link>
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
+│           ├── screenshot.webp
+│           └── <sha1>.css
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the full page DOM. External stylesheets are written
+as sidecar files under `resources/<sha1>.css` and referenced by `<link
+rel="stylesheet" href="resources/...">`. The plugin inlines those
+sidecars into `<style>` blocks before handing the HTML to JCEF, because
+`<iframe srcdoc>` has no base URL and cannot resolve relative paths.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the
+page at capture time. Lives under `resources/` in v2 (top-level in v1).
 
-**`manifest.json`** — metadata about the snapshot:
+**`manifest.json`** — metadata about the snapshot. The `version` field
+is the **schema** version and is always `2`. The plugin refuses to load
+bundles with any other declared version and shows an outdated-bundle
+banner. See [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md)
+for upgrading older bundles.
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
-  "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "timestamp": "2026-04-15T21:07:18.357Z",
+  "playwright": "1.58.2"
 }
 ```
 
@@ -224,6 +237,17 @@ The editor gutter shows a badge next to each locator with the number of matching
 - **0** — no match (broken selector)
 - **2+** — multiple matches (ambiguous selector)
 
+### Highlight current selector (`Alt+Shift+H`)
+
+Press `Alt+Shift+H` in the editor to manually highlight the locator on the
+caret line in the snapshot. This mirrors the cursor-driven highlight
+above, but is useful when a hook or another caret listener has cleared
+the highlight and you want to bring it back without moving the caret.
+
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror tool window toolbar to
+highlight every locator in the current file on the snapshot at once.
+Color-coded overlays distinguish different locators. Duplicate and
+overlapping selectors are flagged with visual badges. There is no
+keyboard shortcut for Highlight All — toggle it from the tool window.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,22 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for
+Playwright + TypeScript, the `playwright-snapshot-saver` npm package
+ships snapshots from real Playwright runs, the framework-agnostic
+`@pagemirror/snapshot-core` package owns bundle assembly + trace
+rendering (released as plugin `0.5.0` /
+`playwright-snapshot-saver@0.7.0` / `@pagemirror/snapshot-core@0.1.0`,
+introducing the v2 bundle layout), the settings UI is on Kotlin UI
+DSL v2, the UI test suite runs under a layered Page Object structure
+with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI +
+Playwright results into a single `claude-summary.{json,md}` bundle
+consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render
+a Playwright-style trace viewer. The current architecture is still
+tightly coupled to TypeScript on the IDE side (regex-based locator
+extraction). With B1 (Task 15) shipped, B2/B3 (Selenium / Cypress /
+Appium adapters) and A1/A2 (Python / JVM Playwright adapters) can be
+layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +25,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same v2 on-disk bundle format (`index.html` + `manifest.json` + `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
@@ -21,11 +36,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` *(shipped in plugin 0.5.0; bundle format v2 + companion `task-15.5-trace-resource-inlining.md` for self-contained trace bundles)*
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 is a pure refactor and is now released; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -119,5 +119,5 @@ initial/
 
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
-- Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
+- Plugin loader: `SnapshotBundle.kt` — `SnapshotBundle.load(dir)` returns `BundleLoadResult.{Loaded, UnsupportedVersion, Empty}`; the supported integer is the `SUPPORTED_BUNDLE_VERSION` constant
 - Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant


### PR DESCRIPTION
## Summary

Bringing the top-level docs back in sync with what's actually shipped on `main` (`7101aad`, plugin `0.5.0`). No code changes — docs only.

### CLAUDE.md
- Plugin ID was stuck on the placeholder `com.example.pagemirror`; the real id (`plugin.xml:2`, `gradle.properties`) is `com.github.artem.pageobjectplugin`. Added a row noting that the plugin is named "Page Object Helper" while the tool window is "Page Mirror".
- "Plugin Source Layout" tree pointed at `kotlin/com/example/pagemirror/`. Replaced with the actual `kotlin/com/github/artem/pageobjectplugin/` tree, added missing files/dirs that exist today: `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `actions/HighlightCurrentSelectorAction.kt` (replacing the never-existed `InsertLocatorAction.kt`), `resources/messages/PageObjectBundle.properties`, `resources/demo-viewer/`. Annotated the two keyboard-bound actions.
- Added a one-line note that "Highlight All / Show All" lives only on the toolbar button (no shortcut).
- "Current State" said Tasks 0–14 + 19 done and Task 15 was "in progress on branch `claude/check-task-statuses-C7rh9`". Task 15 / 15.5 actually shipped in plugin `0.5.0` (`CHANGELOG.md`, `packages/snapshot-core@0.1.0`, `playwright-snapshot-saver@0.7.0`, v2 bundles in `packages/test-project/.snapshots/`). Updated the rollup line and the Task 15 callout. Mentioned the actual loader entry point (`SnapshotBundle.load(dir)` / `SUPPORTED_BUNDLE_VERSION`) and the live-vs-trace sha1-length distinction (16 hex for live capture, 40 hex for trace-extracted).

### USE.md
- "Snapshot Bundle Format" section was still showing the v1 layout: top-level `screenshot.webp`, no `resources/` dir, `manifest.version: 1`, "all external stylesheets inlined as `<style>` tags". Replaced with the v2 layout (sidecar CSS under `resources/`, screenshot under `resources/`, `version: 2`) and noted that the plugin inlines sidecars on read.
- "Highlight All" instructions claimed `Alt+Shift+H` triggers it. The shortcut is bound to `HighlightCurrentSelectorAction` (one-locator highlight) — Highlight All has no shortcut and is the toolbar **Show All** button. Split into two subsections.

### README.md
- Same `Alt+Shift+H` mistake — corrected the feature bullets so the shortcut is attached to "Highlight current selector", and "Highlight All" is described as the **Show All** toolbar button.

### docs/Roadmap.md
- Context paragraph said "Tasks 0–14 plus 19 are complete" and "Task 15 below extracts ..."; updated to reflect that B1 (Task 15 + 15.5) shipped in plugin 0.5.0.
- "Track A" footer mentioned the v1 layout (`screenshot.webp` at top level); switched to the v2 layout.
- Marked B1 as shipped in the Track B list.

### docs/migration-v1-to-v2.md
- "Reference" section pointed at `SnapshotBundle.kt:isSupportedVersion()`, which doesn't exist. The actual entry point is `SnapshotBundle.load(dir) -> BundleLoadResult.{Loaded, UnsupportedVersion, Empty}` and the supported integer is the `SUPPORTED_BUNDLE_VERSION` constant (`SnapshotBundle.kt:16`).

## Test plan
- [ ] Verify on the rendered PR diff that no code paths were touched (only `*.md`).
- [ ] Spot-check the new CLAUDE.md "Plugin Source Layout" tree against `src/main/kotlin/com/github/artem/pageobjectplugin/` and `src/main/resources/`.
- [ ] Confirm the v2 manifest example in `USE.md` matches `packages/test-project/.snapshots/*/manifest.json`.
- [ ] Confirm `Alt+Shift+H` is still bound to `HighlightCurrentSelectorAction` in `src/main/resources/META-INF/plugin.xml:46-52` (the user-facing docs now match this binding).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VygAGhFPa3Ucz7dJ9o3unG)_