### PR TITLE
docs: align CLAUDE.md, README, USE with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +80,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -95,20 +99,35 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  fixtures/
+    app.html
+    login.html
+    styles/
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,11 +149,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published alongside `@pagemirror/snapshot-core`
+on the v2 bundle format, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single `claude-summary.{json,md}`
+bundle, and a Playwright-style trace viewer is auto-generated on PRs tagged
+`demo`. Plugin release `0.5.0` (2026-04-16) shipped the v2 bundle reader and
+the outdated-bundle banner — see `CHANGELOG.md`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +170,17 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped. The
+  `packages/snapshot-core/` workspace (`@pagemirror/snapshot-core@0.1.0`)
+  owns the framework-agnostic core; `playwright-snapshot-saver@0.7.0` is
+  now a thin Playwright adapter on top of it. This release also bumped
+  the snapshot bundle format to v2: `screenshot.<ext>` moves under
+  `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+  referenced by `<link>`, and the plugin inlines sidecar CSS on read
+  (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are
+  refused with a user-visible outdated-bundle banner pointing at
+  `docs/migration-v1-to-v2.md` — regenerate via `npx playwright test` in
+  `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight current selector** — highlight the locator under the cursor on demand (`Alt+Shift+H`).
+- **Highlight All** — toolbar **Show All** button highlights every locator in the current file at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -146,39 +146,56 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory in the v2 bundle layout. See
+[`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md) for the
+authoritative spec.
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html              # Sanitized DOM referencing resources/
+│   │   ├── manifest.json           # Metadata (schema version 2)
+│   │   └── resources/
+│   │       ├── screenshot.webp     # Visual reference (optional)
+│   │       └── <sha1>.css          # CSS sidecars referenced by <link>
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — sanitized DOM. Every `<link>`, `<img>`, and CSS
+`url(...)` reference points at a sidecar under `resources/`. The plugin
+inlines those CSS sidecars into `<style>` blocks before rendering because
+`<iframe srcdoc>` cannot resolve relative filesystem paths.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — visual reference of the page
+at capture time.
+
+**`resources/<sha1>.css`** — stylesheet sidecars; the filename is a
+SHA-1 prefix so identical stylesheets across snapshots de-duplicate.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "playwright": "1.58.0"
 }
 ```
+
+The plugin refuses to load bundles whose `manifest.version` is not `2`
+(or absent) and renders an outdated-bundle banner pointing at
+[`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md). Regenerate
+v1 bundles by re-running `npx playwright test` with
+`playwright-snapshot-saver` ≥ 0.7.0.
 
 ## Stage 2: Load in the IDE
 
@@ -224,6 +241,16 @@ The editor gutter shows a badge next to each locator with the number of matching
 - **0** — no match (broken selector)
 - **2+** — multiple matches (ambiguous selector)
 
+### Highlight current selector
+
+Press `Alt+Shift+H` to highlight the locator at the current cursor
+position in the snapshot. This is the explicit, one-shot version of the
+cursor-driven auto-highlight above.
+
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror toolbar to highlight
+every locator in the current file on the snapshot at once. Color-coded
+overlays distinguish different locators. Duplicate and overlapping
+selectors are flagged with visual badges. Click the button again to clear
+the overlays.


### PR DESCRIPTION
## Summary

The top-level docs had drifted from what the code actually does. This PR
re-aligns them, no code changes.

### CLAUDE.md
- Plugin ID: `com.example.pagemirror` → `com.github.artem.pageobjectplugin`
  (matches `plugin.xml:2` and the Gradle build).
- Kotlin source layout: rooted at `com/github/artem/pageobjectplugin/`,
  with the files that actually exist —
  - rename `actions/InsertLocatorAction.kt` →
    `actions/HighlightCurrentSelectorAction.kt`,
  - add `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`,
    `widgets/PageMirrorStatusBarWidgetFactory.kt`,
  - add `resources/demo-viewer/` (Task 19).
- Test project layout: now under `packages/test-project/`, with the
  `dashboard` page object / spec / snapshots and the `fixtures/`
  directory. Removed the non-existent `utils/save-state.ts`.
- Current State: Task 15 (`@pagemirror/snapshot-core`) is shipped, not
  in progress on `claude/check-task-statuses-C7rh9` — it's released as
  `@pagemirror/snapshot-core@0.1.0` + `playwright-snapshot-saver@0.7.0`
  and the plugin v0.5.0 release notes (CHANGELOG.md) describe the v2
  bundle reader + outdated-bundle banner.

### README.md
- `Alt+Shift+H` is **Highlight Current Selector** (single locator under
  the cursor), not Highlight All. Split into two bullets: the keyboard
  shortcut and the **Show All** toolbar button.

### USE.md
- Snapshot bundle format section was still documenting v1 (top-level
  `screenshot.webp`, `"version": 1`). Replaced with the v2 layout the
  plugin actually consumes — `index.html` + `manifest.json` +
  `resources/` with sidecar CSS + screenshot. Cross-links to
  `docs/snapshot-bundle-spec.md` and `docs/migration-v1-to-v2.md`.
- Same `Alt+Shift+H` fix as README. Added an explicit
  "Highlight current selector" section and a "Highlight All" / Show All
  toolbar section.

## Test plan

- [ ] `CLAUDE.md` Plugin Source Layout matches `find src/main/kotlin -name '*.kt'`.
- [ ] `CLAUDE.md` Test Project Layout matches `packages/test-project/`.
- [ ] `README.md` and `USE.md` shortcut text matches the keybindings in
      `src/main/resources/META-INF/plugin.xml`.
- [ ] `USE.md` Snapshot Bundle Format matches `docs/snapshot-bundle-spec.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HybWmpP1rYoby5syVVwLi5)_