### PR TITLE
docs: align CLAUDE.md and Roadmap with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
+    PageObjectBundle.kt
     PageMirrorToolWindowFactory.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,20 +101,35 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/
+    app.html
+    login.html
+    styles/{reset,layout,theme,components}.css
+  .snapshots/
+    login/
+      initial/        {index.html, manifest.json, resources/}
+      error-state/    {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,11 +151,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+`playwright-snapshot-saver` npm package is published on top of the
+extracted `@pagemirror/snapshot-core`, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+auto-generated on PRs tagged `demo`. The shipped plugin version is
+**v0.5.0** (see `CHANGELOG.md`).
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -142,33 +165,44 @@ auto-generated on PRs tagged `demo`.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
-- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
+- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL in `build.gradle.kts`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
-- **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` and `testReport`; `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`)** — merged. The
+  `packages/snapshot-core/` package owns bundle assembly, manifest
+  generation, save orchestration, and the browser-side collector;
+  `playwright-snapshot-saver` is a thin adapter that depends on
+  `@pagemirror/snapshot-core` via semver. The snapshot bundle format
+  was bumped to v2: `screenshot.<ext>` moved under `resources/`, CSS is
+  written as `resources/<sha1>.css` sidecars referenced by `<link>`,
+  and the plugin inlines sidecar CSS on read (since `srcdoc` iframes
+  can't resolve relative URLs). v1 bundles are refused with a
+  user-visible banner — regenerate via `npx playwright test` in
+  `packages/test-project/`. The v0.5.0 release added the
+  **outdated-bundle banner** that surfaces this state in the tool
+  window with a link to `docs/migration-v1-to-v2.md`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
+  merged. `@pagemirror/snapshot-core` now owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+**Build layout note.** Source packages live under `packages/` as npm
+workspaces (`snapshot-core`, `playwright-snapshot-saver`, `test-project`)
+— there is no top-level `test-project/` directory. The plugin
+itself is a single Kotlin module rooted at the repository root, with
+production code under `src/main/` and the package path
+`com/github/artem/pageobjectplugin/`.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, `@pagemirror/snapshot-core` has been extracted as a framework-agnostic engine, the `playwright-snapshot-saver` npm package depends on it as a thin Playwright adapter and ships snapshots from real Playwright runs, the snapshot bundle format has been bumped to v2 with an outdated-bundle banner shipped in plugin v0.5.0, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) on the IDE side, so language adapters (16–18, 20) and additional driver adapters (17) remain the main expansion vector.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` (and the follow-up `task-15.5-trace-resource-inlining.md`) — **done.** `@pagemirror/snapshot-core` is published and consumed by `playwright-snapshot-saver` via semver.
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B2 and B3 layer new adapters on top of the extracted core by implementing the `TraceBackend` / `PageAdapter` interfaces it exposes.
 
 ---
 
@@ -43,22 +43,21 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
-9. **B3** — mobile/Appium (largest unknowns).
+Done: **C1a–d** (UI test unblock, reliability, diagnostics, page-object refactor), **C2** (CI Claude loop), **B1** (snapshot-core extraction, plus the 15.5 trace-rendering follow-up), and **C3** (feature demo trace viewer, Task 19).
+
+Remaining work, in suggested order:
+
+1. **A1** — Python Playwright (highest user demand for language expansion).
+2. **B2** — Selenium/Cypress adapters.
+3. **A2** — Java/Kotlin Playwright.
+4. **B3** — mobile/Appium (largest unknowns).
 
 ---
 
 ## High-Level Verification
 
 - **A1/A2**: new unit tests in `src/test/kotlin/.../locators/` pass; open a `.py`/`.java` file with locators and confirm gutter badges and caret-driven highlight in the tool window.
-- **B1**: `npm test` in both `snapshot-core` and `playwright-snapshot-saver` passes; no regression in `test-project/` snapshots.
+- **B1**: `npm test` in both `snapshot-core` and `playwright-snapshot-saver` passes; no regression in `packages/test-project/` snapshots.
 - **B2/B3**: each new package has its own integration test target green in CI.
 - **C1**: `./gradlew runIdeForUiTests` boots; all 30 existing UI scenarios run; failing tests produce trace bundles; refactored tests contain zero literal XPaths.
 - **C2**: `./gradlew testReport` produces `build/reports/claude-summary.{json,md}`; CI uploads them as artifacts.


### PR DESCRIPTION
## Summary

While auditing the project, the live reference docs (`CLAUDE.md` and `docs/Roadmap.md`) had drifted from the merged state of `main`. This PR brings them back in sync. No code changes.

### CLAUDE.md
- **Plugin ID / package path**: was `com.example.pagemirror` / `com/example/pagemirror/`; actual is `com.github.artem.pageobjectplugin` (see `src/main/resources/META-INF/plugin.xml` and the actual source tree under `src/main/kotlin/com/github/artem/pageobjectplugin/`).
- **Plugin Source Layout**: added `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `messages/PageObjectBundle.properties`, and `demo-viewer/`; renamed `actions/InsertLocatorAction.kt` (never existed) to the actual `actions/HighlightCurrentSelectorAction.kt`.
- **Test Project Layout**: path is `packages/test-project/`, not top-level `test-project/`; added the `dashboard` page/spec and the `fixtures/` directory.
- **Current State**: Task 15 was described as "in progress on branch claude/check-task-statuses-C7rh9" — both Task 15 (snapshot-core extraction) and Task 15.5 (framework-agnostic trace rendering + resource inlining) are merged. Added a note about the v0.5.0 outdated-bundle banner that shipped on top of them.

### docs/Roadmap.md
- Context paragraph and Track B1 now reflect Tasks 0–15.5 + 19 as complete.
- Suggested Execution Order rewritten: lists what's done and the remaining language/driver adapter work (A1, B2, A2, B3).

## Test plan
- [x] Verified plugin ID against `src/main/resources/META-INF/plugin.xml`
- [x] Cross-checked source layout against `find src/main -type f`
- [x] Cross-checked test-project layout against `packages/test-project/`
- [x] Verified Task 15 / 15.5 merge state via `git log --oneline` (commits `7b808a0`, `d5a6286`, `cbc75f1` already on `main`)
- [x] No functional code changes — docs only

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1tL63JyneMXavyQvizJh9)_