### PR TITLE
docs: align CLAUDE.md, USE.md, Roadmap.md with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | Page Object Helper (tool window: "Page Mirror") |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt           # i18n message bundle accessor
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt     # inlines sidecar CSS for srcdoc iframe
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +81,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties  # i18n strings
     html/
       page-mirror.html
       js/
@@ -95,20 +102,36 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/                   # Task 19 self-contained trace viewer
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/                 # static HTML served by Playwright tests
+    login.html
+    app.html
+    styles/
+  .snapshots/
+    login/
+      initial/       {index.html, manifest.json, resources/}
+      error-state/   {index.html, manifest.json, resources/}
+    dashboard/
+      initial/       {index.html, manifest.json, resources/}
+      ticket-filled/ {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,9 +153,11 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete and shipped.** The plugin is at
+**v0.5.0** (see `CHANGELOG.md`). All plugin features ship, the npm
+workspace publishes both `@pagemirror/snapshot-core` (v0.1.0) and
+`playwright-snapshot-saver` (v0.7.0), the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -142,33 +167,44 @@ auto-generated on PRs tagged `demo`.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
-- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
+- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:114`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
-- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
+- **Task 15 (Extract `@pagemirror/snapshot-core`)** — **shipped in v0.5.0**.
+  The snapshot bundle format is now v2: `screenshot.<ext>` lives under
+  `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+  referenced by `<link>`, and the plugin inlines sidecar CSS on read
+  (since `srcdoc` iframes can't resolve relative URLs).
+  `services/SnapshotHtmlResolver.kt` performs the inlining. v1 bundles
+  are refused with a user-visible outdated-bundle banner that links to
+  `docs/migration-v1-to-v2.md` — regenerate via `npx playwright test`
+  in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`,
+  `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` +
+  `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and
+  `.github/workflows/demo.yml` together render a self-contained trace
+  viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Roadmap (not yet started).** Task docs exist in `docs/tasks/` for
+upcoming framework adapters that will reuse the `TraceBackend` surface
+from Task 15.5:
 
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+- **Task 16:** Python Playwright support.
+- **Task 17:** Selenium / Cypress adapters.
+- **Task 18:** JVM Playwright support.
+- **Task 20:** Appium / mobile support.
 
 ## Working with the Build
 

--- a/USE.md
+++ b/USE.md
@@ -146,39 +146,53 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory in the **v2** bundle layout:
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html              # Sanitized DOM referencing resources/
+│   │   ├── manifest.json           # Metadata, "version": 2
+│   │   └── resources/
+│   │       ├── screenshot.webp     # Visual reference (or .png)
+│   │       └── <sha1>.css          # Stylesheet sidecars (one per <link>)
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
+│           ├── screenshot.webp
+│           └── <sha1>.css
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the sanitized page DOM. External stylesheets are written as
+`resources/<sha1>.css` sidecars referenced by `<link>` tags; the plugin
+inlines them on read because `<iframe srcdoc>` cannot resolve relative URLs.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the page
+at capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "playwright": "1.58.0"
 }
 ```
+
+Bundles produced by `playwright-snapshot-saver` `< 0.7.0` use the v1
+layout (screenshot at top level, CSS inlined directly). The plugin now
+refuses v1 bundles with an outdated-bundle banner — regenerate with the
+latest saver. See [docs/migration-v1-to-v2.md](docs/migration-v1-to-v2.md)
+and [docs/snapshot-bundle-spec.md](docs/snapshot-bundle-spec.md) for
+details.
 
 ## Stage 2: Load in the IDE
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,21 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15 (including 15.5) plus 19 are complete and shipped in
+**v0.5.0**: the plugin works end-to-end for Playwright + TypeScript, the
+`playwright-snapshot-saver` (v0.7.0) and `@pagemirror/snapshot-core`
+(v0.1.0) npm packages ship snapshots from real Playwright runs in the
+**v2 bundle format**, the settings UI is on Kotlin UI DSL v2, the UI
+test suite runs under a layered Page Object structure with
+polling/retry/trace-bundle diagnostics, CI aggregates unit + UI +
+Playwright results into a single `claude-summary.{json,md}` bundle
+consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render
+a Playwright-style trace viewer. The current architecture is still
+tightly coupled to TypeScript (regex-based locator extraction); the
+framework-agnostic `@pagemirror/snapshot-core` extraction (Task 15) and
+its `TraceBackend` interface (Task 15.5) now make it possible to layer
+Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) on top
+without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +24,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk **v2** bundle format (`index.html` + `manifest.json` + `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`


### PR DESCRIPTION
## Summary

Audited `main` against the docs and brought the three primary living
documents back into line with the v0.5.0 codebase. Task / spec files
under `docs/tasks/` are left as historical specs.

### `CLAUDE.md`
- **Plugin ID:** `com.example.pagemirror` → `com.github.artem.pageobjectplugin` (matches `plugin.xml`).
- **Plugin Source Layout:** updated the package path, added `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `resources/messages/`, and `resources/demo-viewer/`. Replaced the non-existent `InsertLocatorAction.kt` with the real `HighlightCurrentSelectorAction.kt`.
- **Test Project Layout:** corrected the root from `test-project/` to `packages/test-project/`, added the `dashboard` snapshot tree and the `fixtures/` directory (the previous `utils/save-state.ts` no longer exists).
- **Current State:** Task 15 and Task 15.5 are now reflected as shipped in **v0.5.0** (CHANGELOG entry), no longer “in progress on branch `…`”. Added a short roadmap stub for Tasks 16/17/18/20.
- Updated the `build.gradle.kts` line reference for `runIdeForUiTests` to match current line numbers.

### `USE.md`
- Snapshot bundle format example bumped from **v1** (top-level `screenshot.webp`, inline CSS, `manifest.version = 1`) to **v2** (`resources/` subdir with sidecar CSS and screenshot, `manifest.version = 2`).
- Added a paragraph + links to `docs/migration-v1-to-v2.md` and `docs/snapshot-bundle-spec.md` for users still on `playwright-snapshot-saver < 0.7.0`.

### `docs/Roadmap.md`
- “Tasks 0–14 plus 19” → “Tasks 0–15 (including 15.5) plus 19” shipped in v0.5.0, and noted both `@pagemirror/snapshot-core` and `playwright-snapshot-saver` are published.
- On-disk bundle format reference updated from v1 to v2.

## Test plan

- [x] Verified plugin ID against `src/main/resources/META-INF/plugin.xml`.
- [x] Verified source-layout claims against `src/main/kotlin/com/github/artem/pageobjectplugin/`.
- [x] Verified test-project layout against `packages/test-project/`.
- [x] Verified Task 15 status against `CHANGELOG.md` (`v0.5.0`) and `packages/snapshot-core/package.json`.
- [x] Cross-checked snapshot bundle wording against `docs/snapshot-bundle-spec.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EaeNi9Womvm2vqAMvkq4i4)_