### PR TITLE
docs: align CLAUDE.md, README, USE, and Roadmap with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,21 +101,37 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/             # Static viewer template emitted by demoReport
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
+The test project is an npm workspace under `packages/test-project/`.
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
   page-objects/login.page.ts
+  page-objects/dashboard.page.ts
   tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tests/dashboard.spec.ts
+  fixtures/                       # static HTML/CSS served by webServer
+  .snapshots/
+    login/
+      initial/      {index.html, manifest.json}
+      error-state/  {index.html, manifest.json}
+    dashboard/
+      initial/      {index.html, manifest.json, resources/}
+      ticket-filled/{index.html, manifest.json, resources/}
 ```
+
+Bundles MAY omit `resources/` when no sidecar resources were captured
+(e.g. the fixture pages used by `login`); the plugin treats a missing
+`resources/` directory as "no sidecars to inline".
 
 ## Task Sequence
 
@@ -130,11 +152,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` package is published and consumed by the
+Playwright adapter, the snapshot bundle format is on v2, the UI test
+suite runs under a layered Page Object structure, CI aggregates test
+results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +173,13 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped and bumped
+the snapshot bundle format to v2: `screenshot.<ext>` moves under
+`resources/`, CSS is written as `resources/<sha1>.css` sidecars
+referenced by `<link>`, and the plugin inlines sidecar CSS on read
+(since `srcdoc` iframes can't resolve relative URLs). v1 bundles are
+refused with a clear error message — regenerate via `npx playwright
+test` in `packages/test-project/`. See `docs/migration-v1-to-v2.md`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a
@@ -277,9 +301,7 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow`.
 
 ## Report Dashboard Access
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 
 - **Page Mirror panel** — displays captured page snapshots in an embedded browser (JCEF), docked to the right side of the IDE.
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
-- **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
+- **Element picker** — toggle inspect mode (`Alt+Shift+I`), then click any element in the snapshot to generate a locator and insert it into your code.
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight current selector** — re-highlight the locator on the current editor line with `Alt+Shift+H`, useful when the snapshot has scrolled away from the cursor's match.
+- **Highlight All** — the **Show All** button in the Page Mirror toolbar highlights every locator in the current file at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -146,39 +146,56 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a v2 bundle directory. Stylesheets, fonts, images, and the
+screenshot all live under a `resources/` sidecar directory referenced from
+`index.html`:
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html          # Sanitized DOM referencing resources/
+│   │   ├── manifest.json       # Metadata (URL, viewport, timestamp, version: 2)
+│   │   └── resources/
+│   │       ├── screenshot.webp # Visual reference (optional)
+│   │       └── <sha1>.css      # Stylesheet sidecars (one per unique CSS)
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
-├── dashboard/
-│   └── main/
-│       └── ...
+│       ├── manifest.json
+│       └── resources/
+└── dashboard/
+    └── main/
+        └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the full page DOM. External stylesheets are emitted as
+`<link rel="stylesheet" href="resources/<sha1>.css">`; the plugin inlines
+the sidecar CSS into `<style>` blocks before handing the HTML to the JCEF
+`srcdoc` iframe (which has no base URL and can't resolve relative paths).
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — visual reference of the page
+at capture time. Optional.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "playwright": "1.48.0"
 }
 ```
+
+`version` is a schema version and is always `2` for current bundles. The
+plugin refuses to load bundles whose `manifest.version` is anything other
+than `2`; regenerate v1 bundles by re-running your tests against
+`playwright-snapshot-saver` ≥ 0.7.0 (see
+[`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md)).
+
+See [`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md) for the
+authoritative spec.
 
 ## Stage 2: Load in the IDE
 
@@ -224,6 +241,10 @@ The editor gutter shows a badge next to each locator with the number of matching
 - **0** — no match (broken selector)
 - **2+** — multiple matches (ambiguous selector)
 
+### Highlight current selector
+
+Press `Alt+Shift+H` to re-highlight the locator on the current editor line. Useful when the snapshot has scrolled away from the cursor's match or the highlight cleared.
+
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror tool window toolbar to highlight every locator in the current file at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges. Click **Show All** again to clear.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs against the v2 bundle format, the framework-agnostic `@pagemirror/snapshot-core` package owns HTML assembly + manifest building + trace rendering, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) on the IDE side, but the snapshot core is now framework-agnostic, so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same v2 on-disk bundle format (`index.html` + `manifest.json` + `resources/` sidecar directory) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`


### PR DESCRIPTION
## Summary

Brings the four top-level docs in sync with what's actually in the tree on `main` today. No code or test changes — pure doc refresh.

### CLAUDE.md
- Plugin ID `com.example.pagemirror` → `com.github.artem.pageobjectplugin` (matches `META-INF/plugin.xml`).
- Source layout reflects the real package path `com/github/artem/pageobjectplugin/`. Adds `widgets/PageMirrorStatusBarWidgetFactory.kt`, `services/SnapshotHtmlResolver.kt`, `actions/HighlightCurrentSelectorAction.kt`, `PageObjectBundle.kt`, `messages/PageObjectBundle.properties`, and `demo-viewer/`. Drops the stale `actions/InsertLocatorAction.kt` entry.
- Test project layout moved under `packages/test-project/` (npm workspace), with `dashboard.page.ts` / `dashboard.spec.ts` and the `fixtures/` static webserver root added. Notes that `resources/` may be absent when a bundle has no sidecars.
- Marks Tasks 15 and 15.5 as shipped (they were already merged but CLAUDE.md still said "in progress on branch claude/check-task-statuses-C7rh9").
- Removes the "SettingsUiTest is `@Disabled`" claim — it isn't.

### README.md
- `Alt+Shift+H` is bound to `HighlightCurrentSelectorAction` (single locator), not "Highlight All". The Show All toolbar button is what triggers highlight-all.
- Split the bullet into "Highlight current selector" (the actual shortcut) and "Highlight All" (the Show All button).

### USE.md
- Replaced the v1 "Snapshot Bundle Format" example (top-level `screenshot.webp`, `manifest.version=1`) with the v2 layout (`resources/` sidecar + `manifest.version=2`); linked the migration guide and authoritative spec. The plugin has refused v1 bundles since v0.5.0 — the doc was actively misleading.
- Split the "Highlight All" walk-through to match the README change.

### docs/Roadmap.md
- "On-disk bundle format" description bumped from v1 (`index.html + screenshot.webp + manifest.json`) to v2 (`+ resources/`).
- Completion summary updated to "Tasks 0–15.5 plus 19" so future Track A/B/C planning starts from the correct baseline.

## Test plan

- [x] Cross-checked every layout entry against `find src/main/kotlin` and `find packages/test-project/.snapshots`.
- [x] Confirmed plugin id via `META-INF/plugin.xml`.
- [x] Confirmed `Alt+Shift+H` is bound to `HighlightCurrentSelectorAction` in `plugin.xml`; "Show All" is the button wired up in `PageMirrorToolWindowFactory.kt`.
- [x] Confirmed `SUPPORTED_BUNDLE_VERSION = 2` in `SnapshotBundle.kt` and `MANIFEST_VERSION` used by `packages/snapshot-core/src/manifest.ts`.
- [x] Confirmed `SettingsUiTest.kt` has no `@Disabled`.
- No runtime behavior changed; nothing to run in CI beyond the doc rendering itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKDTiyF9VpepNPFGcr4pTg)_