### PR TITLE
docs: align CLAUDE.md, README.md, USE.md with current main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,20 +101,33 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/                # Task 19 trace-viewer assets (index.html, app.js, styles.css)
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/                       # Static HTML+CSS pages served to Playwright
+    login.html
+    app.html
+    styles/{reset,layout,theme,components}.css
+  .snapshots/
+    login/
+      initial/      {index.html, manifest.json, resources/}
+      error-state/  {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,8 +149,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` package is published alongside it, snapshot
+bundles are on format **v2**, the UI test suite runs under a layered
 Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
@@ -149,13 +170,17 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** — shipped in plugin
+release **0.5.0** (2026-04-16). `packages/snapshot-core/` is now a
+publishable workspace (`@pagemirror/snapshot-core`) consumed by
+`packages/playwright-snapshot-saver/` via semver. The snapshot bundle
+format is bumped to v2: `screenshot.<ext>` lives under `resources/`,
+CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`,
+and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't
+resolve relative URLs). v1 bundles are refused with a clear error message
+and the tool window shows an outdated-bundle banner with a link to
+`docs/migration-v1-to-v2.md` — regenerate via `npx playwright test` in
+`packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight All** — the **Show All** button in the tool window toolbar highlights every locator in the current file at once with color-coded overlays and duplicate detection. `Alt+Shift+H` re-highlights just the locator on the current line.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -146,39 +146,53 @@ const result = await extractSnapshots({
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory containing (v2 layout — see
+[docs/snapshot-bundle-spec.md](docs/snapshot-bundle-spec.md) for the
+authoritative spec):
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html          # Sanitized DOM referencing resources/
+│   │   ├── manifest.json       # Metadata (URL, viewport, timestamp, version: 2)
+│   │   └── resources/
+│   │       ├── screenshot.webp # Visual reference (or .png)
+│   │       └── <sha1>.css      # Stylesheet sidecars referenced by <link>
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
-├── dashboard/
-│   └── main/
-│       └── ...
+│       ├── manifest.json
+│       └── resources/
+└── dashboard/
+    └── main/
+        └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the full page DOM. External stylesheets are written
+as `resources/<sha1>.css` sidecars referenced via `<link>`. The plugin
+inlines them into `<style>` blocks before rendering because `iframe
+srcdoc` cannot resolve relative paths.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`/`.jpeg`) — a visual
+reference of the page at capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "playwright": "1.48.0"
 }
 ```
+
+The plugin refuses to load bundles whose `manifest.version` is not `2`
+and shows an outdated-bundle banner pointing to
+[docs/migration-v1-to-v2.md](docs/migration-v1-to-v2.md). Re-run
+`npx playwright test` after upgrading
+`playwright-snapshot-saver` to `>= 0.7.0` to regenerate v2 bundles.
 
 ## Stage 2: Load in the IDE
 
@@ -226,4 +240,12 @@ The editor gutter shows a badge next to each locator with the number of matching
 
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror tool window toolbar to
+highlight every locator in the current file on the snapshot at once.
+Color-coded overlays distinguish different locators. Duplicate and
+overlapping selectors are flagged with visual badges. Click **Show All**
+again to clear.
+
+`Alt+Shift+H` is a separate shortcut that re-highlights just the locator
+on the current line — useful when the caret-driven highlight has gone
+stale (e.g. after editing the locator string).


### PR DESCRIPTION
## Summary

Audited the three top-level documentation files against the actual main-branch code and fixed every factual mismatch I found. Starting point was a fresh worktree of `main` so the audit reflected shipped state, not anything in flight.

## Changes

**CLAUDE.md**
- Plugin ID and Kotlin source path updated from the placeholder `com.example.pagemirror` to the real `com.github.artem.pageobjectplugin` (`plugin.xml` is the source of truth).
- Source-layout tree now matches the actual files: adds `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `resources/messages/`, and `resources/demo-viewer/`; replaces the non-existent `InsertLocatorAction.kt` with the real `HighlightCurrentSelectorAction.kt`.
- Test-project tree relocated under `packages/test-project/`, drops the non-existent `utils/save-state.ts`, and adds `dashboard.page.ts` / `dashboard.spec.ts` plus the `fixtures/` directory that `playwright.config.ts` actually serves.
- Current State section: Task 15 and Task 15.5 are no longer "in progress on a feature branch" — they shipped in plugin `0.5.0` (commits `cbc75f1`, `7b808a0`; CHANGELOG `0.5.0`). Updated heading from "Tasks 0–14 and 19" to "Tasks 0–15.5 and 19".

**README.md**
- Highlight All entry: `Alt+Shift+H` actually binds to `HighlightCurrentSelectorAction` (current-line locator), not "Show All". The Highlight All feature is the toolbar **Show All** button with no keyboard shortcut. Rephrased to match what `plugin.xml` and `PageMirrorToolWindowFactory.kt` actually do.

**USE.md**
- Snapshot bundle layout and manifest example bumped from v1 to v2: screenshot lives under `resources/`, CSS is written as `<sha1>.css` sidecars instead of inlined `<style>` tags, and `manifest.version` is `2`. Added a pointer to `docs/migration-v1-to-v2.md` for the outdated-bundle banner.
- Highlight All section corrected the same way as README.md.

## Test plan

- [x] Diff CLAUDE.md "Plugin ID" against `src/main/resources/META-INF/plugin.xml` — match.
- [x] Diff CLAUDE.md source layout against `find src/main/kotlin -name '*.kt'` — match.
- [x] Diff CLAUDE.md test-project layout against `packages/test-project/` — match.
- [x] Diff CLAUDE.md manifest example against `packages/test-project/.snapshots/login/initial/manifest.json` (`"version": 2`) — match.
- [x] Verify `Alt+Shift+H` keymap entry in `plugin.xml:51` maps to `HighlightCurrentSelectorAction`, not a "Show All" action — confirmed.
- [x] Verify USE.md no longer claims `"version": 1` for the manifest and no longer shows screenshot at bundle top level — confirmed.

Docs-only change; no code touched, so CI risk is limited to whatever the `test-report` job runs against doc-only diffs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01R2o4dbhYhonBHqnzkWFwaP)_