### PR TITLE
docs: align CLAUDE.md and USE.md with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,18 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,21 +100,35 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/                # Task 19 trace viewer assets
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/                          # Static HTML pages for offline test runs
+  .snapshots/
+    login/
+      initial/      {index.html, manifest.json, resources/}
+      error-state/  {index.html, manifest.json, resources/}
+    dashboard/
+      initial/      {index.html, manifest.json, resources/}
+      ticket-filled/ {index.html, manifest.json, resources/}
 ```
+
+The test-project lives inside the monorepo's `packages/*` workspace
+(see `package.json`), alongside `snapshot-core` and
+`playwright-snapshot-saver`.
 
 ## Task Sequence
 
@@ -130,11 +149,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published on a v2 bundle format with a
+framework-agnostic `@pagemirror/snapshot-core` package underneath it, the
+UI test suite runs under a layered Page Object structure, CI aggregates
+test results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,13 +169,18 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete** and
+merged to `main`. The snapshot bundle format is now v2:
+`screenshot.<ext>` lives under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). Bundles whose `manifest.version` is not `2` are refused
+with a user-visible banner that links to
+`docs/migration-v1-to-v2.md` — regenerate via `npx playwright test` in
+`packages/test-project/`. The plugin (`v0.5.0`) and the npm packages
+(`@pagemirror/snapshot-core@0.1.0`, `playwright-snapshot-saver@0.7.0`)
+ship the v2 format end-to-end; the monorepo uses npm workspaces under
+`packages/*` and the saver consumes snapshot-core via semver.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/USE.md
+++ b/USE.md
@@ -152,33 +152,44 @@ Each snapshot is a directory containing:
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html          # Sanitized DOM referencing resources/
+│   │   ├── manifest.json       # Metadata (URL, viewport, timestamp), version=2
+│   │   └── resources/          # Stylesheets, screenshot, fonts, images
+│   │       ├── screenshot.webp
+│   │       └── <sha1>.css
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
-├── dashboard/
-│   └── main/
-│       └── ...
+│       ├── manifest.json
+│       └── resources/
+└── dashboard/
+    └── main/
+        └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the sanitized page DOM. External stylesheets are
+shipped as `resources/<sha1>.css` sidecars referenced by `<link>` tags;
+the plugin inlines them into `<style>` blocks at load time because the
+`<iframe srcdoc>` it renders into has no base URL.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference
+of the page at capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "userAgent": "Mozilla/5.0 ...",
+  "playwright": "1.58.0"
 }
 ```
+
+See [`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md) for the
+full schema and [`docs/migration-v1-to-v2.md`](docs/migration-v1-to-v2.md)
+if you have stale v1 bundles that no longer load.
 
 ## Stage 2: Load in the IDE
 


### PR DESCRIPTION
## Summary

Audited `CLAUDE.md` and `USE.md` against the actual code on `main` and
fixed the drift. No code or behavior changes — docs only.

### CLAUDE.md

- **Plugin ID corrected.** Was `com.example.pagemirror`, real id
  registered in `src/main/resources/META-INF/plugin.xml` is
  `com.github.artem.pageobjectplugin`. Source layout path updated to
  match (`com/github/artem/pageobjectplugin/`).
- **Source layout fixed.** Removed nonexistent `InsertLocatorAction.kt`;
  added `HighlightCurrentSelectorAction.kt` (its actual replacement),
  `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`,
  `widgets/PageMirrorStatusBarWidgetFactory.kt`,
  `resources/messages/PageObjectBundle.properties`, and
  `resources/demo-viewer/`.
- **Test project layout fixed.** Was at top-level `test-project/`;
  after the npm workspaces consolidation it lives at
  `packages/test-project/`. Dropped the gone `utils/save-state.ts`,
  added `fixtures/` and the `dashboard.page.ts` / `dashboard.spec.ts`
  pair alongside login.
- **Current State refreshed.** Task 15 and 15.5 were described as "in
  progress on branch claude/check-task-statuses-C7rh9"; both are
  merged (commits 949b026 → cbc75f1). Updated to reflect
  `@pagemirror/snapshot-core@0.1.0` and
  `playwright-snapshot-saver@0.7.0` shipping the v2 format
  end-to-end via npm workspaces.

### USE.md

- Bundle diagram updated to v2 layout (`resources/` subdir with
  `screenshot.*` and `<sha1>.css` sidecars; no more screenshot at the
  top level).
- `index.html` description changed from "with inlined CSS" to reflect
  the v2 contract: sidecar `<link>`s in the bundle, inlining happens
  in the plugin on read because `<iframe srcdoc>` has no base URL.
- Manifest example bumped to `"version": 2` with the current
  `userAgent` field and a pointer to `docs/snapshot-bundle-spec.md` +
  `docs/migration-v1-to-v2.md`.

`README.md`, `docs/snapshot-bundle-spec.md`, `docs/migration-v1-to-v2.md`
and `docs/Roadmap.md` were already consistent with current code — left
untouched. Historical task docs under `docs/tasks/` were also left
alone since they are records of past work and reference paths as they
were at the time.

## Test plan

- [x] `grep -n "com.example.pagemirror\|com/example/pagemirror\|InsertLocatorAction\|claude/check-task-statuses" CLAUDE.md USE.md README.md` returns nothing.
- [x] Source layout in CLAUDE.md matches `find src/main/kotlin -name "*.kt"`.
- [x] Test project layout in CLAUDE.md matches `ls packages/test-project/`.
- [x] USE.md manifest example matches a real bundle manifest in `packages/test-project/.snapshots/login/initial/manifest.json` (`"version": 2`).


---
_Generated by [Claude Code](https://claude.ai/code/session_017ekBUaHpymDgqDafDmnBXp)_