### PR TITLE
docs: align CLAUDE.md and Roadmap with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +80,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -100,15 +104,27 @@ src/main/
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
+  tsconfig.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/         # static HTML/CSS served to Playwright during snapshot capture
+    app.html
+    login.html
+    styles/
+  .snapshots/
+    login/
+      initial/         {index.html, manifest.json, resources/}
+      error-state/     {index.html, manifest.json, resources/}
+    dashboard/
+      initial/         {index.html, manifest.json, resources/}
+      ticket-filled/   {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,8 +146,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` package is extracted and publishable, the
+snapshot bundle format is on v2, the UI test suite runs under a layered
 Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
@@ -149,13 +167,15 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete** and
+shipped on `main`. The `@pagemirror/snapshot-core` package lives under
+`packages/snapshot-core/` and `playwright-snapshot-saver` consumes it via
+semver (see commit `cbc75f1`). The snapshot bundle format is bumped to
+v2: `screenshot.<ext>` moves under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a
@@ -276,10 +296,11 @@ The layout was overhauled in Task 13 — follow these rules.
   idempotent. Tests should always be in working shape — fix flakiness,
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
-  Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  Page/Flow example. `tests/SettingsUiTest.kt` is the canonical example
+  for tests that compose `SettingsChangeFlow` + `PluginSettingsPage`;
+  it was re-enabled after `PageMirrorConfigurable` gained explicit
+  accessible names on its testable fields and the settings locators were
+  rewritten to key off those names instead of UI DSL class-name quirks.
 
 ## Report Dashboard Access
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `manifest.json` + `resources/`, see v2 layout in `docs/snapshot-bundle-spec.md` and summarized in `CLAUDE.md`).
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`


### PR DESCRIPTION
## Summary

Docs-only PR. `CLAUDE.md` had drifted from the actual code on several concrete points; this aligns it back to reality without changing any code. Also fixes one stale sentence in `docs/Roadmap.md`.

## Mismatches fixed

**Project Configuration / Plugin Source Layout**
- Plugin ID: `com.example.pagemirror` → `com.github.artem.pageobjectplugin` (matches `src/main/resources/META-INF/plugin.xml`).
- Source-tree package path: `kotlin/com/example/pagemirror/` → `kotlin/com/github/artem/pageobjectplugin/`.
- Added files that exist on disk but were missing from the tree:
  - `PageObjectBundle.kt` (top-level)
  - `services/SnapshotHtmlResolver.kt`
  - `widgets/PageMirrorStatusBarWidgetFactory.kt`
- `actions/InsertLocatorAction.kt` doesn't exist — replaced with the actual file `HighlightCurrentSelectorAction.kt`.

**Test Project Layout**
- Path moved under npm workspaces in commit `0f43157`: `test-project/` → `packages/test-project/`.
- Added `dashboard.page.ts`, `dashboard.spec.ts`, the `fixtures/` directory, `tsconfig.json`, and the `dashboard/` snapshot subtree (all present on disk).
- Removed `utils/save-state.ts` (no such file).

**Current State**
- Task 15 (extract `@pagemirror/snapshot-core`) is shipped on `main`, not "in progress on branch `claude/check-task-statuses-C7rh9`". The package is publishable (commit `cbc75f1`) and `.snapshots/` already use v2 layout.
- Headline sentence updated to "Tasks 0–15, 15.5, and 19 are complete."

**UI Test Conventions**
- `SettingsUiTest.kt` is no longer `@Disabled` — re-enabled after `PageMirrorConfigurable` gained explicit accessible names. Updated the reference-tests blurb.

**Roadmap.md**
- The brief on-disk bundle format mention listed top-level `screenshot.webp`, which is the v1 layout. v2 puts it under `resources/`. Replaced the inline triple with a pointer to `docs/snapshot-bundle-spec.md`.

## Test plan

- [x] No code changed — docs-only diff (`CLAUDE.md`, `docs/Roadmap.md`).
- [x] Every doc claim verified against `src/main/kotlin/...`, `plugin.xml`, `packages/test-project/`, `packages/snapshot-core/package.json`, and `build.gradle.kts` line ranges (`:219`, `:261`, `112-144` all still match).
- [x] Line references `build.gradle.kts:112-144`, `:219`, `:261` rechecked — still accurate, left unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnVVqEdCpYk1TyX2Rty26k)_