### PR TITLE
docs(CLAUDE.md): sync project doc with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,22 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
+      HighlightCurrentSelectorAction.kt
       ToggleInspectAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
     html/
       page-mirror.html
       js/
@@ -99,42 +108,85 @@ src/main/
 
 ## Test Project Layout
 
+The Playwright test project lives under `packages/test-project/`:
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  fixtures/
+    app.html
+    login.html
+    styles/
+  .snapshots/
+    login/
+      initial/      {index.html, manifest.json, resources/}
+      error-state/  {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
+```
+
+The snapshot saver and framework-agnostic core also live under
+`packages/`:
+
+```
+packages/
+  snapshot-core/                # @pagemirror/snapshot-core (framework-agnostic engine)
+  playwright-snapshot-saver/    # Playwright adapter on top of snapshot-core
+  test-project/                 # Sample Playwright project used as a fixture + smoke test
 ```
 
 ## Task Sequence
 
 Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
-| #  | Task                              | Key Output                        | Depends On |
-|----|-----------------------------------|-----------------------------------|------------|
-| 0  | Dummy Playwright test project     | `.snapshots/` with real data      | Nothing    |
-| 1  | Plugin shell + JCEF Tool Window   | Tool Window renders static HTML   | Nothing    |
-| 2  | Snapshot loading via CefQuery     | HTML renders in iframe + highlight| 0, 1       |
-| 3  | File watcher + auto-discovery     | Auto-loads snapshots on file open | 2          |
-| 4  | Code-to-UI highlight bridge       | Cursor on locator → highlight     | 3          |
-| 5  | Element picker + code generation  | Click element → insert locator    | 4          |
-| 6  | Live selector validation (gutter) | Match count badges in editor      | 4          |
-| 7  | Refinements and polish            | Settings, shortcuts, themes       | 5, 6       |
-| 8  | Highlight all + duplicates        | Show All button, overlap detection| 4, 6       |
-| 9  | Snapshot saver npm package        | Standalone `playwright-snapshot-saver`             | 0 |
+| #     | Task                                       | Key Output                                                | Depends On |
+|-------|--------------------------------------------|-----------------------------------------------------------|------------|
+| 0     | Dummy Playwright test project              | `.snapshots/` with real data                              | Nothing    |
+| 1     | Plugin shell + JCEF Tool Window            | Tool Window renders static HTML                           | Nothing    |
+| 2     | Snapshot loading via CefQuery              | HTML renders in iframe + highlight                        | 0, 1       |
+| 3     | File watcher + auto-discovery              | Auto-loads snapshots on file open                         | 2          |
+| 4     | Code-to-UI highlight bridge                | Cursor on locator → highlight                             | 3          |
+| 5     | Element picker + code generation           | Click element → insert locator                            | 4          |
+| 6     | Live selector validation (gutter)          | Match count badges in editor                              | 4          |
+| 7     | Refinements and polish                     | Settings, shortcuts, themes                               | 5, 6       |
+| 8     | Highlight all + duplicates                 | Show All button, overlap detection                        | 4, 6       |
+| 9     | Snapshot saver npm package                 | Standalone `playwright-snapshot-saver`                    | 0          |
+| 10    | Trace extraction & reporter                | `extract` CLI + Playwright reporter + `snapshot()` marker | 9          |
+| 11    | Manifest fixes                             | Timestamp, change detection, version increment            | 9          |
+| 12    | Settings UI DSL v2                         | `PageMirrorConfigurable.kt` rewritten on UI DSL v2        | 7          |
+| 13a–d | UI test framework                          | Unblock, reliability, diagnostics, page-object refactor   | 7          |
+| 14    | CI test reporting                          | `claude-summary.{json,md}` aggregator + dashboard upload  | 13         |
+| 15    | Extract `@pagemirror/snapshot-core`        | Framework-agnostic core + bundle format v2                | 9          |
+| 15.5  | Framework-agnostic trace rendering         | `TraceBackend` interface + fully self-contained bundles   | 15         |
+| 19    | Feature demo trace viewer                  | Per-PR Playwright-style trace viewer on `demo`-tagged PRs | 13c, 14    |
+
+Planned (see `docs/Roadmap.md`):
+
+| #  | Task                                  | Key Output                                              |
+|----|---------------------------------------|---------------------------------------------------------|
+| 16 | Python Playwright support             | Python locator extractor + saver sibling package        |
+| 17 | Selenium + Cypress adapters           | Adapters on top of `@pagemirror/snapshot-core`          |
+| 18 | Java/Kotlin Playwright support        | JVM locator extractor + saver sibling package           |
+| 20 | Appium / mobile environment support   | Mobile adapter + manifest extensions                    |
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete and merged to `main`.** All plugin
+features ship, the snapshot saver npm package is published,
+`@pagemirror/snapshot-core` is extracted and consumed via semver, the
+snapshot bundle format is at v2 with self-contained `resources/`, the UI
+test suite runs under a layered Page Object structure, CI aggregates test
+results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -142,33 +194,16 @@ auto-generated on PRs tagged `demo`.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
-- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
+- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:114`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
-- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** `packages/snapshot-core/` ships the framework-agnostic core (`browser/collector.ts`, `assemble-html.ts`, `manifest.ts`, `save-snapshot.ts`, `types.ts`) consumed by `packages/playwright-snapshot-saver/` via semver. The snapshot bundle format moved to v2: `screenshot.<ext>` lives under `resources/`, CSS ships as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a user-visible outdated-bundle banner that links to `docs/migration-v1-to-v2.md` — regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
+- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `ui/support/FeatureTagListener.kt`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+**In-flight / planned:** Tasks 16, 17, 18, 20 (see `docs/Roadmap.md`).
 
 ## Working with the Build
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` had drifted from the code on `main`. This PR re-aligns it so the project doc once again describes what is actually checked in.

### What was stale

- **Plugin ID + source package path.** Doc said `com.example.pagemirror`, code/`gradle.properties`/`plugin.xml` are all `com.github.artem.pageobjectplugin`.
- **Source layout.** Listed `InsertLocatorAction.kt` (doesn't exist); omitted `HighlightCurrentSelectorAction.kt`, `services/SnapshotHtmlResolver.kt`, top-level `PageObjectBundle.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `resources/messages/`, and `resources/demo-viewer/` — all of which ship today.
- **Test project layout.** Doc still pointed at top-level `test-project/`; the project moved under `packages/test-project/` (npm workspaces, commit `0f43157`). Doc also listed `utils/save-state.ts` (gone) and only the `login/` snapshots — `dashboard/{initial,ticket-filled}/` and the `fixtures/` directory are missing.
- **Task sequence table.** Stopped at Task 9 even though Tasks 10–15.5 + 19 are merged. Roadmap items 16/17/18/20 weren't mentioned in the table.
- **Current State.** Tasks 15 and 15.5 were labelled "in progress on branch `claude/check-task-statuses-C7rh9`", but that branch was merged via PR #30 (`dac7042`); subsequent commits (`7b808a0`, `cbc75f1`) finished 15.5 and made `@pagemirror/snapshot-core` publishable on `main`.
- **Task 13a line reference.** `build.gradle.kts:112-144` is now just `:114` for `register("runIdeForUiTests")`.
- **Task 19 file path.** `FeatureTagListener` lives at `ui/support/FeatureTagListener.kt`, not at the top of `ui/`.

### What didn't change

The Critical Constraints, Snapshot Bundle Format (v2), Test Loop, Redlines, UI Test Conventions, Common Pitfalls, and Report Dashboard Access sections are still accurate against the code and are untouched.

## Test plan

- [x] `grep` confirms no remaining `com.example.pagemirror`, `com/example/pagemirror`, `InsertLocatorAction`, `utils/save-state`, or "in progress" strings in `CLAUDE.md`.
- [x] Every path/file mentioned in the rewritten Source Layout and Test Project Layout exists on `main` (`src/main/kotlin/com/github/artem/pageobjectplugin/…`, `packages/test-project/.snapshots/dashboard/{initial,ticket-filled}/`, etc.).
- [x] Plugin ID matches both `plugin.xml` (`<id>`) and `gradle.properties` (`pluginGroup`).
- [x] Task 13a's referenced line (`build.gradle.kts:114`) and Task 14's referenced lines (`:219`, `:261`) match the current file.
- [x] Docs-only change — no source, build, or test files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiJYq6euepP56aLd2ff8MB)_