### PR TITLE
docs: align CLAUDE.md and Roadmap with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,12 +101,16 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/                 # static assets for the Task 19 trace viewer
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
   page-objects/login.page.ts
@@ -130,11 +140,14 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship,
+`playwright-snapshot-saver` and `@pagemirror/snapshot-core` are both
+published, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
+`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer
+is auto-generated on PRs tagged `demo`. Snapshot bundles are on
+format **v2**; v1 bundles are refused with a user-visible banner that
+points at `docs/migration-v1-to-v2.md`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -147,28 +160,13 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** `packages/snapshot-core/src/{assemble-html.ts, browser/, manifest.ts, save-snapshot.ts, types.ts}` ship the framework-agnostic core; `packages/playwright-snapshot-saver/src/playwright-adapter.ts` is the thin Playwright adapter. Snapshot bundle format bumped to **v2**: `screenshot.<ext>` lives under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a user-visible banner — regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+**Outstanding tracks (see `docs/Roadmap.md`):** Track A (Python / JVM
+Playwright locator + saver — tasks 16, 18), Track B remainder (Selenium
++ Cypress adapters task 17, Appium task 20).
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the new framework-agnostic `@pagemirror/snapshot-core` (both live capture and trace extraction now produce self-contained v2 bundles), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The IDE side is still tightly coupled to TypeScript (regex-based locator extraction); Tracks A and the remainder of Track B layer Python / JVM Playwright support and Selenium / Cypress / Appium adapters on top of `@pagemirror/snapshot-core` without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,23 +21,23 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` (**done**, plus `task-15.5-trace-resource-inlining.md`).
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor and shipped along with Task 15.5 (framework-agnostic trace rendering + resource inlining); B2 and B3 layer new adapters on top of the extracted core by implementing its `TraceBackend` / `PageAdapter` surfaces.
 
 ---
 
-## Track C — Repo / Inner Loop Improvements
+## Track C — Repo / Inner Loop Improvements (**done**)
 
-- **C1. UI test framework** — split into four subtasks:
+- **C1. UI test framework** — split into four subtasks (all done):
   - `task-13a-ui-tests-unblock.md` — fix `splitMode` + fast-fail health check
   - `task-13b-ui-tests-reliability.md` — polling helpers, retry-once, `@Quarantine`
   - `task-13c-ui-tests-diagnostics.md` — per-test trace bundle (feeds C3)
   - `task-13d-ui-tests-page-object-refactor.md` — locators/pages/flows layering
-- **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md`
-- **C3. Feature demo reporting (Playwright-style trace viewer)** — `task-19-feature-demo-trace-viewer.md`
+- **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md` (**done**)
+- **C3. Feature demo reporting (Playwright-style trace viewer)** — `task-19-feature-demo-trace-viewer.md` (**done**)
 
 ---
 


### PR DESCRIPTION
## Summary

A code-vs-docs audit on `main` (HEAD `7101aad`) found several stale
claims in `CLAUDE.md` and `docs/Roadmap.md`. This PR fixes them so the
docs match what is actually on `main` today.

### CLAUDE.md

- **Plugin ID** was listed as `com.example.pagemirror`; actual is
  `com.github.artem.pageobjectplugin` (see
  `src/main/resources/META-INF/plugin.xml:2`).
- **Plugin Source Layout** still used the historical
  `com/example/pagemirror/` package and was missing several files /
  listed one that does not exist. Updated to match
  `src/main/kotlin/com/github/artem/pageobjectplugin/...`:
  - **Added:** `PageObjectBundle.kt`,
    `services/SnapshotHtmlResolver.kt`,
    `widgets/PageMirrorStatusBarWidgetFactory.kt`,
    `actions/HighlightCurrentSelectorAction.kt`,
    `resources/messages/PageObjectBundle.properties`,
    `resources/demo-viewer/{index.html,app.js,styles.css}`.
  - **Removed:** `actions/InsertLocatorAction.kt` — never existed on
    `main`; the picker → insert flow lives in
    `locators/PickerResultHandler.kt`.
- **Test Project Layout** referenced `test-project/` at repo root; the
  npm workspaces consolidation (commit `0f43157`) moved it under
  `packages/test-project/`.
- **Current State** said Task 15 was "in progress on branch
  claude/check-task-statuses-C7rh9". Task 15 plus 15.5 are merged on
  `main` (commits `949b026`..`7b808a0`, `cbc75f1`) and the v2 bundle
  format is shipped (`CHANGELOG.md` 0.5.0). The section now lists
  Tasks 15 / 15.5 alongside the other completed tasks and points at
  Tracks A / remainder of B as the outstanding work.

### docs/Roadmap.md

- Context paragraph now says "Tasks 0–15, 15.5, and 19 are complete"
  and reflects that `@pagemirror/snapshot-core` already exists, rather
  than describing Task 15 as future work.
- Marked B1 (Task 15 + 15.5) and all of Track C done; the unfinished
  roadmap items are Track A (Python / JVM Playwright — tasks 16, 18)
  and Track B remainder (Selenium + Cypress task 17, Appium task 20).

No code changes; docs only.

## Test plan

- [x] `git diff` reviewed — only `CLAUDE.md` and `docs/Roadmap.md`
      changed.
- [x] Cross-checked every file path in the updated Plugin Source
      Layout against `find src/main -type f` on `main`.
- [x] Cross-checked plugin ID against
      `src/main/resources/META-INF/plugin.xml`.
- [x] Cross-checked Task 15 / 15.5 status against `git log --grep`
      and `CHANGELOG.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_011CDts3kAV6X8qyjiVXjtBv)_