### PR TITLE
docs: align CLAUDE.md and USE.md with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,13 +80,15 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -100,7 +104,7 @@ src/main/
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
   page-objects/login.page.ts
@@ -130,11 +134,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` package is extracted and consumed via semver,
+the UI test suite runs under a layered Page Object structure, CI
+aggregates test results into a single `claude-summary.{json,md}` bundle,
+and a Playwright-style trace viewer is auto-generated on PRs tagged
+`demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,26 +155,31 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** merged into main
+  (commit `cbc75f1`). Bumps the snapshot bundle format to v2:
+  `screenshot.<ext>` moves under `resources/`, CSS is written as
+  `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+  inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+  relative URLs). v1 bundles are refused with a clear error message —
+  regenerate via `npx playwright test` in `packages/test-project/`. The
+  bundle spec is frozen in `docs/snapshot-bundle-spec.md`; the v1→v2
+  migration steps are in `docs/migration-v1-to-v2.md`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+Open tasks: 16 (Python Playwright), 17 (Selenium/Cypress adapters), 18
+(JVM Playwright), 20 (Appium mobile). See `docs/Roadmap.md` and the
+matching files under `docs/tasks/` for scope.
 
 ## Working with the Build
 

--- a/USE.md
+++ b/USE.md
@@ -152,33 +152,38 @@ Each snapshot is a directory containing:
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html          # Sanitized DOM referencing resources/
+│   │   ├── manifest.json       # Metadata (schema version 2)
+│   │   └── resources/
+│   │       ├── screenshot.webp # Visual reference (optional)
+│   │       └── <sha1>.css      # Stylesheet sidecars referenced by <link>
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the sanitized page DOM. External stylesheets are written as `resources/<sha1>.css` sidecars and referenced via `<link>`; the plugin inlines them on read because `srcdoc` iframes can't resolve relative URLs.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "userAgent": "Mozilla/5.0 ...",
+  "playwright": "1.58.0"
 }
 ```
+
+`version` is the bundle schema version. The plugin refuses to load bundles whose version is anything other than `2` — see [docs/migration-v1-to-v2.md](docs/migration-v1-to-v2.md) if you have older snapshots.
 
 ## Stage 2: Load in the IDE
 


### PR DESCRIPTION
## Summary

Auditing the docs against the current `main` (commit `7101aad`) turned up several stale claims. This PR brings `CLAUDE.md` and `USE.md` back in line with the code that actually ships.

### `CLAUDE.md`

- **Plugin ID.** `com.example.pagemirror` → `com.github.artem.pageobjectplugin`. The actual ID in `src/main/resources/META-INF/plugin.xml:2`.
- **Plugin Source Layout.** Updated the package path to `com/github/artem/pageobjectplugin/` (matches the real `src/main/kotlin/` tree) and corrected the file list:
  - Added `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `actions/HighlightCurrentSelectorAction.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`.
  - Removed `actions/InsertLocatorAction.kt` — no such file exists in the tree, and no action of that ID is registered in `plugin.xml`.
- **Test Project Layout.** Path updated from root `test-project/` to `packages/test-project/` (consolidated under the npm workspace in commit `0f43157`).
- **Current State.** Tasks 15 and 15.5 are merged into `main` (commit `cbc75f1`); the previous text claimed Task 15 was "in progress" on the long-deleted branch `claude/check-task-statuses-C7rh9`. Updated the summary line to "Tasks 0–15, 15.5, and 19 are complete" and added an explicit list of open tasks (16, 17, 18, 20).

### `USE.md`

- **Bundle layout diagram and manifest example** were still showing v1 (`screenshot.webp` at top level, `"version": 1`). Refreshed to v2: `screenshot.webp` and `<sha1>.css` sidecars under `resources/`, `"version": 2`, `userAgent` field, and a link to `docs/migration-v1-to-v2.md`.
- The behavioral note about CSS handling now matches reality — bundles ship CSS sidecars and the plugin inlines them on read (because `srcdoc` iframes have base URL `about:srcdoc`).

No code changes; docs-only.

## Test plan

- [x] Verified the new CLAUDE.md "Plugin Source Layout" matches `find src/main/kotlin/com/github/artem/pageobjectplugin -name '*.kt'`.
- [x] Verified `packages/test-project/.snapshots/dashboard/initial/` actually contains `index.html`, `manifest.json`, and `resources/` with `.css` sidecars, and that a real `manifest.json` carries `"version": 2`.
- [x] Cross-checked the v2 manifest example against `docs/snapshot-bundle-spec.md` (the authoritative spec) and `CHANGELOG.md` v0.5.0 entry — fields and semantics line up.
- [ ] CI (`test-report` job) green on the branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PXjwCWJrKogMhYWqfNSzyy)_