### PR TITLE
docs: align CLAUDE.md and task docs with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,28 +63,32 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
       CaretHighlightListener.kt
     locators/
       LocatorExtractor.kt
-      PickerResultHandler.kt
+      PickerResultHandler.kt          # also handles locator insertion into the editor
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
     html/
@@ -99,13 +103,19 @@ src/main/
 
 ## Test Project Layout
 
+The test project lives under `packages/test-project/` (moved there during
+Task 15 when packages were consolidated under npm workspaces). Snapshot
+saving is consumed from the `playwright-snapshot-saver` workspace
+package — there is no local `utils/save-state.ts` anymore.
+
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
+  tsconfig.json
+  fixtures/                # HTML fixtures served during tests (app.html, login.html, styles/)
+  page-objects/            # login.page.ts, dashboard.page.ts
+  tests/                   # login.spec.ts, dashboard.spec.ts
   .snapshots/login/
     initial/      {index.html, manifest.json, resources/}
     error-state/  {index.html, manifest.json, resources/}
@@ -130,11 +140,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published, `@pagemirror/snapshot-core` has been
+extracted and now owns trace rendering with full resource inlining,
+the UI test suite runs under a layered Page Object structure, CI
+aggregates test results into a single `claude-summary.{json,md}` bundle,
+and a Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -149,26 +160,28 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** packages consolidated
+  under npm workspaces; `packages/snapshot-core/src/` ships
+  `assemble-html.ts`, `manifest.ts`, `save-snapshot.ts`, plus `browser/`
+  and `trace/` subpackages, and is published as `@pagemirror/snapshot-core`.
+  The snapshot bundle format is v2: `screenshot.<ext>` lives under
+  `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+  referenced by `<link>`, and the plugin inlines sidecar CSS on read
+  (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are
+  refused with a clear error message — regenerate via `npx playwright test`
+  in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend`
+  interface (`packages/snapshot-core/src/trace/{types, renderer, inline,
+  extract, runtime-script, content-type}.ts`). The Playwright package
+  (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`)
+  reshapes `TraceLoader.storage()` into that interface; `extractor.ts`
+  delegates to `extractFromBackend`. Trace bundles are fully
+  self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`,
+  and SVG `<use>` reference points at a real file under `resources/`, and
+  the `<base>` element is stripped. Selenium/Cypress/Appium adapters
+  (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same
+  `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/tasks/task-9-snapshot-package.md
+++ b/docs/tasks/task-9-snapshot-package.md
@@ -1,8 +1,13 @@
 # Task 9: Snapshot Saver npm Package
 
+> **Note (post-implementation):** The planning name `packages/snapshot-saver/`
+> was renamed to `packages/playwright-snapshot-saver/` during
+> implementation (it is now published as the `playwright-snapshot-saver`
+> npm package). References below use the implemented directory name.
+
 > **Goal:** Extract snapshot-saving logic from `test-project/utils/save-state.ts` into a standalone, publishable npm package with a configurable API.
 > **Depends on:** Task 0
-> **Output:** `packages/snapshot-saver/` — a self-contained npm package consumable by any Playwright project
+> **Output:** `packages/playwright-snapshot-saver/` — a self-contained npm package consumable by any Playwright project
 
 ## Motivation
 
@@ -14,7 +19,7 @@ The snapshot capture logic (HTML inlining, layout generation, manifest creation)
 
 ```
 packages/
-  snapshot-saver/
+  playwright-snapshot-saver/
     src/
       index.ts              # Public API: saveSnapshot()
       html-inliner.ts       # CSS inlining + DOM serialization
@@ -300,7 +305,7 @@ await saveSnapshot(page, {
 ```
 
 - `test-project/utils/save-state.ts` is deleted
-- `test-project/package.json` adds `playwright-snapshot-saver` as a dev dependency (local path: `"file:../packages/snapshot-saver"`)
+- `test-project/package.json` adds `playwright-snapshot-saver` as a dev dependency (local path: `"file:../packages/playwright-snapshot-saver"`)
 
 ---
 
@@ -311,9 +316,9 @@ The project becomes a lightweight monorepo:
 ```
 PageObjectPlugin/
   packages/
-    snapshot-saver/        # npm package (TypeScript)
-  test-project/            # Playwright tests (consumes snapshot-saver)
-  src/                     # IntelliJ plugin (Kotlin)
+    playwright-snapshot-saver/  # npm package (TypeScript)
+    test-project/               # Playwright tests (consumes playwright-snapshot-saver) — relocated under packages/ in Task 15
+  src/                          # IntelliJ plugin (Kotlin)
   build.gradle.kts         # Kotlin plugin build (unchanged)
 ```
 
@@ -325,21 +330,21 @@ No monorepo tooling (nx, turborepo) needed. The test-project references the pack
 
 | File | Change |
 |------|--------|
-| `packages/snapshot-saver/src/index.ts` | **New** — public API, `saveSnapshot()` |
-| `packages/snapshot-saver/src/html-inliner.ts` | **New** — extracted from `save-state.ts` |
-| `packages/snapshot-saver/src/layout-generator.ts` | **New** — extracted from `save-state.ts` |
-| `packages/snapshot-saver/src/manifest-generator.ts` | **New** — extracted from `save-state.ts` |
-| `packages/snapshot-saver/src/types.ts` | **New** — shared interfaces |
-| `packages/snapshot-saver/package.json` | **New** |
-| `packages/snapshot-saver/tsconfig.json` | **New** |
-| `packages/snapshot-saver/tests/save-snapshot.spec.ts` | **New** — integration tests |
+| `packages/playwright-snapshot-saver/src/index.ts` | **New** — public API, `saveSnapshot()` |
+| `packages/playwright-snapshot-saver/src/html-inliner.ts` | **New** — extracted from `save-state.ts` |
+| `packages/playwright-snapshot-saver/src/layout-generator.ts` | **New** — extracted from `save-state.ts` |
+| `packages/playwright-snapshot-saver/src/manifest-generator.ts` | **New** — extracted from `save-state.ts` |
+| `packages/playwright-snapshot-saver/src/types.ts` | **New** — shared interfaces |
+| `packages/playwright-snapshot-saver/package.json` | **New** |
+| `packages/playwright-snapshot-saver/tsconfig.json` | **New** |
+| `packages/playwright-snapshot-saver/tests/save-snapshot.spec.ts` | **New** — integration tests |
 | `test-project/tests/login.spec.ts` | Update imports to use new package |
 | `test-project/package.json` | Add `file:` dependency, remove `save-state` utils |
 | `test-project/utils/save-state.ts` | **Delete** |
 
 ## Acceptance Criteria
 
-- [x] `packages/snapshot-saver/` builds with `npm run build` and produces `dist/`
+- [x] `packages/playwright-snapshot-saver/` builds with `npm run build` and produces `dist/`
 - [x] `saveSnapshot()` generates all 4 snapshot files (html, layout, screenshot, manifest)
 - [x] Output satisfies `SnapshotBundle.fromDirectory()` contract (index.html + layout.json present)
 - [x] Every `selector` in generated layout.json resolves in the generated index.html


### PR DESCRIPTION
## Summary

Surgical doc-drift fixes against the actual source tree on `main`. Each edit was verified by `ls` / `grep` against real files — no source code changed.

- **CLAUDE.md plugin ID:** `com.example.pagemirror` -> `com.github.artem.pageobjectplugin` (matches `src/main/resources/META-INF/plugin.xml`).
- **CLAUDE.md Plugin Source Layout:** rewritten to reflect the real `com/github/artem/pageobjectplugin/` package — adds `PageObjectBundle.kt`, `services/SnapshotHtmlResolver.kt`, `actions/HighlightCurrentSelectorAction.kt`, and the `widgets/PageMirrorStatusBarWidgetFactory.kt` subpackage; drops the never-created `actions/InsertLocatorAction.kt` (locator insertion lives in `locators/PickerResultHandler.kt`).
- **CLAUDE.md Test Project Layout:** moved from `test-project/` to `packages/test-project/` (relocated during Task 15 npm-workspaces consolidation); removed `utils/save-state.ts` (consumed from the `playwright-snapshot-saver` workspace package now).
- **CLAUDE.md Current State:** Tasks 15 and 15.5 promoted from "in progress" to "complete" with file paths verified against `packages/snapshot-core/src/` and `packages/playwright-snapshot-saver/src/trace/`.
- **docs/tasks/task-9-snapshot-package.md:** added post-implementation note that the planned `packages/snapshot-saver/` was renamed to `packages/playwright-snapshot-saver/` during implementation; updated inline references for consistency.

## Test plan

- [ ] Docs-only PR; no build or runtime impact.
- [ ] Spot-check that each file path mentioned in updated docs exists on `main`.