### PR TITLE
docs: align documentation with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,23 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
+    demo-viewer/
+      index.html
+      app.js
+      styles.css
     html/
       page-mirror.html
       js/
@@ -277,9 +287,10 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow`; it was
+  enabled once `PageMirrorConfigurable` gained explicit accessible names
+  on its testable fields and the settings locators in
+  `ui/locators/PageMirrorLocators` were rewritten to match those names.
 
 ## Report Dashboard Access
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 
 - **Page Mirror panel** — displays captured page snapshots in an embedded browser (JCEF), docked to the right side of the IDE.
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
-- **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
+- **Element picker** — toggle inspect mode (`Alt+Shift+I`), then click any element in the snapshot to generate a locator and insert it into your code.
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight current selector** — highlight the locator on the current cursor line in the snapshot (`Alt+Shift+H`).
+- **Highlight All** — the **Show All** button in the Page Mirror toolbar highlights every locator on the page at once with color-coded overlays and duplicate/overlap detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -65,7 +65,7 @@ npx playwright test
 | Option | Default | Description |
 |--------|---------|-------------|
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace screencast |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp`. Off by default (trace screencast frames are low-fidelity and often blank); pass `true` to opt in. |
 | `manifest` | `true` | Generate `manifest.json` with metadata |
 
 ```typescript
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false }, // or `false` to skip
   manifest: true,
 });
 ```
@@ -98,8 +98,8 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` or `jpeg` |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Screenshot options, or `false` to disable |
+| `screenshot.format` | `png` | Live capture supports `png` only (`webp` throws — use the extract path for webp) |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -139,44 +139,46 @@ const result = await extractSnapshots({
 |--------|---------|-------------|
 | `source` | (required) | Report directory, trace ZIP path, or URL |
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp` (opt-in) |
 | `manifest` | `true` | Generate `manifest.json` |
 | `filter.page` | — | Only extract this page |
 | `filter.state` | — | Only extract this state |
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory in the **v2** bundle format:
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html          # Sanitized DOM referencing resources/
+│   │   ├── manifest.json       # Metadata, schema version 2
+│   │   └── resources/
+│   │       ├── screenshot.webp  # Visual reference (optional)
+│   │       └── <sha1>.css       # Stylesheet sidecars referenced by <link>
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the sanitized page DOM. It references CSS and other assets via relative `resources/<filename>` paths. The plugin inlines those sidecar stylesheets into `<style>` blocks on read (a `srcdoc` iframe can't resolve relative URLs), so producers ship sidecars rather than pre-inlining.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the page at capture time.
 
-**`manifest.json`** — metadata about the snapshot:
+**`manifest.json`** — metadata about the snapshot. The plugin refuses to load any bundle whose `version` is not `2`:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "playwright": "1.58.2"
 }
 ```
 
@@ -224,6 +226,10 @@ The editor gutter shows a badge next to each locator with the number of matching
 - **0** — no match (broken selector)
 - **2+** — multiple matches (ambiguous selector)
 
+### Highlight current selector
+
+Press `Alt+Shift+H` to highlight the locator on the current cursor line in the snapshot. This is handy when auto-highlight-on-caret is off or you want to re-trigger the highlight.
+
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror toolbar to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges. (This action has no default keyboard shortcut.)

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -5,7 +5,8 @@
 The snapshot bundle format was upgraded from v1 to v2 as part of the
 `@pagemirror/snapshot-core` extraction (Task 15). The Page Mirror plugin
 (v2024.3+) **only loads v2 bundles** — bundles with `manifest.version`
-set to any other integer are rejected with a log warning.
+set to any other integer are rejected with a log warning and an
+outdated-bundle banner in the Page Mirror tool window.
 
 If your snapshots stopped loading after an upgrade, this guide explains
 what changed and how to fix it.
@@ -119,5 +120,8 @@ initial/
 
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
-- Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
-- Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant
+- Plugin loader: `SnapshotBundle.kt` — `load()` checks the declared
+  version against the `SUPPORTED_BUNDLE_VERSION` constant
+- Manifest builder: `packages/snapshot-core/src/manifest.ts` consumes the
+  `MANIFEST_VERSION` constant, which is defined in
+  `packages/snapshot-core/src/types.ts`

--- a/docs/snapshot-bundle-spec.md
+++ b/docs/snapshot-bundle-spec.md
@@ -70,7 +70,7 @@ window dropdown.
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "userAgent": "Mozilla/5.0 ...",
-  "playwright": "1.58.0"
+  "playwright": "1.58.2"
 }
 ```
 

--- a/packages/playwright-snapshot-saver/README.md
+++ b/packages/playwright-snapshot-saver/README.md
@@ -196,11 +196,11 @@ Each snapshot is a directory containing:
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "userAgent": "Mozilla/5.0 …",
-  "playwright": "1.58.0"
+  "playwright": "1.58.2"
 }
 ```
 
-Exactly one driver field (`playwright` / `selenium` / `cypress` / `appium`) is populated per manifest, matching the driver that produced the bundle. The Playwright version is auto-detected from your installed `@playwright/test`.
+Exactly one driver field (`playwright` / `selenium` / `cypress` / `appium`) is populated per manifest, matching the driver that produced the bundle. The Playwright version is auto-detected from your installed `playwright-core`.
 
 The v1 format is **not backwards compatible** — the plugin refuses to load v1 bundles with a user-visible error. Regenerate them by re-running your tests.
 

--- a/packages/snapshot-core/README.md
+++ b/packages/snapshot-core/README.md
@@ -29,7 +29,7 @@ A small set of pure functions plus a couple of interfaces. Everything is statele
 
 1. **`TraceBackend`** — the single interface you implement to give core access to your driver's trace data (frame snapshots, resources, screencast frames, resource-by-sha1).
 2. **`renderSnapshot(backend, pageOrFrameId, snapshotName)`** — pure renderer that turns a `FrameSnapshot` plus its resource overrides into HTML.
-3. **`inlineResources(rendered)`** — resolves every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference against the backend's sha1 store, emitting files under `resources/` and rewriting the HTML to match. Strips any `<base>` element.
+3. **`inlineResources(rendered, backend)`** — resolves every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference against the backend's sha1 store, emitting files under `resources/` and rewriting the HTML to match. Strips any `<base>` element.
 4. **`extractFromBackend(backend, markers, options)`** — orchestrator that takes a list of `TraceMarker`s and writes one v2 bundle per marker.
 
 ## Writing a new driver adapter
@@ -190,7 +190,7 @@ for (const info of result.snapshots) {
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "userAgent": "Mozilla/5.0 …",
-  "playwright": "1.58.0"
+  "playwright": "1.58.2"
 }
 ```
 
@@ -241,7 +241,7 @@ See [`docs/snapshot-bundle-spec.md`](../../docs/snapshot-bundle-spec.md) in the 
 | `buildManifest(captured, driver?, now?)` | Produces a v2 `ManifestJson`.                                      |
 | `saveSnapshot(adapter, options)` | Full live-capture orchestrator.                                             |
 | `renderSnapshot(backend, pageOrFrameId, snapshotName)` | Renders a single `FrameSnapshot` to HTML.            |
-| `inlineResources(rendered)` | Resolves all resource references, emitting files under `resources/`.            |
+| `inlineResources(rendered, backend)` | Resolves all resource references, emitting files under `resources/`.   |
 | `extractFromBackend(backend, markers, options)` | Full trace-extraction orchestrator.                       |
 | `extensionFromContentType(mimeType)` | Maps a MIME type to a canonical file extension.                      |
 

--- a/packages/snapshot-core/src/types.ts
+++ b/packages/snapshot-core/src/types.ts
@@ -107,7 +107,7 @@ export interface SaveSnapshotOptions extends CollectorOptions {
   group?: string;
   /**
    * Screenshot options. Pass `false` to disable, omit for default
-   * (`{ format: 'webp', fullPage: false }`), or specify a partial object.
+   * (`{ format: 'png', fullPage: false }`), or specify a partial object.
    */
   screenshot?: Partial<ScreenshotOptions> | false;
   /** Generate `manifest.json`. Default `true`. */


### PR DESCRIPTION
## Summary

Audited the living docs against the actual code (plugin.xml, Kotlin sources, the `snapshot-core`/`playwright-snapshot-saver` packages) and corrected the spots where documentation had drifted from the implementation. No code behavior changes — docs only, plus one inaccurate doc-comment.

## Mismatches fixed

**CLAUDE.md**
- Plugin ID and source-layout package path corrected to `com.github.artem.pageobjectplugin` (was `com.example.pagemirror`).
- Source tree updated: removed the non-existent `InsertLocatorAction.kt`; added the real files — `HighlightCurrentSelectorAction.kt`, `services/SnapshotHtmlResolver.kt`, top-level `PageObjectBundle.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `resources/messages/PageObjectBundle.properties`, and `resources/demo-viewer/`.
- `SettingsUiTest.kt` is no longer `@Disabled` — updated the UI Test Conventions note.

**README.md / USE.md**
- `Alt+Shift+H` is **Highlight Current Selector** (highlights the current cursor line), not "Highlight All". The real **Highlight All** is the unbound **Show All** toolbar button. `Alt+Shift+I` toggles inspect mode for the picker.
- USE.md: removed the non-existent `screenshot.enabled` option; fixed the format values (live capture is `png`-only, not `jpeg`); corrected the reporter/extract `screenshot` default to `false`; rewrote the bundle-format section for the **v2** layout (manifest `version: 2`, assets under `resources/`).

**docs/migration-v1-to-v2.md**
- Noted the user-visible outdated-bundle banner (not just a log warning).
- Fixed stale code references: `SnapshotBundle.load()` + `SUPPORTED_BUNDLE_VERSION`, and `MANIFEST_VERSION` lives in `types.ts`.

**Package docs**
- snapshot-core README: `inlineResources(rendered, backend)` (two args).
- saver README: Playwright version is read from `playwright-core` (not `@playwright/test`); example manifest version bumped to the pinned `1.58.2`.
- `types.ts`: `SaveSnapshotOptions.screenshot` default documented as `png` (matches `DEFAULT_SCREENSHOT`).

## Test plan

- [ ] Docs-only changes; verify the rendered Markdown reads correctly and the corrected facts (shortcuts, source tree, v2 bundle layout, API arity) match `plugin.xml`, the Kotlin sources, and the package sources.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGBMkAApbvUxzPR3br4XX5)_