### PR TITLE
docs: align docs with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
 | Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +63,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +80,22 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/PageObjectBundle.properties
+    demo-viewer/             # self-contained trace viewer (Task 19)
+      index.html
+      app.js
+      styles.css
     html/
       page-mirror.html
       js/
@@ -100,15 +109,23 @@ src/main/
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  fixtures/                       # static HTML/CSS served to Playwright
+    login.html
+    app.html
+    styles/{reset,layout,components,theme}.css
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/{initial, error-state}/        {index.html, manifest.json, resources/}
+    dashboard/{initial, ticket-filled}/  {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence
@@ -130,17 +147,18 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete** and merged to `main`. All plugin
+features ship, the snapshot saver npm package is published, the
+framework-agnostic `@pagemirror/snapshot-core` is extracted, the UI test
+suite runs under a layered Page Object structure, CI aggregates test
+results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
   Highlight All, and the `playwright-snapshot-saver` npm package.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
-- **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
+- **Task 11 (Manifest fixes):** timestamp and change detection (HTML diffed against the on-disk `index.html`). Note: the Task 11 "increment `version` on change" behavior was reverted in v2 — `manifest.version` is now strictly the schema version (`2`), not a write counter.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
 - **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
@@ -149,13 +167,15 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete** and merged
+to `main`. It bumped the snapshot bundle format to v2: `screenshot.<ext>`
+moved under `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+referenced by `<link>`, and the plugin inlines sidecar CSS on read (since
+`srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a
+clear error message — regenerate via `npx playwright test` in
+`packages/test-project/`. `@pagemirror/snapshot-core` ships as a publishable
+package (`0.1.0`); `playwright-snapshot-saver` consumes it via semver
+(`^0.1.0`).
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight All** — the **Show All** button in the tool window highlights every locator in the current file at once with color-coded overlays and duplicate/overlap detection.
+- **Highlight current selector** — jump the snapshot highlight to the locator on the current line (`Alt+Shift+H`).
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false }, // or `false` to disable
   manifest: true,
 });
 ```
@@ -98,8 +98,8 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` or `jpeg` |
+| `screenshot` | `{ format, fullPage }` | Screenshot config, or `false` to disable |
+| `screenshot.format` | `png` | `png` or `webp` |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -139,46 +139,57 @@ const result = await extractSnapshots({
 |--------|---------|-------------|
 | `source` | (required) | Report directory, trace ZIP path, or URL |
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace |
+| `screenshot` | `false` | Extract screenshot from trace (`--screenshot` to enable) |
 | `manifest` | `true` | Generate `manifest.json` |
 | `filter.page` | — | Only extract this page |
 | `filter.state` | — | Only extract this state |
 
 ## Snapshot Bundle Format
 
-Each snapshot is a directory containing:
+Each snapshot is a directory in the **v2 bundle format**: `index.html` and
+`manifest.json` at the top level, with every resource the HTML references
+(stylesheets, screenshot) under a `resources/` subdirectory.
 
 ```
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
+│   │   ├── index.html                 # Sanitized DOM referencing resources/
+│   │   ├── manifest.json              # Metadata (schema version 2)
+│   │   └── resources/
+│   │       ├── screenshot.webp        # Visual reference (optional)
+│   │       └── <sha1>.css             # Stylesheet sidecars
 │   └── error/
 │       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│       ├── manifest.json
+│       └── resources/
 ├── dashboard/
 │   └── main/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the sanitized page DOM. External stylesheets are written as
+`resources/<sha1>.css` sidecars and referenced by `<link>` tags; the plugin
+inlines them when it loads the bundle (an `srcdoc` iframe can't resolve
+relative paths). This is what the plugin renders.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/screenshot.webp`** (or `.png`) — a visual reference of the page at
+capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "playwright": "1.48.0"
 }
 ```
+
+See [`docs/snapshot-bundle-spec.md`](docs/snapshot-bundle-spec.md) for the
+authoritative spec and v1 → v2 migration notes.
 
 ## Stage 2: Load in the IDE
 
@@ -226,4 +237,6 @@ The editor gutter shows a badge next to each locator with the number of matching
 
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror toolbar to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+
+To highlight just the locator on the current line instead, press `Alt+Shift+H` (Highlight Current Selector).

--- a/docs/snapshot-bundle-spec.md
+++ b/docs/snapshot-bundle-spec.md
@@ -53,9 +53,11 @@ window dropdown.
 
 - **One flat level.** No nested subdirectories under `resources/`.
   Filenames are all that's referenced from `index.html`.
-- **CSS sidecars** are named by a 16-hex-char prefix of the
-  `sha1(css_source)` so identical stylesheets across snapshots
-  de-duplicate naturally.
+- **CSS sidecars** are named by the hex `sha1(css_source)` so identical
+  stylesheets across snapshots de-duplicate naturally. The live-capture
+  path uses a 16-hex-char prefix; the trace-extraction path uses the full
+  40-char digest. Consumers MUST treat the basename as an opaque token and
+  resolve it from the `<link href>` rather than assuming a fixed length.
 - **Screenshots** are named `screenshot.png` or `screenshot.webp`.
   Only one screenshot per bundle is expected.
 - **Path traversal is rejected.** The plugin refuses to load any


### PR DESCRIPTION
## Summary

Audited the docs against the shipping code on `main` and fixed the places where they had drifted. Code is treated as the source of truth; only docs change here (no code/behavior changes).

### CLAUDE.md
- **Plugin ID** corrected from the stale `com.example.pagemirror` to the real `com.github.artem.pageobjectplugin` (per `META-INF/plugin.xml`).
- **Plugin Source Layout** rewritten to match the actual tree: correct package path, plus `SnapshotHtmlResolver.kt`, `PageObjectBundle.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `demo-viewer/`, and `messages/PageObjectBundle.properties`; removed the nonexistent `InsertLocatorAction.kt` and added `HighlightCurrentSelectorAction.kt`.
- **Test Project Layout** moved from `test-project/` to the real `packages/test-project/` and updated to the actual files (fixtures/, dashboard page object + spec, dashboard snapshots).
- **Current State**: Task 15 (`@pagemirror/snapshot-core` extraction) is marked **complete & merged** rather than in-progress — `snapshot-core@0.1.0` is published and `playwright-snapshot-saver` consumes it via `^0.1.0`. Also corrected the Task 11 note, since v2 reverted the version-counter behavior (`manifest.version` is now strictly the schema version `2`).

### USE.md
- **Snapshot Bundle Format** updated from the documented v1 layout (top-level `screenshot.webp`, CSS inlined as `<style>`, `manifest.version: 1`) to the actual **v2** layout (`resources/` subdir, sidecar `resources/<sha1>.css` referenced by `<link>` and inlined by the plugin on read, `version: 2`).
- **`saveSnapshot` options**: `screenshot.format` is `png | webp` (not `jpeg`); `screenshot` is `{ format, fullPage }` or `false` (there is no `enabled` field).
- **`extract` options**: `screenshot` default is `false`, not `true`.
- **Highlight All**: it's the **Show All** toolbar button, not the `Alt+Shift+H` shortcut (which highlights the current line's selector).

### README.md
- Same Highlight All correction: split into the **Show All** button (highlight all + duplicate/overlap detection) and the `Alt+Shift+H` "highlight current selector" shortcut.

### docs/snapshot-bundle-spec.md
- CSS sidecar filenames: full 40-char sha1 on the trace-extract path vs 16-char prefix on live capture — documented as an opaque token to be resolved from `<link href>`.

## Test plan
- [ ] Docs-only change; no code paths affected. Verify the rendered Markdown reads correctly and the layout/ID claims match `META-INF/plugin.xml`, the `src/main/kotlin/...` tree, and `packages/test-project/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RniAurKrmGmv4siKY4hA7U)_