### PR TITLE
docs: align plugin/bundle docs with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,8 +11,9 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked Tool W
 | Plugin SDK      | IntelliJ Platform Gradle Plugin 2.x        |
 | Language         | Kotlin (no Java)                           |
 | Target IDEs     | IntelliJ Community + Ultimate + WebStorm   |
-| Min Platform    | 2024.3+                                    |
-| Plugin ID       | `com.example.pagemirror`                   |
+| Min Platform    | 2024.3+ (`sinceBuild = 243`)               |
+| Plugin ID       | `com.github.artem.pageobjectplugin`        |
+| Plugin Name     | "Page Object Helper" (tool window + settings are branded "Page Mirror") |
 | UI Location     | Tool Window, right panel, anchor=right     |
 | JCEF            | Guaranteed available (bundled in 2024.3+)  |
 
@@ -63,12 +64,14 @@ with a user-visible error.
 
 ```
 src/main/
-  kotlin/com/example/pagemirror/
+  kotlin/com/github/artem/pageobjectplugin/
     PageMirrorToolWindowFactory.kt
+    PageObjectBundle.kt          # i18n message bundle (DynamicBundle)
     model/
       SnapshotBundle.kt
     services/
       SnapshotService.kt
+      SnapshotHtmlResolver.kt    # inlines resources/<sha1>.css sidecars on read
     listeners/
       SnapshotDiscoveryListener.kt
       SnapshotWatcher.kt
@@ -78,15 +81,19 @@ src/main/
       PickerResultHandler.kt
     actions/
       LoadSnapshotAction.kt
-      InsertLocatorAction.kt
       ToggleInspectAction.kt
+      HighlightCurrentSelectorAction.kt
     annotators/
       SelectorValidationAnnotator.kt
     settings/
       PageMirrorSettings.kt
       PageMirrorConfigurable.kt
+    widgets/
+      PageMirrorStatusBarWidgetFactory.kt
   resources/
     META-INF/plugin.xml
+    messages/
+      PageObjectBundle.properties
     html/
       page-mirror.html
       js/
@@ -95,20 +102,35 @@ src/main/
         highlight.js
         inspect.js
         theme.js
+    demo-viewer/                 # self-contained trace viewer (Task 19)
+      index.html
+      app.js
+      styles.css
 ```
 
 ## Test Project Layout
 
 ```
-test-project/
+packages/test-project/
   package.json
   playwright.config.ts
-  page-objects/login.page.ts
-  tests/login.spec.ts
-  utils/save-state.ts
-  .snapshots/login/
-    initial/      {index.html, manifest.json, resources/}
-    error-state/  {index.html, manifest.json, resources/}
+  tsconfig.json
+  fixtures/
+    app.html
+    login.html
+  page-objects/
+    login.page.ts
+    dashboard.page.ts
+  tests/
+    login.spec.ts
+    dashboard.spec.ts
+  .snapshots/
+    login/
+      initial/        {index.html, manifest.json, resources/}
+      error-state/    {index.html, manifest.json, resources/}
+    dashboard/
+      initial/        {index.html, manifest.json, resources/}
+      ticket-filled/  {index.html, manifest.json, resources/}
 ```
 
 ## Task Sequence

--- a/USE.md
+++ b/USE.md
@@ -99,7 +99,7 @@ await saveSnapshot(page, {
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
 | `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` or `jpeg` |
+| `screenshot.format` | `png` | `png` (the only format supported for live capture) |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -152,31 +152,31 @@ Each snapshot is a directory containing:
 .snapshots/
 ├── login/
 │   ├── initial/
-│   │   ├── index.html          # Sanitized DOM with inlined CSS
-│   │   ├── screenshot.webp     # Visual reference
-│   │   └── manifest.json       # Metadata (URL, viewport, timestamp)
-│   └── error/
-│       ├── index.html
-│       ├── screenshot.webp
-│       └── manifest.json
+│   │   ├── index.html          # Sanitized DOM, links resources/<sha1>.css
+│   │   ├── manifest.json       # Metadata (version 2, viewport, timestamp, ...)
+│   │   └── resources/
+│   │       ├── <sha1>.css      # Stylesheet sidecars referenced by <link>
+│   │       └── screenshot.webp # Visual reference (optional)
+│   └── error-state/
+│       └── ...
 ├── dashboard/
-│   └── main/
+│   └── initial/
 │       └── ...
 ```
 
-**`index.html`** — the full page DOM with all external stylesheets inlined as `<style>` tags. This is what the plugin renders.
+**`index.html`** — the full page DOM. External stylesheets are written as `resources/<sha1>.css` sidecars referenced by `<link>` tags; the plugin inlines them into `<style>` blocks when it loads the bundle (a `srcdoc` iframe cannot resolve relative paths). Inline `<style>` blocks may also be present. This is what the plugin renders.
 
-**`screenshot.webp`** (or `.png`/`.jpeg`) — a visual reference of the page at capture time.
+**`resources/`** — sidecar files referenced by `index.html`: CSS sidecars named by a `sha1` of their content, plus an optional `screenshot.webp` (or `.png`) visual reference of the page at capture time.
 
 **`manifest.json`** — metadata about the snapshot:
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0"
+  "playwright": "1.58.0"
 }
 ```
 

--- a/docs/snapshot-bundle-spec.md
+++ b/docs/snapshot-bundle-spec.md
@@ -36,8 +36,13 @@ window dropdown.
   `<base href>` after resolving URLs against it. A surviving `<base>`
   would redirect every `resources/...` reference to the original origin
   and break the bundle when opened outside its origin.
-- Scripts stripped or neutralized — the plugin renders this in a
-  `srcdoc` iframe and does not execute arbitrary JS from snapshots.
+- Scripts are NOT stripped by the saver or the plugin — any `<script>`
+  the captured page carried is preserved verbatim in `index.html`. The
+  plugin renders the HTML in a `srcdoc` iframe whose sandbox is
+  `sandbox="allow-same-origin allow-scripts"` (see
+  `html/js/snapshot.js`), so snapshot-borne scripts CAN execute inside
+  that iframe. Treat snapshot HTML as untrusted; do not assume it is
+  script-free.
 - UTF-8 encoded.
 - Preserves original element attributes so locators (`data-testid`,
   `role`, `aria-*`, `id`, `name`, classes) resolve identically to the
@@ -53,9 +58,12 @@ window dropdown.
 
 - **One flat level.** No nested subdirectories under `resources/`.
   Filenames are all that's referenced from `index.html`.
-- **CSS sidecars** are named by a 16-hex-char prefix of the
-  `sha1(css_source)` so identical stylesheets across snapshots
-  de-duplicate naturally.
+- **CSS sidecars** are content-addressed by the `sha1` of the
+  stylesheet source so identical stylesheets across snapshots
+  de-duplicate naturally. The live saver (`@pagemirror/snapshot-core`'s
+  `assemble-html`) uses a 16-hex-char prefix of that sha1; trace-extracted
+  bundles reuse Playwright's native full-length sha1 filename. Consumers
+  must treat the filename as an opaque identifier, not a fixed-width hash.
 - **Screenshots** are named `screenshot.png` or `screenshot.webp`.
   Only one screenshot per bundle is expected.
 - **Path traversal is rejected.** The plugin refuses to load any


### PR DESCRIPTION
## Summary

Audited the repo's docs against the shipped code (no code changes) and fixed the concrete mismatches I found.

### CLAUDE.md
- **Plugin ID / name.** Documented `com.example.pagemirror`; the real `plugin.xml` `<id>` is `com.github.artem.pageobjectplugin` and the plugin name is "Page Object Helper" (only the tool window + settings panel are branded "Page Mirror"). Also noted `sinceBuild = 243` next to the already-correct "2024.3+" min platform.
- **Plugin source layout.** Package path corrected to `com/github/artem/pageobjectplugin/`. Removed `actions/InsertLocatorAction.kt` (does not exist) and added the files that actually ship: `actions/HighlightCurrentSelectorAction.kt`, `widgets/PageMirrorStatusBarWidgetFactory.kt`, `services/SnapshotHtmlResolver.kt`, the top-level `PageObjectBundle.kt` i18n bundle, `resources/messages/PageObjectBundle.properties`, and `resources/demo-viewer/`.
- **Test project layout.** Path is `packages/test-project/`, not `test-project/`; replaced the phantom `utils/save-state.ts` with the real `fixtures/`, added `tsconfig.json`, `dashboard.page.ts`, `dashboard.spec.ts`, and the `dashboard/` snapshot group.

### USE.md
- Snapshot bundle layout updated to v2 (CSS sidecars + optional screenshot live under `resources/`; `index.html` references `resources/<sha1>.css` via `<link>` and the plugin inlines on read).
- Manifest example bumped from `"version": 1` to `"version": 2` (`MANIFEST_VERSION = 2`).
- `screenshot.format` corrected from "`png` or `jpeg`" to png-only — the Playwright adapter throws on any non-`png` live-capture format.

### docs/snapshot-bundle-spec.md
- Removed the false "scripts stripped or neutralized" claim. The saver does not strip `<script>`, and the plugin's iframe runs with `sandbox="allow-same-origin allow-scripts"`, so snapshot scripts can execute. Reworded to treat snapshot HTML as untrusted.
- CSS sidecar naming clarified: only the live saver uses a 16-hex-char sha1 prefix; trace-extracted bundles reuse Playwright's full-length sha1, so the filename should be treated as opaque.

### Intentionally not changed
- The manifest schema's `url`/`userAgent` fields are correct against the code (`buildManifest`/`buildTraceManifest` both emit `url`). The committed `.snapshots/` example bundles omit `url`, but that's stale fixture *data*, not a doc bug, so it's out of scope here.

## Test plan
- [ ] Docs-only change; no code or build affected. Verify the rendered Markdown reads correctly and the file paths/IDs match `src/main/`, `packages/`, and `gradle.properties`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSv3tvjbtD8k21Eo5UeCi7)_