### PR TITLE
docs: align stale claims with shipped code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/                     # external stylesheets linked by app.html
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -125,13 +126,17 @@ packages/test-project/
     login.spec.ts
     dashboard.spec.ts
   .snapshots/
-    login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
-    dashboard/
+    login/                      # login.html uses inline CSS — no resources/
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
+    dashboard/                  # app.html links external CSS — sidecars emitted
       initial/        {index.html, manifest.json, resources/}
       ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+`resources/` is optional: it exists only when `index.html` references
+external assets (CSS sidecars or a screenshot). Bundles built from a page
+with only inline `<style>` and no screenshot legitimately omit it.
 
 ## Task Sequence
 
@@ -152,11 +157,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published, `@pagemirror/snapshot-core` is extracted and
+consumed via semver, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single `claude-summary.{json,md}`
+bundle, and a Playwright-style trace viewer is auto-generated on PRs tagged
+`demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -171,13 +177,14 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete** — the
+package ships in `packages/snapshot-core/` and the saver consumes it via
+semver. It bumped the snapshot bundle format to v2: `screenshot.<ext>` moves
+under `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+referenced by `<link>`, and the plugin inlines sidecar CSS on read (since
+`srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a
+clear error message — regenerate via `npx playwright test` in
+`packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 ## Features
 
 - **Page Mirror panel** — displays captured page snapshots in an embedded browser (JCEF), docked to the right side of the IDE.
-- **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
+- **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot (or press `Alt+Shift+H` to highlight the current line's locator on demand).
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight All** — the **Show All** button in the tool window highlights every locator on the page at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -224,6 +224,10 @@ The editor gutter shows a badge next to each locator with the number of matching
 - **0** — no match (broken selector)
 - **2+** — multiple matches (ambiguous selector)
 
+### Highlight current selector
+
+Press `Alt+Shift+H` to highlight the locator on the current editor line in the snapshot.
+
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror tool window to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.

--- a/docs/snapshot-bundle-spec.md
+++ b/docs/snapshot-bundle-spec.md
@@ -16,7 +16,8 @@
 <snapshot-name>/
   index.html                 # REQUIRED — sanitized DOM referencing resources/
   manifest.json              # REQUIRED — schema version 2
-  resources/                 # Everything index.html references by relative path
+  resources/                 # OPTIONAL — present only when index.html
+                             # references external assets by relative path
     screenshot.png|webp      # Visual reference (optional)
     <sha1>.css               # Stylesheet sidecars
     <sha1>.woff2|png|jpg|... # Fonts, images, media, SVG sprites, etc.
@@ -56,6 +57,9 @@ window dropdown.
 
 ## `resources/` directory
 
+- **Optional.** A bundle built from a page with only inline `<style>` and
+  no screenshot references no external assets and ships without a
+  `resources/` directory at all (e.g. the test-project `login/*` bundles).
 - **One flat level.** No nested subdirectories under `resources/`.
   Filenames are all that's referenced from `index.html`.
 - **CSS sidecars** are content-addressed by the `sha1` of the
@@ -115,7 +119,7 @@ Differences:
 | Screenshot location | `<bundle>/screenshot.<ext>` (top-level) | `<bundle>/resources/screenshot.<ext>` |
 | CSS | Inlined as `<style>` inside `index.html` by the saver | Written as `resources/<sha1>.css` sidecars referenced by `<link>`; plugin inlines them on read |
 | `manifest.version` | Sometimes a schema version, sometimes a write counter (Task 11 overloaded it) | Strictly the schema version — always `2` |
-| Top-level files | `index.html`, `screenshot.*`, `manifest.json` | `index.html`, `manifest.json`, `resources/` |
+| Top-level files | `index.html`, `screenshot.*`, `manifest.json` | `index.html`, `manifest.json`, and `resources/` when external assets are referenced |
 
 To migrate an existing `.snapshots/` directory:
 


### PR DESCRIPTION
## Summary

Audited the living docs against the code on `main` and fixed the factual mismatches I could verify. No code changes — docs only.

- **CLAUDE.md — Task 15 status was stale.** It claimed `@pagemirror/snapshot-core` extraction was "in progress on branch `claude/check-task-statuses-C7rh9`", but the package fully ships in `packages/snapshot-core/` on `main` (merged via `7b808a0`, later published/consolidated). The very next paragraph already described the dependent Task 15.5 as done, so the section was internally contradictory. Marked Task 15 complete and bumped the completed range to `0–15.5`.
- **CLAUDE.md + `docs/snapshot-bundle-spec.md` — `resources/` is optional.** The test-project `login/*` bundles render from inline-`<style>` pages with no screenshot and ship with no `resources/` directory at all; only the `dashboard/*` bundles (which link external CSS) carry sidecars. The docs implied `resources/` is always present. Corrected the test-project layout, the spec's directory-layout block, the `resources/` section, and the v1→v2 migration table.
- **README.md + USE.md — wrong keyboard shortcut.** `plugin.xml` binds `Alt+Shift+H` to **Highlight Current Selector** (the locator on the current editor line). "Highlight All" is the tool window's **Show All** button and has no shortcut. The docs attributed `Alt+Shift+H` to Highlight All. Fixed both, and documented the Highlight Current Selector shortcut where it belongs.

## Verified accurate (left unchanged)

- Plugin source layout, `build.gradle.kts` line refs (`:112-144`, `:219`, `:261`), and `snapshot-core/src/trace/` file list all still match.
- The manifest producer (`buildManifest` / `buildTraceManifest`) always writes `url`, conditionally writes `userAgent`, and keys the version field by driver name — consistent with the spec's required/optional markers, so the manifest schema docs were left as-is.

## Note for maintainers (not addressed here)

The committed `packages/test-project/.snapshots/*/manifest.json` fixtures lack the `url` field that the current saver always emits — they appear to predate that code. That's a fixtures-vs-code inconsistency (regenerating requires running Playwright), not a docs bug, so it's out of scope for this PR.

## Test plan

- [ ] Docs-only change; confirm the rendered Markdown reads correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GNNNyKhVq6tmQ9AFJirTtv)_