### PR TITLE
docs: align user docs with current snapshot-saver behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 ## Features
 
 - **Page Mirror panel** — displays captured page snapshots in an embedded browser (JCEF), docked to the right side of the IDE.
-- **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
+- **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot (or press `Alt+Shift+H` to re-highlight the current line's locator on demand).
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight All** — the **Show All** button in the tool window highlights every locator in the current file at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -65,7 +65,7 @@ npx playwright test
 | Option | Default | Description |
 |--------|---------|-------------|
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace screencast |
+| `screenshot` | `false` | Opt in to extracting a screencast frame as `resources/screenshot.webp`. Off by default — trace screencast frames are low-fidelity and frequently blank. |
 | `manifest` | `true` | Generate `manifest.json` with metadata |
 
 ```typescript
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false }, // or `false` to disable
   manifest: true,
 });
 ```
@@ -98,8 +98,8 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` (the only format supported for live capture) |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Screenshot options, or `false` to disable. A screenshot is captured by default on this live-capture path. |
+| `screenshot.format` | `png` | `png` (the only format supported for live capture; `webp` throws) |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -119,9 +119,14 @@ npx playwright-snapshot-saver extract --source ./test-results/trace.zip
 # From a hosted report URL
 npx playwright-snapshot-saver extract --source https://example.com/report
 
-# With filters
-npx playwright-snapshot-saver extract --source ./playwright-report --page login --state initial --output ./my-snapshots
+# With filters and screenshot extraction (off by default)
+npx playwright-snapshot-saver extract --source ./playwright-report --page login --state initial --output ./my-snapshots --screenshot
 ```
+
+CLI flags: `--source` (required), `--output` (default `.snapshots`),
+`--page` / `--state` (filters), `--screenshot` (opt in to
+`resources/screenshot.webp`, off by default), `--no-screenshot`
+(explicit disable), and `--no-manifest` (skip `manifest.json`).
 
 **Programmatic:**
 
@@ -139,7 +144,7 @@ const result = await extractSnapshots({
 |--------|---------|-------------|
 | `source` | (required) | Report directory, trace ZIP path, or URL |
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace |
+| `screenshot` | `false` | Opt in to extracting a screencast frame from the trace |
 | `manifest` | `true` | Generate `manifest.json` |
 | `filter.page` | — | Only extract this page |
 | `filter.state` | — | Only extract this state |
@@ -176,7 +181,7 @@ Each snapshot is a directory containing:
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.58.0"
+  "playwright": "1.58.2"
 }
 ```
 
@@ -196,7 +201,7 @@ With a snapshot loaded, the plugin bridges your code and the UI:
 
 ### Cursor-driven highlighting
 
-Place your cursor on any Playwright locator in a page object or test file. The plugin parses the locator and highlights the matching element in the snapshot.
+Place your cursor on any Playwright locator in a page object or test file. The plugin parses the locator and highlights the matching element in the snapshot. Highlighting follows the caret automatically; press `Alt+Shift+H` (**Highlight Current Selector**) to re-highlight the locator on the current line on demand.
 
 ```typescript
 export class LoginPage {
@@ -226,4 +231,4 @@ The editor gutter shows a badge next to each locator with the number of matching
 
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror tool window to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.

--- a/docs/snapshot-bundle-spec.md
+++ b/docs/snapshot-bundle-spec.md
@@ -78,7 +78,7 @@ window dropdown.
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "userAgent": "Mozilla/5.0 ...",
-  "playwright": "1.58.0"
+  "playwright": "1.58.2"
 }
 ```
 

--- a/packages/playwright-snapshot-saver/README.md
+++ b/packages/playwright-snapshot-saver/README.md
@@ -196,7 +196,7 @@ Each snapshot is a directory containing:
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "userAgent": "Mozilla/5.0 …",
-  "playwright": "1.58.0"
+  "playwright": "1.58.2"
 }
 ```
 

--- a/packages/snapshot-core/README.md
+++ b/packages/snapshot-core/README.md
@@ -22,7 +22,7 @@ A small set of pure functions plus a couple of interfaces. Everything is statele
 
 1. **`collectorSource`** / **`collectPage`** — browser-side collector that serializes `document.documentElement`, pulls in every `<link rel="stylesheet">` + `<style>`, and returns a `CollectedPayload`.
 2. **`assembleHtml(captured)`** — rewrites the collected HTML to reference CSS sidecars under `resources/<sha1>.css`.
-3. **`buildManifest(captured, driver?)`** — produces a schema-v2 `manifest.json` object.
+3. **`buildManifest(captured, driver?, now?)`** — produces a schema-v2 `manifest.json` object.
 4. **`saveSnapshot(adapter, options)`** — orchestrator that writes the full bundle to disk. Takes a `PageAdapter` you implement.
 
 ### Trace pipeline (framework-agnostic)
@@ -190,11 +190,11 @@ for (const info of result.snapshots) {
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
   "userAgent": "Mozilla/5.0 …",
-  "playwright": "1.58.0"
+  "selenium": "4.18.0"
 }
 ```
 
-Exactly one driver field is populated per manifest, matching `DriverInfo.name`. The v1 format is **not backwards compatible** and is refused by the plugin.
+Exactly one driver field is populated per manifest, and its key is whatever you pass as `DriverInfo.name` (`playwright` / `selenium` / `cypress` / `appium` / …) — this package is framework-agnostic and does not assume Playwright. The v1 format is **not backwards compatible** and is refused by the plugin.
 
 See [`docs/snapshot-bundle-spec.md`](../../docs/snapshot-bundle-spec.md) in the main repo for the authoritative spec.
 
@@ -207,6 +207,7 @@ See [`docs/snapshot-bundle-spec.md`](../../docs/snapshot-bundle-spec.md) in the 
 | `StylesheetData`           | One stylesheet (`href?`, `source`) as produced by the collector                   |
 | `Resource`                 | A file to be written under `resources/` (`filename`, `bytes`)                     |
 | `CapturedPage`             | Output of a `PageAdapter.capture()` call                                         |
+| `CollectedPayload`         | Raw return value of `collectPage` (`html` + `stylesheets`)                        |
 | `CollectorOptions`         | `extraSelectors` / `excludeSelectors` / `extraAttributes`                         |
 | `ScreenshotOptions`        | `{ format: 'png' \| 'webp', fullPage: boolean }`                                  |
 | `CaptureRequest`           | `CollectorOptions & { screenshot?: ScreenshotOptions }`                           |
@@ -214,6 +215,7 @@ See [`docs/snapshot-bundle-spec.md`](../../docs/snapshot-bundle-spec.md) in the 
 | `DriverInfo`               | `{ name, version }` written into the manifest                                    |
 | `SaveSnapshotOptions`      | Options for `saveSnapshot`                                                       |
 | `SnapshotResult`           | `{ outputDir, files: { html, manifest?, resources } }`                           |
+| `AssembleResult`           | Return value of `assembleHtml` (`{ html, cssResources }`)                         |
 | `ManifestJson`             | Schema-v2 manifest shape                                                         |
 | `MANIFEST_VERSION`         | Constant `2`                                                                     |
 
@@ -227,9 +229,14 @@ See [`docs/snapshot-bundle-spec.md`](../../docs/snapshot-bundle-spec.md) in the 
 | `ResourceOverride`         | Per-snapshot URL → sha1 override                                                 |
 | `ScreencastFrame`          | One screencast frame (sha1 + timestamp)                                          |
 | `TraceBackend`             | The trace-data abstraction you implement                                         |
+| `RenderedSnapshot`         | Return value of `renderSnapshot` (HTML + resource references to resolve)          |
+| `RenderedSnapshotInput`    | Input accepted by `inlineResources`                                              |
+| `InlineResult`             | Return value of `inlineResources` (`html` + emitted `resources`)                  |
+| `InlinedResource`          | One file emitted under `resources/` by `inlineResources`                          |
 | `TraceMarker`              | Snapshot marker consumed by `extractFromBackend`                                 |
 | `ExtractFromBackendOptions`| Options for `extractFromBackend`                                                 |
 | `ExtractFromBackendResult` | `{ snapshots: ExtractedSnapshotInfo[] }`                                         |
+| `ExtractedSnapshotInfo`    | One extracted bundle's metadata (`page`, `state`, `outputDir`, `files`)           |
 
 ### Functions
 

--- a/packages/snapshot-core/src/types.ts
+++ b/packages/snapshot-core/src/types.ts
@@ -107,7 +107,7 @@ export interface SaveSnapshotOptions extends CollectorOptions {
   group?: string;
   /**
    * Screenshot options. Pass `false` to disable, omit for default
-   * (`{ format: 'webp', fullPage: false }`), or specify a partial object.
+   * (`{ format: 'png', fullPage: false }`), or specify a partial object.
    */
   screenshot?: Partial<ScreenshotOptions> | false;
   /** Generate `manifest.json`. Default `true`. */


### PR DESCRIPTION
## Summary

Audited the living docs against the current code and fixed the mismatches found. Code is the source of truth; only docs (and one stale code comment) changed.

### Mismatches fixed

- **Screenshot extraction is opt-in (default `false`)** for the reporter and the `extract` CLI/API — the code gates on `screenshot === true` (`extractor.ts:36`, `cli.ts:65`). USE.md claimed `true`.
- **`saveSnapshot` has no `screenshot.enabled` field.** `ScreenshotOptions` is `{ format, fullPage }`; disable via `screenshot: false`. Fixed the USE.md example/table and corrected the stale `snapshot-core` `ScreenshotOptions` doc comment (`webp` → `png`, matching `DEFAULT_SCREENSHOT` in `save-snapshot.ts:20`).
- **Documented the `--screenshot` / `--no-screenshot` extract CLI flags** (were missing from USE.md).
- **"Highlight All" is the Show All tool-window button**, not `Alt+Shift+H`. `Alt+Shift+H` maps to **Highlight Current Selector** (`HighlightCurrentSelectorAction`, `plugin.xml`), confirmed by `task-7-polish.md` and UI test `UT-11`. Corrected README.md and USE.md.
- **`buildManifest` takes an optional third `now?` arg** — prose updated to match the existing reference-table entry and `manifest.ts`.
- **`snapshot-core` is framework-agnostic** — the example manifest now uses a non-Playwright driver and clarifies that the driver key follows `DriverInfo.name`.
- **Added public types omitted from the `snapshot-core` API reference**: `CollectedPayload`, `AssembleResult`, `RenderedSnapshot`, `RenderedSnapshotInput`, `InlineResult`, `InlinedResource`, `ExtractedSnapshotInfo` (all exported from `index.ts`).
- **Bumped the example manifest `playwright` version to `1.58.2`** — the value the saver now auto-detects (`playwright-core` pin + generated `.snapshots` manifests).

Verified as accurate (no change needed): plugin source layout, supported locator patterns, settings fields, keyboard shortcuts for the picker (`Alt+Shift+I`), reporter `outputDir`/`manifest` defaults, `extractSnapshots` option/result shapes, exports, and the `>=1.40.0` Playwright requirement.

## Test plan

- [ ] Docs-only change plus one comment fix — no behavior change. CI green on the branch.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TkAKK3BGJhhEWzwDANLdX9)_