### PR TITLE
docs(USE): correct screenshot defaults and drop non-existent `screenshot.enabled`

### DIFF
--- a/USE.md
+++ b/USE.md
@@ -65,14 +65,14 @@ npx playwright test
 | Option | Default | Description |
 |--------|---------|-------------|
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace screencast |
+| `screenshot` | `false` | Opt in to extracting a screencast frame as `resources/screenshot.webp`. Off by default — trace screencast frames are low-fidelity and frequently blank. |
 | `manifest` | `true` | Generate `manifest.json` with metadata |
 
 ```typescript
 reporter: [
   ['playwright-snapshot-saver/reporter', {
     outputDir: './my-snapshots',
-    screenshot: false,
+    screenshot: true,
   }]
 ]
 ```
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false }, // or `false` to disable
   manifest: true,
 });
 ```
@@ -98,8 +98,8 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` (the only format supported for live capture) |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Screenshot options, or `false` to disable. A screenshot is captured by default on this live-capture path. |
+| `screenshot.format` | `png` | `png` (the only format supported for live capture; `webp` throws) |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -119,9 +119,14 @@ npx playwright-snapshot-saver extract --source ./test-results/trace.zip
 # From a hosted report URL
 npx playwright-snapshot-saver extract --source https://example.com/report
 
-# With filters
-npx playwright-snapshot-saver extract --source ./playwright-report --page login --state initial --output ./my-snapshots
+# With filters and screenshot extraction (off by default)
+npx playwright-snapshot-saver extract --source ./playwright-report --page login --state initial --output ./my-snapshots --screenshot
 ```
+
+CLI flags: `--source` (required), `--output` (default `.snapshots`),
+`--page` / `--state` (filters), `--screenshot` (opt in to
+`resources/screenshot.webp`, off by default), `--no-screenshot`
+(explicit disable), and `--no-manifest` (skip `manifest.json`).
 
 **Programmatic:**
 
@@ -139,7 +144,7 @@ const result = await extractSnapshots({
 |--------|---------|-------------|
 | `source` | (required) | Report directory, trace ZIP path, or URL |
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace |
+| `screenshot` | `false` | Opt in to extracting a screencast frame from the trace |
 | `manifest` | `true` | Generate `manifest.json` |
 | `filter.page` | — | Only extract this page |
 | `filter.state` | — | Only extract this state |


### PR DESCRIPTION
## Summary

Audited `USE.md` against the shipped saver code (no code changes) and fixed three concrete mismatches that survived PR #74's docs sweep.

### What was wrong

**1. Reporter `screenshot` default (Option A)**

USE.md said the reporter's `screenshot` defaulted to `true`. The extractor — which the reporter forwards into — reads `options.screenshot === true` (`packages/playwright-snapshot-saver/src/extractor.ts:36`), so any falsy/undefined value disables it. Default is `false`. The example snippet also had the wrong sign — it set `screenshot: false` to "override the default", which only makes sense when the default is `true`; flipped it to `screenshot: true` so the example actually changes behavior.

**2. `screenshot.enabled` does not exist (Option B)**

USE.md documented `screenshot.enabled` for `saveSnapshot()`. The `ScreenshotOptions` interface (`packages/snapshot-core/src/types.ts:64`) has only `format` and `fullPage`. The way to disable a live-capture screenshot is `screenshot: false`. Replaced the bogus `screenshot.enabled` row with an honest `screenshot` row that points at the `| false` shape, and removed `enabled: true` from the code sample.

**3. Extract API + CLI `screenshot` default (Option C)**

Same root cause as #1 — the table claimed `screenshot` defaulted to `true` for `extractSnapshots()`. It defaults to `false`. The CLI agrees: `cli.ts` initialises `result: { screenshot: false, manifest: true }` and exposes `--screenshot` / `--no-screenshot` / `--no-manifest`. Updated the example invocation to opt in explicitly and added an inline flag list since none was documented before.

### Why the rest of the docs are fine

Spot-checked everything else flagged in the recent CLAUDE.md sweep (PR #74):
- Plugin ID `com.github.artem.pageobjectplugin`, source layout, keyboard shortcuts (`Alt+Shift+I`, `Alt+Shift+H`), `MANIFEST_VERSION = 2`, v2 bundle layout with `resources/` sidecars — all match plugin.xml / SnapshotBundle.kt / types.ts.
- All task docs referenced from CLAUDE.md exist under `docs/tasks/`.
- `snapshot-bundle-spec.md`, package READMEs, and Roadmap don't claim anything that contradicts the code.

## Test plan

- [x] Verified `extractor.ts:36` (`options.screenshot === true`) → reporter and `extractSnapshots` default is `false`.
- [x] Verified `types.ts:64` (`ScreenshotOptions { format, fullPage }`) → no `enabled` field exists.
- [x] Verified `cli.ts` initializes `screenshot: false` and exposes `--screenshot` / `--no-screenshot` / `--no-manifest`.
- [x] `git diff` reviewed: only USE.md is touched, only the documented defaults change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BMeqvAFMfWXi8JQtExAbrY)_