### PR TITLE
docs: align CLAUDE.md / Roadmap with shipped Task 15 / 15.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,11 +152,14 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core`
+owns the framework-agnostic capture / assembly / trace-rendering
+pipeline, the v2 bundle format is the only supported on-disk shape
+(plugin v0.5.0 refuses v1), the UI test suite runs under a layered Page
+Object structure, CI aggregates test results into a single
+`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer
+is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -165,19 +168,26 @@ auto-generated on PRs tagged `demo`.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
 - **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
-- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
+- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created. `ClaudeSummaryModel.kt` deliberately drops the `quarantined` field from the v1 schema rather than carrying a perpetually-empty placeholder (see the file-level comment in `buildSrc/.../buildtools/ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped in plugin
+v0.5.0 (2026-04-16). `packages/snapshot-core/` is now its own publishable
+npm package (`@pagemirror/snapshot-core@0.1.0`) and owns the
+framework-agnostic capture pipeline: `assemble-html.ts`, `manifest.ts`,
+`save-snapshot.ts`, `browser/collector.ts`, and the shared `types.ts`
+(`PageAdapter`, `CapturedPage`, `DriverInfo`, `ManifestJson`).
+`playwright-snapshot-saver` is now a thin adapter that implements
+`PageAdapter` and delegates assembly + save to core. The bundle format
+moved to v2: `screenshot.<ext>` lives under `resources/`, CSS is written
+as `resources/<sha1>.css` sidecars referenced by `<link>` tags, and the
+plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a user-visible banner —
+regenerate via `npx playwright test` in `packages/test-project/`. See
+`docs/migration-v1-to-v2.md` for the upgrade path.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the framework-agnostic `@pagemirror/snapshot-core` (Tasks 15 / 15.5), the v2 bundle format is the only supported on-disk shape, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). With core extraction landed, Selenium / Cypress / Appium / Python / JVM adapters (Tasks 16–18, 20) can now be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,12 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ shipped in plugin v0.5.0
+- **B1.5. Framework-agnostic trace rendering + resource inlining** — `task-15.5-trace-resource-inlining.md` ✅ shipped
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 / B1.5 are complete (`packages/snapshot-core/` owns capture, assembly, manifest, and trace rendering; `playwright-snapshot-saver` is a thin `PageAdapter` + `TraceBackend` on top). B2 and B3 layer new adapters on the same `PageAdapter` / `TraceBackend` interfaces.
 
 ---
 
@@ -33,7 +34,7 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 - **C1. UI test framework** — split into four subtasks:
   - `task-13a-ui-tests-unblock.md` — fix `splitMode` + fast-fail health check
-  - `task-13b-ui-tests-reliability.md` — polling helpers, retry-once, `@Quarantine`
+  - `task-13b-ui-tests-reliability.md` — polling helpers, retry-once (`@Quarantine` was deferred; `ClaudeSummaryModel.kt` drops the field)
   - `task-13c-ui-tests-diagnostics.md` — per-test trace bundle (feeds C3)
   - `task-13d-ui-tests-page-object-refactor.md` — locators/pages/flows layering
 - **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md`


### PR DESCRIPTION
## Summary

Audited `main` to compare project docs against actual code state. Found three concrete stale claims and fixed them.

### CLAUDE.md → "Current State"

- Header said **"Tasks 0–14 and 19 are complete"** but then a paragraph below described **Task 15** as *"in progress on branch claude/check-task-statuses-C7rh9"*. Reality: plugin v0.5.0 (2026-04-16) shipped Task 15. `packages/snapshot-core/` exists as `@pagemirror/snapshot-core@0.1.0`, `playwright-snapshot-saver` is a thin adapter on it, and the v2 bundle format is the only on-disk shape the plugin accepts. Updated the header to "Tasks 0–15.5 and 19" and rewrote the Task 15 paragraph in the past tense with concrete file references.
- **Task 13b note** said `@Quarantine` was *"only tracked as a reporting field in `ClaudeSummaryModel.kt`"*. The model's file-level comment actually states the opposite — the `quarantined` field was **dropped** from the v1 schema. Replaced with an accurate description.

### docs/Roadmap.md

- "Context" section mirrored the same stale claim ("Tasks 0–14 plus 19 are complete" + "Task 15 below extracts ..."). Updated to match.
- Marked Track B's **B1** and added **B1.5** as ✅ shipped.
- C1's `task-13b` line listed `@Quarantine` as deliverable; noted it was deferred.

### Verified-correct (no edit needed)

- Plugin Source Layout (every path under `src/main/` exists)
- Test Project Layout
- `build.gradle.kts` line references (`:112-144`, `:219`, `:261`) still accurate
- UI test file layout (`ui/{support,annotations,locators,pages,flows,tests}/`)
- buildSrc tools list (`ClaudeSummaryGenerator`, `DemoReportRenderer.kt`, etc.)
- Snapshot bundle spec, migration guide, README, CHANGELOG
- Plugin SDK / `sinceBuild = 243` / Plugin ID

## Test plan

- [x] `git diff origin/main` shows only the two doc files
- [ ] CI passes on the branch (docs-only change; existing checks should be green)


---
_Generated by [Claude Code](https://claude.ai/code/session_01WZEoZiR1QG3YZ3AqF2c1ie)_