### PR TITLE
docs: mark Task 15 / 15.5 complete and fix @Quarantine note in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core` owns
+the v2 bundle + trace-rendering surface, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -165,19 +166,22 @@ auto-generated on PRs tagged `demo`.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
 - **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
-- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
+- **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** neither the `@Quarantine` annotation nor a `quarantined` reporting field was shipped; `ClaudeSummaryModel.kt` deliberately omits the field (see its kdoc).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped the
+framework-agnostic capture package at `packages/snapshot-core/` (published
+as `@pagemirror/snapshot-core`, currently `0.1.0`) and bumped the snapshot
+bundle format to v2: `screenshot.<ext>` lives under `resources/`, CSS is
+written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the
+plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`. The
+`playwright-snapshot-saver` package depends on `@pagemirror/snapshot-core`
+via semver and delegates the capture/save pipeline to it.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a


### PR DESCRIPTION
## Summary

Audited `main` for documentation drift against the current code. Most of `CLAUDE.md` (file layout, plugin id/name, min platform, line numbers in `build.gradle.kts`, Task 13/14/19 file lists, bundle spec) is already accurate after PR #74. Three concrete mismatches remained in the **Current State** section — this PR fixes them.

### What was wrong

- **Task 15 was listed as "in progress" on branch `claude/check-task-statuses-C7rh9`**, but:
  - `packages/snapshot-core/` ships v0.1.0 with `src/{assemble-html.ts, save-snapshot.ts, manifest.ts, types.ts, browser/, trace/}`.
  - `packages/playwright-snapshot-saver/package.json` declares `@pagemirror/snapshot-core: ^0.1.0` as a dependency.
  - The plugin's `SnapshotBundle.kt` already enforces `SUPPORTED_BUNDLE_VERSION = 2` and `packages/test-project/.snapshots/` is fully on v2.
  - That feature branch no longer exists.
- **The completion summary line read "Tasks 0–14 and 19 are complete"**, omitting Task 15 and Task 15.5 even though the paragraphs below describe their shipped state.
- **The Task 13b "Gap" note claimed `@Quarantine` was "only tracked as a reporting field in `ClaudeSummaryModel.kt`"**, but that model's kdoc explicitly says it omits the `quarantined` field — neither the annotation nor the reporting field exists.

### Changes

Edits to `CLAUDE.md` only (15 +/- 11):

- Bumped the completion summary to "Tasks 0–15, 15.5, and 19 are complete" and added a one-clause mention of `@pagemirror/snapshot-core`.
- Rewrote the Task 15 paragraph from "in progress on branch X" to a shipped-state description that names the package, version, and dependency relationship.
- Tightened the Task 13b gap note to match what `ClaudeSummaryModel.kt`'s kdoc actually says.

No code changes; Task 15.5 paragraph, file paths, line numbers, and the rest of the doc are untouched (they already matched).

## Test plan

- [ ] Re-read the **Current State** section of `CLAUDE.md` and confirm the three updated paragraphs match the code state described in the PR body.
- [ ] Spot-check `packages/snapshot-core/package.json` (version `0.1.0`) and `packages/playwright-snapshot-saver/package.json` (`@pagemirror/snapshot-core` dep) against the new Task 15 wording.
- [ ] Confirm `ClaudeSummaryModel.kt`'s kdoc still matches the new Task 13b sentence.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ULoYTC79L4kzWKmMWPtKom)_