### PR TITLE
docs: mark Task 15 complete in CLAUDE.md Current State

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
+**Tasks 0–15 (including 15.5) and 19 are complete.** All plugin features
+ship, the snapshot saver npm package is published, `@pagemirror/snapshot-core`
+is extracted as a framework-agnostic core (publishable, consumed by the
+Playwright saver via semver), the UI test suite runs under a layered
 Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
@@ -171,10 +173,12 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+**Task 15 (Extract `@pagemirror/snapshot-core`)** — `packages/snapshot-core/`
+ships as a publishable `@pagemirror/snapshot-core` package; the Playwright
+saver depends on it via semver (`packages/playwright-snapshot-saver` →
+`@pagemirror/snapshot-core`). This also bumped the snapshot bundle format
+to v2: `screenshot.<ext>` lives under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
 inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
 URLs). v1 bundles are refused with a clear error message — regenerate via
 `npx playwright test` in `packages/test-project/`.


### PR DESCRIPTION
## Summary

The `Current State` section of `CLAUDE.md` was stale: it described Task 15 (`@pagemirror/snapshot-core` extraction) as **in progress** on `claude/check-task-statuses-C7rh9`, but that work has long since shipped to `main`. This PR aligns the doc with the code.

## Evidence

Task 15 landed on `main` across multiple commits:

- `949b026` `feat(snapshot-core): scaffold @pagemirror/snapshot-core package`
- `229794b` `feat(snapshot-core): core types, manifest builder, HTML assembler, browser collector`
- `83b47cf` `feat(snapshot-core): saveSnapshot orchestration + 10 FakePageAdapter tests`
- `4d5a586` `refactor(saver): move live-capture to @pagemirror/snapshot-core + bundle v2`
- `3a34b51` `test-project: add @pagemirror/snapshot-core as a file: devDep`
- `cbc75f1` `build: make @pagemirror/snapshot-core publishable, switch consumers to semver`

Task 15.5 already landed in `7b808a0` (`feat(snapshot-core): own trace rendering + resource inlining (Task 15.5)`) and was already described correctly in CLAUDE.md.

Verified state:

- `packages/snapshot-core/` exists with `package.json` (`name: @pagemirror/snapshot-core`, `version: 0.1.0`), publishable.
- `packages/playwright-snapshot-saver` depends on it via semver.
- `MANIFEST_VERSION = 2` in `packages/snapshot-core/src/types.ts`.
- `SnapshotHtmlResolver.kt` inlines sidecar CSS on read.

## Changes

- Update the headline `Tasks 0–14 and 19 are complete` → `Tasks 0–15 (including 15.5) and 19 are complete`, and mention `@pagemirror/snapshot-core` in the summary line.
- Rewrite the Task 15 paragraph to describe the shipped state (publishable, consumed via semver) instead of pointing to a now-defunct branch.
- No other doc changes — the rest of `CLAUDE.md`, `docs/snapshot-bundle-spec.md`, and the task files audit cleanly against the code.

## Test plan

- [x] `git diff CLAUDE.md` — only the two paragraphs above are changed
- [x] All file paths and line numbers cited elsewhere in `CLAUDE.md` (e.g. `build.gradle.kts:112-144`, `:219`, `:261`) still match HEAD
- [x] No code changes; CI doc/build paths unaffected

---
_Generated by [Claude Code](https://claude.ai/code/session_01U66mn9GPfju3S4Fm1pYaVe)_