### PR TITLE
docs: mark Task 15 / 15.5 complete and align test-project layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/                        # external stylesheets referenced by fixtures/*.html
+      reset.css
+      layout.css
+      components.css
+      theme.css
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -152,11 +157,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` engine is published and consumed by the
+saver, the UI test suite runs under a layered Page Object structure, CI
+aggregates test results into a single `claude-summary.{json,md}` bundle,
+and a Playwright-style trace viewer is auto-generated on PRs tagged
+`demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -171,13 +178,18 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete**.
+`packages/snapshot-core/` ships the framework-agnostic engine
+(`assemble-html.ts`, `manifest.ts`, `save-snapshot.ts`,
+`browser/collector.ts`) and is published as
+[`@pagemirror/snapshot-core@0.1.0`](https://www.npmjs.com/package/@pagemirror/snapshot-core).
+`packages/playwright-snapshot-saver` consumes it via a semver dependency
+and a thin `PlaywrightAdapter`. The snapshot bundle format is v2:
+`screenshot.<ext>` lives under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` engine is extracted, published, and consumed by the saver (Task 15) with full trace-resource inlining behind a driver-agnostic `TraceBackend` interface (Task 15.5), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction); Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can now be layered onto `@pagemirror/snapshot-core` without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ **Done.** Plus `task-15.5-trace-resource-inlining.md` moved the trace pipeline behind a `TraceBackend` interface so future adapters can reuse it.
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 is shipped; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+1. ✅ **C1a** — unblock UI tests (everything else benefits).
+2. ✅ **C1b–d** — reliability, diagnostics, page-object refactor.
+3. ✅ **C2** — get the Claude inner loop solid before adding scope.
+4. ✅ **B1** — refactor snapshot core (low risk, enables B2/B3).
+5. ✅ **C3** — demo reporting (depends on C1c trace format + C2 stable).
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

`CLAUDE.md` and `docs/Roadmap.md` had drifted from the shipped code on three points. This PR aligns the docs:

- **Task 15 status.** `CLAUDE.md` described Task 15 (Extract `@pagemirror/snapshot-core`) as **in progress** on a stale branch (`claude/check-task-statuses-C7rh9`). In reality the package is published at [`@pagemirror/snapshot-core@0.1.0`](https://www.npmjs.com/package/@pagemirror/snapshot-core) (`packages/snapshot-core/package.json:3`), `packages/playwright-snapshot-saver@0.7.0` consumes it via a semver dep (`packages/playwright-snapshot-saver/package.json:24`), all `.snapshots/` fixtures carry `"version": 2`, and the plugin loads v2 bundles (`SUPPORTED_BUNDLE_VERSION = 2` at `src/main/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundle.kt:16`). The headline status line in `CLAUDE.md` and `docs/Roadmap.md` also still said "Tasks 0–14 and 19 are complete", omitting Task 15.5 (trace-resource inlining via `TraceBackend`) which is fully implemented under `packages/snapshot-core/src/trace/`.
- **Test-project layout.** `packages/test-project/fixtures/styles/` (containing `reset.css`, `layout.css`, `components.css`, `theme.css`) exists on disk but was missing from the layout block in `CLAUDE.md`. These stylesheets exercise the sidecar-CSS rendering path.
- **Roadmap execution order.** B1 was not marked done in Track B, and the Suggested Execution Order didn't show which steps had landed.

### What changed

- `CLAUDE.md`
  - Bump "Tasks 0–14 and 19 are complete" → "Tasks 0–15.5 and 19 are complete"; mention `@pagemirror/snapshot-core` in the headline summary.
  - Rewrite the Task 15 entry from **in progress** → **complete**, with the actual package layout and published version.
  - Add `fixtures/styles/` to the test-project layout.
- `docs/Roadmap.md`
  - Same status bump in the Context paragraph; note Task 15.5 (`TraceBackend`).
  - Mark B1 ✅ Done in Track B.
  - Mark C1a / C1b–d / C2 / B1 / C3 ✅ done in Suggested Execution Order so the next-up list starts with **A1 (Python Playwright)**.

No code changes — docs only.

## Test plan

- [x] `git diff` reviewed — only `CLAUDE.md` and `docs/Roadmap.md` touched, no stray edits.
- [x] Statements cross-checked against the codebase:
  - `packages/snapshot-core/package.json` shows `@pagemirror/snapshot-core@0.1.0` published (`publishConfig.access: public`).
  - `packages/playwright-snapshot-saver/package.json` lists `@pagemirror/snapshot-core: ^0.1.0` under `dependencies` and `version: 0.7.0`.
  - All four `.snapshots/**/manifest.json` files have `"version": 2`.
  - `SnapshotBundle.kt:16` exports `const val SUPPORTED_BUNDLE_VERSION = 2`.
  - `packages/test-project/fixtures/styles/` contains the four `.css` files listed in the doc update.


---
_Generated by [Claude Code](https://claude.ai/code/session_01W2BRfPpmQuTbkKYouzSx4T)_