### PR TITLE
docs: align CLAUDE.md and Roadmap with shipped Task 15/15.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,11 +152,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, both
+npm packages (`@pagemirror/snapshot-core` and `playwright-snapshot-saver`)
+are published, the snapshot bundle format is at v2, the UI test suite
+runs under a layered Page Object structure, CI aggregates test results
+into a single `claude-summary.{json,md}` bundle, and a Playwright-style
+trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -169,28 +170,37 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** `packages/snapshot-core/`
+  ships the framework-agnostic engine (`assemble-html.ts`, `manifest.ts`,
+  `save-snapshot.ts`, `browser/collector.ts`) and is published as
+  `@pagemirror/snapshot-core@0.1.0`. `playwright-snapshot-saver@0.7.0`
+  depends on it via a `^0.1.0` semver range and provides the
+  `PlaywrightAdapter` shim. The snapshot bundle format is bumped to v2:
+  `screenshot.<ext>` lives under `resources/`, CSS is written as
+  `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+  inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+  relative URLs). v1 bundles are refused with a clear error and a
+  banner inside the tool window — regenerate via `npx playwright test`
+  in `packages/test-project/`. Released to users as plugin v0.5.0
+  (see `CHANGELOG.md`).
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+**Remaining roadmap tasks** (see `docs/Roadmap.md` and `docs/tasks/`):
+Track A language support (Task 16 Python, Task 18 JVM), Track B
+adapters (Task 17 Selenium/Cypress, Task 20 Appium/mobile). None are
+started.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,21 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for
+Playwright + TypeScript, both `@pagemirror/snapshot-core` and
+`playwright-snapshot-saver` are published to npm and produce v2 snapshot
+bundles (`resources/` sidecars, framework-agnostic trace rendering), the
+settings UI is on Kotlin UI DSL v2, the UI test suite runs under a
+layered Page Object structure with polling/retry/trace-bundle
+diagnostics, CI aggregates unit + UI + Playwright results into a single
+`claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`,
+and PRs tagged `demo` auto-render a Playwright-style trace viewer. The
+plugin is still tightly coupled to TypeScript (regex-based locator
+extraction) and Playwright (`PlaywrightAdapter` + Playwright trace
+loader). The remaining roadmap tracks add Python / JVM language support
+(A1, A2), Selenium / Cypress / Appium driver adapters built on the
+existing `PageAdapter` + `TraceBackend` interfaces (B2, B3), and any
+future infra polish.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,48 +24,45 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same v2 bundle layout (`index.html` + `manifest.json` + `resources/`) frozen in `docs/snapshot-bundle-spec.md`.
 
-- **A1. Python Playwright support** — `task-16-python-playwright-support.md`
-- **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
-
-Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implementation so the three language savers (TS/Python/JVM) stay in lockstep.
+- **A1. Python Playwright support** — `task-16-python-playwright-support.md` (not started)
+- **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md` (not started)
 
 ---
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
-- **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
-- **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` — **done.** `@pagemirror/snapshot-core@0.1.0` published; `playwright-snapshot-saver@0.7.0` depends on it. Trace pipeline also moved into core under Task 15.5 (`task-15.5-trace-resource-inlining.md`).
+- **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md` (not started)
+- **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md` (not started)
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B2 and B3 implement the existing `PageAdapter` + `TraceBackend` interfaces in core; no new abstractions needed.
 
 ---
 
 ## Track C — Repo / Inner Loop Improvements
 
-- **C1. UI test framework** — split into four subtasks:
+All three sub-tracks are **done**:
+
+- **C1. UI test framework** — split into four subtasks (all done):
   - `task-13a-ui-tests-unblock.md` — fix `splitMode` + fast-fail health check
   - `task-13b-ui-tests-reliability.md` — polling helpers, retry-once, `@Quarantine`
   - `task-13c-ui-tests-diagnostics.md` — per-test trace bundle (feeds C3)
   - `task-13d-ui-tests-page-object-refactor.md` — locators/pages/flows layering
-- **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md`
-- **C3. Feature demo reporting (Playwright-style trace viewer)** — `task-19-feature-demo-trace-viewer.md`
+- **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md` — done.
+- **C3. Feature demo reporting (Playwright-style trace viewer)** — `task-19-feature-demo-trace-viewer.md` — done.
 
 ---
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
-9. **B3** — mobile/Appium (largest unknowns).
+C1, C2, C3 and B1 (incl. 15.5) are done. Remaining order:
+
+1. **A1** — Python Playwright (highest user demand for language expansion).
+2. **B2** — Selenium/Cypress adapters.
+3. **A2** — Java/Kotlin Playwright.
+4. **B3** — mobile/Appium (largest unknowns).
 
 ---
 

--- a/docs/issues/manifest-timestamp-epoch.md
+++ b/docs/issues/manifest-timestamp-epoch.md
@@ -1,8 +1,17 @@
 # Manifest timestamp shows epoch-zero date
 
 > **Date:** 2026-04-01
-> **Status:** Open
+> **Status:** Resolved (Task 11)
 > **Affects:** `extractSnapshots()`, reporter
+>
+> Fixed in `packages/snapshot-core/src/trace/extract.ts` (`buildTraceManifest`,
+> lines 222–225): the manifest timestamp is now derived from
+> `marker.wallTime` (epoch ms reconstructed in
+> `packages/playwright-snapshot-saver/src/trace/playwright-backend.ts` via
+> `context.wallTime + (action.startTime - context.startTime)`). Falls back
+> to `new Date()` only when the trace omits wall-clock data. Verified by
+> the live `packages/test-project/.snapshots/dashboard/initial/manifest.json`
+> carrying real 2026-04 timestamps.
 
 ## Symptom
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` and `docs/Roadmap.md` still described **Task 15** (snapshot-core extraction) as in-progress on a stale branch (`claude/check-task-statuses-C7rh9`), even though:

- `@pagemirror/snapshot-core@0.1.0` and `playwright-snapshot-saver@0.7.0` are both published.
- The v2 bundle format (`resources/<sha1>.css`, `resources/screenshot.*`, inlined sidecars) is the live, shipped layout — plugin v0.5.0 already refuses v1 bundles with a banner (`CHANGELOG.md`, `model/SnapshotBundle.kt`).
- All Track C subtasks (13a–d, 14, 19) are also long shipped.

This PR aligns the docs with what's actually on disk:

- **`CLAUDE.md`** — "Current State" now reads "Tasks 0–15.5 and 19 are complete", folds the Task 15 description inline next to 15.5, and ends with a pointer to the remaining roadmap (Track A + B2/B3).
- **`docs/Roadmap.md`** — "Context" reflects published packages and the existing `PageAdapter` + `TraceBackend` interfaces; B1 marked **done** (incl. 15.5); C1/C2/C3 marked **done**; execution order pruned to the four remaining items.
- **`docs/issues/manifest-timestamp-epoch.md`** — flipped from **Open** to **Resolved** with file:line pointers to the fix in `packages/snapshot-core/src/trace/extract.ts` and verification against `packages/test-project/.snapshots/dashboard/initial/manifest.json` (real 2026-04 timestamps, no 1970).

No code changes; docs only.

## Test plan

- [ ] `CLAUDE.md` "Current State" reads cleanly and matches package versions (`packages/snapshot-core/package.json`, `packages/playwright-snapshot-saver/package.json`).
- [ ] `docs/Roadmap.md` Track A/B/C status reflects shipped tasks.
- [ ] `docs/issues/manifest-timestamp-epoch.md` status is **Resolved** with a verifiable code pointer.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jezv5h5w1aJaAoSQqMF87a)_