### PR TITLE
docs: align CLAUDE.md with shipped Task 15 + active SettingsUiTest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,11 +152,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published, `@pagemirror/snapshot-core` has been
+extracted with framework-agnostic trace rendering, the UI test suite runs
+under a layered Page Object structure, CI aggregates test results into a
+single `claude-summary.{json,md}` bundle, and a Playwright-style trace
+viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -171,13 +172,13 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped on main.
+  The snapshot bundle format is now v2: `screenshot.<ext>` lives under
+  `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+  referenced by `<link>`, and the plugin inlines sidecar CSS on read
+  (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are
+  refused with a clear error message — regenerate via `npx playwright
+  test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a
@@ -299,9 +300,11 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow`; it
+  became active after `PageMirrorConfigurable` was given explicit
+  accessible names on its testable fields (and the settings locators
+  in `PageMirrorLocators` were rewritten to match those names instead
+  of relying on UI DSL class-name quirks).
 
 ## Report Dashboard Access
 


### PR DESCRIPTION
## Summary

Two stale claims in `CLAUDE.md` were drifting from reality. This PR brings the doc back in sync with `main`.

**Task 15 is shipped, not in progress.** The previous text described Task 15 (`@pagemirror/snapshot-core` extraction and the v2 bundle format) as in progress on branch `claude/check-task-statuses-C7rh9`. In fact `SnapshotBundle.SUPPORTED_BUNDLE_VERSION = 2`, the resolver inlines sidecar CSS, and `packages/snapshot-core/` exists on main. Task 15 is now listed in the completed-tasks bullet list alongside 15.5, the substantive description of what v2 means (screenshot under `resources/`, `<sha1>.css` sidecars, plugin inlines on read, v1 refused with a clear error) is preserved, and the lead "Current State" sentence is updated from "Tasks 0–14 and 19 are complete" to "Tasks 0–15.5 and 19 are complete".

**SettingsUiTest is active, not `@Disabled`.** The UI Test Conventions section claimed `tests/SettingsUiTest.kt` was "currently `@Disabled` for unrelated reasons (UI DSL component wrapping)". The file has no `@Disabled` annotation and contains five active tests (UT-21 through UT-25); its own KDoc says it was enabled after `PageMirrorConfigurable` was given explicit accessible names. The paragraph now mirrors that wording and notes the parallel rewrite of `PageMirrorLocators`.

## Test plan

- [ ] Doc-only change, no code touched — CI just needs to stay green.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YNq7u2rpKdaeHsUACvMU3R)_