### PR TITLE
docs: align CLAUDE.md / Roadmap / USE.md with current main state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/             # external stylesheets referenced by the fixtures
+      reset.css
+      layout.css
+      components.css
+      theme.css
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -126,12 +131,19 @@ packages/test-project/
     dashboard.spec.ts
   .snapshots/
     login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
+      initial/         {index.html, manifest.json}
+      error-state/     {index.html, manifest.json}
     dashboard/
-      initial/        {index.html, manifest.json, resources/}
-      ticket-filled/  {index.html, manifest.json, resources/}
+      initial/         {index.html, manifest.json, resources/}
+      ticket-filled/   {index.html, manifest.json, resources/}
 ```
+
+`resources/` is present only when the captured page references external
+stylesheets/images (so the saver writes sidecars). The `login` fixture
+is single-file with inline styles, so its snapshots ship without a
+`resources/` directory; the `dashboard` fixture pulls in
+`fixtures/styles/*.css`, so its snapshots carry one `<sha1>.css` sidecar
+per external sheet.
 
 ## Task Sequence
 
@@ -152,11 +164,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, both npm
+packages (`@pagemirror/snapshot-core` and `playwright-snapshot-saver`)
+are published and produce v2 snapshot bundles, the plugin shows an
+in-tool-window banner when it finds outdated v1 bundles, the UI test
+suite runs under a layered Page Object structure, CI aggregates test
+results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -169,28 +183,36 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** `packages/snapshot-core/`
+  ships the framework-agnostic engine (`assemble-html.ts`, `manifest.ts`,
+  `save-snapshot.ts`, `browser/collector.ts`) and is published as
+  `@pagemirror/snapshot-core@0.1.0`. `playwright-snapshot-saver@0.7.0`
+  depends on it via a `^0.1.0` semver range and ships the
+  `PlaywrightAdapter` shim. The snapshot bundle format is bumped to v2:
+  `screenshot.<ext>` lives under `resources/`, CSS is written as
+  `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+  inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+  relative URLs). v1 bundles are refused; an outdated-bundle banner in
+  the tool window links to `docs/migration-v1-to-v2.md`. Released to
+  users as plugin v0.5.0 (see `CHANGELOG.md`).
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+**Remaining roadmap tasks** (see `docs/Roadmap.md` and `docs/tasks/`):
+Track A language support (Task 16 Python, Task 18 JVM) and Track B
+non-Playwright adapters (Task 17 Selenium/Cypress, Task 20
+Appium/mobile). None are started.
 
 ## Working with the Build
 
@@ -298,10 +320,12 @@ The layout was overhauled in Task 13 — follow these rules.
   idempotent. Tests should always be in working shape — fix flakiness,
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
-  Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  Page/Flow example. `tests/SettingsUiTest.kt` is the canonical example
+  for tests that compose `SettingsChangeFlow`; it became active after
+  `PageMirrorConfigurable` was given explicit accessible names on its
+  testable fields and the settings locators in `PageMirrorLocators`
+  were rewritten to match those names instead of relying on UI DSL
+  class-name quirks (JBIntSpinner vs JSpinner, etc.).
 
 ## Report Dashboard Access
 

--- a/USE.md
+++ b/USE.md
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false },
   manifest: true,
 });
 ```
@@ -98,9 +98,9 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` (the only format supported for live capture) |
-| `screenshot.fullPage` | `false` | Capture the full scrollable page |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Screenshot options. Pass `false` to disable the screenshot entirely. |
+| `screenshot.format` | `'png'` | `'png'` is the only format supported for live capture (`page.screenshot()` cannot produce webp). Trace-extracted snapshots emit webp from the screencast on their own. |
+| `screenshot.fullPage` | `false` | Capture the full scrollable page instead of just the viewport. |
 | `manifest` | `true` | Generate `manifest.json` |
 
 ### Option C: Extract from Existing Sources (CLI / API)

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, both `@pagemirror/snapshot-core` and `playwright-snapshot-saver` are published on npm and produce v2 snapshot bundles (`resources/` sidecars, framework-agnostic trace rendering), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The plugin is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (`PlaywrightAdapter` + Playwright trace loader). The remaining roadmap tracks add Python / JVM language support (A1, A2) and Selenium / Cypress / Appium driver adapters that plug into the existing `PageAdapter` + `TraceBackend` interfaces in `@pagemirror/snapshot-core` (B2, B3).
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,48 +10,45 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm packages cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the v2 bundle layout (`index.html` + `manifest.json` + `resources/`) frozen in `docs/snapshot-bundle-spec.md`.
 
-- **A1. Python Playwright support** — `task-16-python-playwright-support.md`
-- **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
-
-Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implementation so the three language savers (TS/Python/JVM) stay in lockstep.
+- **A1. Python Playwright support** — `task-16-python-playwright-support.md` (not started)
+- **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md` (not started)
 
 ---
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
-- **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
-- **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` — **done.** `@pagemirror/snapshot-core@0.1.0` is published, `playwright-snapshot-saver@0.7.0` depends on it. Trace rendering and resource inlining were also moved into core under Task 15.5 (`task-15.5-trace-resource-inlining.md`, done).
+- **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md` (not started)
+- **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md` (not started)
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B2 and B3 implement the existing `PageAdapter` + `TraceBackend` interfaces in `@pagemirror/snapshot-core`; no new abstractions are needed.
 
 ---
 
 ## Track C — Repo / Inner Loop Improvements
 
-- **C1. UI test framework** — split into four subtasks:
+All three sub-tracks are **done**:
+
+- **C1. UI test framework** — four subtasks (all done):
   - `task-13a-ui-tests-unblock.md` — fix `splitMode` + fast-fail health check
   - `task-13b-ui-tests-reliability.md` — polling helpers, retry-once, `@Quarantine`
   - `task-13c-ui-tests-diagnostics.md` — per-test trace bundle (feeds C3)
   - `task-13d-ui-tests-page-object-refactor.md` — locators/pages/flows layering
-- **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md`
-- **C3. Feature demo reporting (Playwright-style trace viewer)** — `task-19-feature-demo-trace-viewer.md`
+- **C2. CI test reporting + Claude loop** — `task-14-ci-test-reporting.md` — done.
+- **C3. Feature demo reporting (Playwright-style trace viewer)** — `task-19-feature-demo-trace-viewer.md` — done.
 
 ---
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
-9. **B3** — mobile/Appium (largest unknowns).
+C1, C2, C3, and B1 (incl. 15.5) are done. Remaining order:
+
+1. **A1** — Python Playwright (highest user demand for language expansion).
+2. **B2** — Selenium/Cypress adapters.
+3. **A2** — Java/Kotlin Playwright.
+4. **B3** — mobile/Appium (largest unknowns).
 
 ---
 

--- a/docs/issues/manifest-timestamp-epoch.md
+++ b/docs/issues/manifest-timestamp-epoch.md
@@ -1,8 +1,18 @@
 # Manifest timestamp shows epoch-zero date
 
 > **Date:** 2026-04-01
-> **Status:** Open
+> **Status:** Resolved (Task 11)
 > **Affects:** `extractSnapshots()`, reporter
+>
+> Fixed in `packages/snapshot-core/src/trace/extract.ts` (`buildTraceManifest`):
+> the manifest timestamp is now derived from `marker.wallTime` (epoch ms
+> reconstructed in
+> `packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`
+> from `context.wallTime + (action.startTime - context.startTime)`) and
+> falls back to `new Date()` only when the trace omits wall-clock data.
+> Verified by the regenerated
+> `packages/test-project/.snapshots/dashboard/initial/manifest.json`
+> carrying real 2026-04 timestamps.
 
 ## Symptom
 


### PR DESCRIPTION
## Summary

Fix several places where the docs lag the shipped code on main. No source changes.

### `CLAUDE.md`

- **Task 15 / 15.5 status.** The doc still says Task 15 is *"in progress on branch `claude/check-task-statuses-C7rh9`"*, but `packages/snapshot-core/` is published as `@pagemirror/snapshot-core@0.1.0`, `playwright-snapshot-saver@0.7.0` depends on it, the v2 bundle format is live, and the work was released as plugin v0.5.0 (see `CHANGELOG.md`). Rewritten as a shipped bullet under the Tasks list and bumped the headline from "Tasks 0–14 and 19" to "0–15.5 and 19". Added a note about the outdated-bundle banner that ships with v0.5.0.
- **`SettingsUiTest`.** The doc says it is `@Disabled` for UI DSL component-wrapping reasons. The file has no `@Disabled` annotation — it became active after `PageMirrorConfigurable` was given accessible names and `PageMirrorLocators` was rewritten against them. Updated the description to match the in-file comment.
- **Test Project Layout.** The doc omits `fixtures/styles/{reset,layout,components,theme}.css`, which the dashboard fixture references. Added the directory and clarified that `resources/` only appears on snapshots whose source page references external assets (login bundles ship without it; dashboard bundles ship with one `<sha1>.css` sidecar per external sheet).

### `docs/Roadmap.md`

- Bumped headline from "Tasks 0–14 plus 19" to "0–15.5 plus 19".
- Marked Track B1 (`task-15`) done and called out that the trace work moved into core under Task 15.5.
- Marked Track C (UI test framework, CI reporting, demo viewer) done.
- Reduced the Suggested Execution Order to the remaining tasks (A1, B2, A2, B3).
- Dropped the obsolete "freeze `snapshot-bundle-spec.md` before A1/A2" sentence — the spec is already the source of truth.

### `USE.md`

- Removed the non-existent `screenshot.enabled` option from the `saveSnapshot` example and the options table. The actual API (`packages/snapshot-core/src/save-snapshot.ts:115`) accepts `screenshot: ScreenshotOptions | false`; pass `false` to disable.

### `docs/issues/manifest-timestamp-epoch.md`

- Status was "Open"; the bug was fixed under Task 11. Added a "Resolved (Task 11)" header pointing at the live fix in `snapshot-core/src/trace/extract.ts:buildTraceManifest` and the `wallTime` reconstruction in the Playwright backend.

## Notes on overlap with other open PRs

There are ~20 open docs-alignment PRs (#69–#89) covering subsets of this same drift. This PR merges the same alignment work into a single self-contained diff and additionally fixes `USE.md` (`screenshot.enabled`) and `docs/issues/manifest-timestamp-epoch.md`, which most of the earlier PRs do not touch. The other PRs can be closed once this lands.

## Test plan

- [ ] CI: `unit-tests`, `ui-tests`, `playwright-tests`, `test-report` jobs green. (Docs-only change — no code paths touched.)
- [ ] Manual: render `CLAUDE.md`, `docs/Roadmap.md`, `USE.md`, `docs/issues/manifest-timestamp-epoch.md` and sanity-check formatting.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KYEsSiSFcJ2mDoYP6sfmxk)_