### PR TITLE
docs: align CLAUDE.md + Roadmap with shipped Task 15 / 15.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,12 +126,16 @@ packages/test-project/
     dashboard.spec.ts
   .snapshots/
     login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
     dashboard/
       initial/        {index.html, manifest.json, resources/}
       ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+`resources/` is only emitted when the captured page references external
+stylesheets/fonts/images that need sidecaring; the self-contained login
+fixture does not.
 
 ## Task Sequence
 
@@ -152,11 +156,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15 (including 15.5) and 19 are complete.** All plugin features
+ship, the snapshot saver npm package is published, `@pagemirror/snapshot-core`
+owns the framework-agnostic bundle assembly + trace rendering, the UI test
+suite runs under a layered Page Object structure, CI aggregates test
+results into a single `claude-summary.{json,md}` bundle, and a
+Playwright-style trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -171,13 +176,17 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete and merged
+to main.** `@pagemirror/snapshot-core` (v0.1.0) owns bundle assembly,
+manifest generation, and HTML post-processing under `packages/snapshot-core/src/`;
+`playwright-snapshot-saver` (v0.7.0) depends on it via `^0.1.0` and reduces
+to a thin Playwright adapter (`packages/playwright-snapshot-saver/src/playwright-adapter.ts`).
+The snapshot bundle format is now v2: `screenshot.<ext>` lives under
+`resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced
+by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc`
+iframes can't resolve relative URLs). v1 bundles are refused with a clear
+error message — regenerate via `npx playwright test` in
+`packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15 (including 15.5) plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the framework-agnostic `@pagemirror/snapshot-core` engine, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The architecture is still tightly coupled to TypeScript (regex-based locator extraction); Track A below adds Python/JVM locator extractors, and Track B layers Selenium / Cypress / Appium adapters on top of the extracted snapshot-core.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,7 +21,7 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` *(complete; see also `task-15.5-trace-resource-inlining.md`)*
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` still showed **Task 15 (snapshot-core extraction)** as *in progress on branch `claude/check-task-statuses-C7rh9`*, and the `Current State` opener said only "Tasks 0–14 and 19 are complete". `docs/Roadmap.md` had matching stale context.

In fact, on `main`:
- `packages/snapshot-core/` ships `@pagemirror/snapshot-core` at v0.1.0 with its own `src/`, `tests/`, and `README.md`.
- `packages/playwright-snapshot-saver/` (v0.7.0) depends on it via `^0.1.0` and reduces to a Playwright adapter.
- Task 15.5's trace renderer (`packages/snapshot-core/src/trace/{types,renderer,inline,extract,runtime-script,content-type}.ts`) plus the Playwright backend (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) are present and consumed by `extractor.ts`.
- All `packages/test-project/.snapshots/*/manifest.json` carry `"version": 2`; dashboard bundles use `resources/<sha1>.css` sidecars.

This PR brings the docs in line with that reality.

## Changes

- **`CLAUDE.md`**
  - `Current State` opener now reads "Tasks 0–15 (including 15.5) and 19 are complete" and credits `@pagemirror/snapshot-core` for owning bundle assembly + trace rendering.
  - Task 15 paragraph rewritten as past-tense ("complete and merged to main"), references the actual v0.1.0 package and the `playwright-adapter.ts` thin shim, and drops the stale branch reference.
  - Test Project Layout block: `login/initial` and `login/error-state` no longer claim a `resources/` subdir (the login fixture is self-contained and emits none); added a one-line note that `resources/` is conditional.
- **`docs/Roadmap.md`**
  - Context paragraph updated to "Tasks 0–15 (including 15.5) plus 19 are complete" and rewords the Track A/B sentence so it no longer talks about Task 15 as future work.
  - Track B B1 bullet annotated `(complete; see also task-15.5-trace-resource-inlining.md)`.

## Verification

- `packages/snapshot-core/package.json` → `"name": "@pagemirror/snapshot-core", "version": "0.1.0"`.
- `packages/playwright-snapshot-saver/package.json` → depends on `"@pagemirror/snapshot-core": "^0.1.0"`.
- `find packages/test-project/.snapshots -maxdepth 4 -type f` confirms only the `dashboard/*` bundles ship `resources/<sha1>.css` sidecars; both `login/*` bundles are `{index.html, manifest.json}` only.
- All file paths cited in CLAUDE.md (`packages/snapshot-core/src/trace/*.ts`, `playwright-backend.ts`, `playwright-adapter.ts`, `SnapshotHtmlResolver.kt`, `buildSrc/.../*.kt`, `build.gradle.kts:219`/`:261`) verified to exist at the locations referenced.

No code changes; docs only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CGgbs3PDE8iQsSjNvaAapp)_