### PR TITLE
docs: fix USE.md screenshot defaults and saveSnapshot API shape

### DIFF
--- a/USE.md
+++ b/USE.md
@@ -65,7 +65,7 @@ npx playwright test
 | Option | Default | Description |
 |--------|---------|-------------|
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace screencast |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp`. Off by default since trace screencast frames are low-fidelity and frequently blank. |
 | `manifest` | `true` | Generate `manifest.json` with metadata |
 
 ```typescript
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false },
   manifest: true,
 });
 ```
@@ -98,7 +98,7 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Pass `false` to disable, or override fields |
 | `screenshot.format` | `png` | `png` (the only format supported for live capture) |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
@@ -139,7 +139,7 @@ const result = await extractSnapshots({
 |--------|---------|-------------|
 | `source` | (required) | Report directory, trace ZIP path, or URL |
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp`. Off by default since trace screencast frames are low-fidelity and frequently blank. |
 | `manifest` | `true` | Generate `manifest.json` |
 | `filter.page` | — | Only extract this page |
 | `filter.state` | — | Only extract this state |


### PR DESCRIPTION
## Summary

Audited the project docs against the shipped code. The previous alignment commit (`b105504`) is mostly current, but `USE.md` still misdocuments the `screenshot` option in three places. The package READMEs (`playwright-snapshot-saver/README.md`, `snapshot-core/README.md`) are already correct — this PR brings `USE.md` in line with them and with the code in `extractor.ts` / `save-snapshot.ts`.

### Drift fixed in `USE.md`

| Section | Claim | Reality |
|---|---|---|
| Reporter options table (L68) | `screenshot` default is `true` | `extractor.ts:36` is `options.screenshot === true` → default `false`, and `types.ts:18` literally says `(default: false)` |
| `extractSnapshots` options table (L142) | `screenshot` default is `true` | Same code path — default `false` |
| `saveSnapshot` example (L91) | `screenshot: { enabled: true, format: 'png', fullPage: false }` | `SaveSnapshotOptions.screenshot` is `Partial<ScreenshotOptions> \| false`; there is no `enabled` field |
| `saveSnapshot` options table (L101) | `screenshot.enabled` row | Same — disabling is done by passing `screenshot: false`, not a nested `enabled: false` |

The fix follows the wording already used in `packages/playwright-snapshot-saver/README.md` for consistency.

### Verified in sync (no changes needed)

- `CLAUDE.md` Plugin Source Layout, Test Project Layout, Current State task references, min platform / plugin ID
- `README.md` features list and `screenshot` shape description
- `docs/snapshot-bundle-spec.md` v2 layout, sidecar naming, manifest schema, scripts-not-stripped note
- `docs/migration-v1-to-v2.md`
- `CHANGELOG.md` top entry

## Test plan

- [x] `git diff` reviewed — only `USE.md` changed, four single-line edits
- [x] Each new default cross-checked against `packages/playwright-snapshot-saver/src/{reporter,extractor,types}.ts` and `packages/snapshot-core/src/{save-snapshot,types}.ts`
- [x] No code changes — docs only, no test impact

---
_Generated by [Claude Code](https://claude.ai/code/session_017BUjZQLAujKEnfJADnMfAy)_