### PR TITLE
docs: mark SettingsUiTest as enabled in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,9 +299,11 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow` — it
+  was re-enabled once `PageMirrorConfigurable` gained explicit
+  accessible names on its four testable fields and the settings
+  locators in `ui/locators/PageMirrorLocators.kt` were rewritten to
+  target those names directly.
 
 ## Report Dashboard Access
 


### PR DESCRIPTION
## Summary

CLAUDE.md's "UI Test Conventions → Reference tests" bullet claimed `tests/SettingsUiTest.kt` was `@Disabled` for UI DSL component wrapping reasons. That stopped being true once `PageMirrorConfigurable` gained accessible names on its testable fields and `ui/locators/PageMirrorLocators.kt` was rewritten to target them — the test class is active (no `@Disabled` annotation, and its own Kdoc says "Enabled after `PageMirrorConfigurable` was given explicit accessible names...").

This PR aligns the doc with the code.

## Audit scope

A broader doc-vs-code audit was performed across `CLAUDE.md`, `README.md`, `USE.md`, `docs/snapshot-bundle-spec.md`, `docs/migration-v1-to-v2.md`, `docs/Roadmap.md`, `docs/release-flow.md`, `docs/release-runbook.md`, and `docs/tasks/*.md`. All file paths, plugin configuration values, task statuses, build.gradle.kts line references (`:112-144`, `:219`, `:261`), package layouts (`packages/snapshot-core/`, `packages/playwright-snapshot-saver/`, `packages/test-project/`), and snapshot bundle v2 format claims checked out. The `SettingsUiTest` status was the only material mismatch.

## Test plan

- [ ] CI green on `test-report` job for this branch


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBtFbYUhLyjQEgiUFPZ7Wc)_