### PR TITLE
docs: fix screenshot defaults and migration symbol references

### DIFF
--- a/USE.md
+++ b/USE.md
@@ -65,7 +65,7 @@ npx playwright test
 | Option | Default | Description |
 |--------|---------|-------------|
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace screencast |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp`. Off by default since 0.6.0; pass `true` to re-enable. |
 | `manifest` | `true` | Generate `manifest.json` with metadata |
 
 ```typescript
@@ -88,7 +88,7 @@ await saveSnapshot(page, {
   outputDir: '.snapshots',
   name: 'login-initial',
   group: 'login',
-  screenshot: { enabled: true, format: 'png', fullPage: false },
+  screenshot: { format: 'png', fullPage: false }, // or `false` to skip, or omit for defaults
   manifest: true,
 });
 ```
@@ -98,8 +98,8 @@ await saveSnapshot(page, {
 | `outputDir` | (required) | Base output directory |
 | `name` | (required) | Snapshot name — becomes the subdirectory |
 | `group` | — | Parent group directory |
-| `screenshot.enabled` | `true` | Capture a screenshot |
-| `screenshot.format` | `png` | `png` (the only format supported for live capture) |
+| `screenshot` | `{ format: 'png', fullPage: false }` | Screenshot options. Pass `false` to disable, omit for defaults. |
+| `screenshot.format` | `png` | `png` (the only format supported for live capture; `webp` throws — for webp bytes use the trace-extraction path) |
 | `screenshot.fullPage` | `false` | Capture the full scrollable page |
 | `manifest` | `true` | Generate `manifest.json` |
 
@@ -139,7 +139,7 @@ const result = await extractSnapshots({
 |--------|---------|-------------|
 | `source` | (required) | Report directory, trace ZIP path, or URL |
 | `outputDir` | `.snapshots` | Where to save snapshots |
-| `screenshot` | `true` | Extract screenshot from trace |
+| `screenshot` | `false` | Extract a screencast frame as `resources/screenshot.webp`. Off by default since 0.6.0; pass `true` to re-enable. |
 | `manifest` | `true` | Generate `manifest.json` |
 | `filter.page` | — | Only extract this page |
 | `filter.state` | — | Only extract this state |

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -119,5 +119,5 @@ initial/
 
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
-- Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
+- Plugin loader: `SnapshotBundle.kt` — `SUPPORTED_BUNDLE_VERSION` constant + `BundleLoadResult.UnsupportedVersion`
 - Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant


### PR DESCRIPTION
## Summary

Two doc-vs-code mismatches surfaced when comparing `main` against the shipped code:

### `USE.md` — `screenshot` defaults & non-existent `enabled` field

- **Reporter and `extractSnapshots` `screenshot` default.** Docs claimed `true`; the code default is `false` (changed in 0.6.0 — see `packages/playwright-snapshot-saver/README.md` "Changed in 0.6.0" note and `ExtractOptions` in `packages/playwright-snapshot-saver/src/types.ts:18-19`). Updated both option tables to match.
- **`screenshot.enabled` field.** The `SaveSnapshotOptions` table and example code showed `screenshot: { enabled: true, format: 'png', fullPage: false }`. `enabled` is not a real field — `ScreenshotOptions` in `packages/snapshot-core/src/types.ts:64-67` is `{ format, fullPage }` only, and `resolveScreenshot()` in `save-snapshot.ts:114-123` just ignores anything else. To disable, callers pass `screenshot: false`. Updated the table and the example to reflect the actual API and added a brief note that `format: 'webp'` throws for live capture.

### `docs/migration-v1-to-v2.md` — symbol that doesn't exist

- The "Reference" section pointed at `SnapshotBundle.kt — isSupportedVersion() method`. That method was never written; the real loader uses `const val SUPPORTED_BUNDLE_VERSION = 2` (`SnapshotBundle.kt:16`) and surfaces rejections via `BundleLoadResult.UnsupportedVersion`. Updated the reference to the real symbols.

Everything else in `docs/snapshot-bundle-spec.md`, `Roadmap.md`, `release-flow.md`, `release-runbook.md`, the package READMEs, and `CHANGELOG.md` matched the current code on inspection — no other edits needed.

## Test plan

- [x] `git diff` shows only the two file changes (10 + 2 lines).
- [x] Cross-checked `USE.md` defaults against `packages/playwright-snapshot-saver/README.md` (which already documented `screenshot: false` correctly) and against `ExtractOptions` / `SnapshotReporterOptions` source.
- [x] Cross-checked `SaveSnapshotOptions` shape against `packages/snapshot-core/src/types.ts` and `save-snapshot.ts`.
- [x] Confirmed `SUPPORTED_BUNDLE_VERSION` + `BundleLoadResult.UnsupportedVersion` are the real symbols in `src/main/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundle.kt`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QcW4Mk2fxe11wMSnsDggFW)_