### PR TITLE
docs: mark Task 15/15.5 complete and refresh SettingsUiTest note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published, the framework-agnostic `@pagemirror/snapshot-core`
+package owns bundle assembly and trace rendering, the UI test suite runs under
+a layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,10 +172,12 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete**. The
+framework-agnostic `packages/snapshot-core/` package owns bundle assembly,
+manifest generation, and HTML post-processing; `packages/playwright-snapshot-saver/`
+depends on it via semver. The snapshot bundle format is v2:
+`screenshot.<ext>` lives under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
 inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
 URLs). v1 bundles are refused with a clear error message — regenerate via
 `npx playwright test` in `packages/test-project/`.
@@ -299,9 +302,11 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow`; it was
+  enabled after `PageMirrorConfigurable` gained explicit accessible names
+  on its four testable fields and the locators in `PageMirrorLocators`
+  were rewritten to match those names instead of relying on UI DSL
+  class-name quirks.
 
 ## Report Dashboard Access
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` package owns bundle assembly and trace rendering, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction). With `snapshot-core` extracted, Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` _(complete)_, plus `task-15.5-trace-resource-inlining.md` _(complete)_
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 (and its 15.5 follow-up) shipped; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+1. **C1a** — unblock UI tests (everything else benefits). _(done)_
+2. **C1b–d** — reliability, diagnostics, page-object refactor. _(done)_
+3. **C2** — get the Claude inner loop solid before adding scope. _(done)_
+4. **B1** — refactor snapshot core (low risk, enables B2/B3). _(done)_
+5. **C3** — demo reporting (depends on C1c trace format + C2 stable). _(done)_
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

Audited the docs on `main` against the actual code state and found two stale claims in `CLAUDE.md` (and corresponding stale framing in `docs/Roadmap.md`):

1. **Task 15 status** — `CLAUDE.md` said Task 15 (`@pagemirror/snapshot-core` extraction) was "in progress on branch `claude/check-task-statuses-C7rh9`", but:
   - the branch no longer exists,
   - `packages/snapshot-core/` ships with `MANIFEST_VERSION = 2` (`packages/snapshot-core/src/types.ts:154`),
   - `packages/playwright-snapshot-saver/` depends on it via semver,
   - all `packages/test-project/.snapshots/*/` bundles are v2 with `resources/<sha1>.css` sidecars,
   - Task 15.5 (framework-agnostic trace rendering + resource inlining) is also fully landed (`packages/snapshot-core/src/trace/*` + `packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`).

2. **`SettingsUiTest.kt` status** — `CLAUDE.md` said it is "currently `@Disabled` for unrelated reasons (UI DSL component wrapping)", but the file (`src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/tests/SettingsUiTest.kt`) has no `@Disabled` annotation. Per its own docstring it was re-enabled after `PageMirrorConfigurable` gained accessible names and `PageMirrorLocators` was rewritten to match them.

## Changes

- `CLAUDE.md` — "Current State" header now says "Tasks 0–15.5 and 19 are complete"; Task 15 paragraph rewritten in past tense; SettingsUiTest reference updated to reflect that it is active.
- `docs/Roadmap.md` — context paragraph drops the framing where Task 15 is still upcoming; Track B's B1 entry and the Suggested Execution Order list mark B1/15.5 as done.

All other audited claims (Plugin Source Layout, Test Project Layout, Task 13a/c/d, Task 14 line numbers, Task 19 files, CI workflow, snapshot bundle spec) were verified against the tree and match reality.

## Test plan

- [ ] Re-read `CLAUDE.md` "Current State" and confirm Task 15/15.5 wording matches what's on `main`.
- [ ] Confirm `docs/Roadmap.md` no longer reads as if `snapshot-core` is still a future refactor.
- [ ] Spot-check `src/uiTest/.../tests/SettingsUiTest.kt` has no `@Disabled`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4ZmhC6VGCBmXa2a2KYTys)_