### PR TITLE
docs: mark Task 15 / 15.5 complete in CLAUDE.md and Roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,11 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` is extracted and powering the v2 bundle
+format end-to-end, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,12 +173,16 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped the
+framework-agnostic core package at `packages/snapshot-core/` (browser
+collector, HTML assembler, manifest builder, save orchestration). The
+Playwright saver was rewritten as a thin `PageAdapter` over the core
+(`packages/playwright-snapshot-saver/src/playwright-adapter.ts`). This
+bumped the snapshot bundle format to v2: `screenshot.<ext>` moves under
+`resources/`, CSS is written as `resources/<sha1>.css` sidecars
+referenced by `<link>`, and the plugin inlines sidecar CSS on read
+(since `srcdoc` iframes can't resolve relative URLs). v1 bundles are
+refused with a clear error message — regenerate via
 `npx playwright test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` package (Task 15) now owns bundle assembly, manifest generation, HTML post-processing, and trace rendering (Task 15.5) behind a `PageAdapter` / `TraceBackend` surface, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction). Future Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) plug into `snapshot-core` without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ done (see also `task-15.5-trace-resource-inlining.md`)
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor and has shipped; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+1. **C1a** ✅ done — unblock UI tests (everything else benefits).
+2. **C1b–d** ✅ done — reliability, diagnostics, page-object refactor.
+3. **C2** ✅ done — get the Claude inner loop solid before adding scope.
+4. **B1** ✅ done — refactor snapshot core (low risk, enables B2/B3).
+5. **C3** ✅ done — demo reporting (depends on C1c trace format + C2 stable).
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

`CLAUDE.md` still described **Task 15 — Extract `@pagemirror/snapshot-core`** as "in progress on branch `claude/check-task-statuses-C7rh9`", which contradicted the same file's own "Tasks 0–14 and 19 are complete" headline and is no longer true: the `packages/snapshot-core/` package, the v2 bundle layout, and the Playwright adapter are all on `main` and powering both live capture and trace extraction (Task 15.5). `docs/snapshot-bundle-spec.md` and `docs/migration-v1-to-v2.md` already treat Task 15 as the source of v2 — only the high-level state summaries were stale.

This PR realigns the high-level docs with the code without touching any source.

### Verified against `main`

- `packages/snapshot-core/` exists with `package.json` declaring `@pagemirror/snapshot-core` v0.1.0 and the documented `src/{index,types,manifest,save-snapshot,assemble-html}.ts` + `browser/collector.ts` + `trace/{types,renderer,inline,extract,runtime-script,content-type}.ts` files.
- `packages/playwright-snapshot-saver/src/playwright-adapter.ts` and `trace/playwright-backend.ts` exist — the Playwright saver is the thin adapter Task 15 specified.
- Plugin source layout, `build.gradle.kts` line references (`runIdeForUiTests` at 114, `aggregateTestReport` at 219, `testReport` at 261), `buildSrc/.../buildtools/` class list, and `src/uiTest/.../ui/{locators,pages,flows,tests,support,annotations,fixtures}/` layout all match the current docs and need no changes.
- `sinceBuild = "243"` confirmed in `build.gradle.kts`.

### Changes

- `CLAUDE.md` — bump "Current State" headline from "0–14 and 19" to "0–15.5 and 19", and rewrite the Task 15 paragraph in past tense, naming the actual shipped paths (`packages/snapshot-core/`, `packages/playwright-snapshot-saver/src/playwright-adapter.ts`).
- `docs/Roadmap.md` — context paragraph, Track B1 bullet, and "Suggested Execution Order" updated to show B1 (Task 15), C1, C2, and C3 (Task 19) as done.

## Test plan

- [ ] Re-read `CLAUDE.md` "Current State" — no contradictions, Task 15 reads as complete, Task 15.5 still describes the trace-rendering implementation.
- [ ] Re-read `docs/Roadmap.md` — completed items are marked, the next unstarted item is A1 (Python Playwright).
- [ ] Confirm no other doc references "in progress" for Task 15 (`grep -n 'Task 15.*in progress'` returns nothing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SJ1M2ds8pS4nBkwDBVNXJp)_