### PR TITLE
docs: align CLAUDE.md test-project layout with on-disk reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,8 +126,8 @@ packages/test-project/
     dashboard.spec.ts
   .snapshots/
     login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
     dashboard/
       initial/        {index.html, manifest.json, resources/}
       ticket-filled/  {index.html, manifest.json, resources/}


### PR DESCRIPTION
## Summary

The "Test Project Layout" snippet in `CLAUDE.md` showed `{index.html, manifest.json, resources/}` for all four snapshot bundles under `packages/test-project/.snapshots/`. That doesn't match what's actually on disk.

Under the v2 snapshot bundle format, the saver only emits a `resources/` subdirectory when there's something to put in it (external CSS sidecars, screenshots, etc.). The login pages have no external CSS to extract, so their bundles ship just `index.html` + `manifest.json`. Only the dashboard bundles have `resources/`.

## Change

Drop `, resources/` from the two `login/*` lines in the layout snippet. Dashboard lines stay as-is.

## Verified on disk

- `packages/test-project/.snapshots/login/initial/` -> `index.html`, `manifest.json` (no `resources/`)
- `packages/test-project/.snapshots/login/error-state/` -> `index.html`, `manifest.json` (no `resources/`)
- `packages/test-project/.snapshots/dashboard/initial/` -> `index.html`, `manifest.json`, `resources/` (4 CSS sidecars)
- `packages/test-project/.snapshots/dashboard/ticket-filled/` -> same shape as `dashboard/initial/`

Doc-only change; no code or behavior is affected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CAZotgNNSuGEHHQqifALhE)_