### PR TITLE
docs: mark Tasks 15 and 15.5 complete in CLAUDE.md and Roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+`playwright-snapshot-saver` and `@pagemirror/snapshot-core` npm packages
+are published, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,16 +172,17 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete**. The
+extracted package ships at `packages/snapshot-core/` and the snapshot
+bundle format is bumped to v2: `screenshot.<ext>` moves under
+`resources/`, CSS is written as `resources/<sha1>.css` sidecars
+referenced by `<link>`, and the plugin inlines sidecar CSS on read
+(since `srcdoc` iframes can't resolve relative URLs). v1 bundles are
+refused with a clear error message — regenerate via
 `npx playwright test` in `packages/test-project/`.
 
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
+**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** is
+**complete**. `@pagemirror/snapshot-core` now owns trace rendering behind a
 `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
 renderer, inline, extract, runtime-script, content-type}.ts`). The
 Playwright package (`packages/playwright-snapshot-saver/src/trace/

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` and `@pagemirror/snapshot-core` npm packages ship snapshots and trace renders from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The architecture is still tightly coupled to TypeScript on the IDE side (regex-based locator extraction); the snapshot saver, however, is now framework-agnostic — `@pagemirror/snapshot-core` (Task 15) owns bundle assembly and trace rendering behind a `TraceBackend` interface, so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can layer on top without duplicating that work.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` (done; also Task 15.5 trace-rendering refactor in `task-15.5-trace-resource-inlining.md`)
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 shipped (`@pagemirror/snapshot-core` is on npm). B2 and B3 layer new adapters on top of the extracted core via the `PageAdapter` + `TraceBackend` surfaces it exposes.
 
 ---
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
+1. ~~**C1a** — unblock UI tests (everything else benefits).~~ **done**
+2. ~~**C1b–d** — reliability, diagnostics, page-object refactor.~~ **done**
+3. ~~**C2** — get the Claude inner loop solid before adding scope.~~ **done**
+4. ~~**B1** — refactor snapshot core (low risk, enables B2/B3).~~ **done** (incl. Task 15.5)
 5. **A1** — Python Playwright (highest user demand for language expansion).
 6. **B2** — Selenium/Cypress adapters.
 7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+8. ~~**C3** — demo reporting (depends on C1c trace format + C2 stable).~~ **done**
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

Audited CLAUDE.md and `docs/` against the current state of `main` and found one outdated section: Task 15 (Extract `@pagemirror/snapshot-core`) was still listed as **"in progress on branch `claude/check-task-statuses-C7rh9`"**, even though:

- `packages/snapshot-core/` is fully present on `main` with a published `package.json` (`@pagemirror/snapshot-core@0.1.0`).
- The v2 snapshot bundle format Task 15 introduced shipped in plugin **v0.5.0 (2026-04-16)** per `CHANGELOG.md`.
- The follow-up Task 15.5 (framework-agnostic trace rendering + resource inlining) is already merged (`feat(snapshot-core): own trace rendering + resource inlining`).
- The branch `claude/check-task-statuses-C7rh9` no longer exists.
- The `README.md` and `docs/snapshot-bundle-spec.md` already describe snapshot-core as shipped.
- `docs/Roadmap.md` echoed the same outdated "Tasks 0-14 plus 19 are complete" line.

Every other claim in CLAUDE.md (plugin source layout, 17 source files, `build.gradle.kts` line refs at 112-144/219/261, Task 13a-d files, Task 19 files, `META-INF/plugin.xml` ID, snapshot bundle layout, packages directory contents) was verified to match reality.

## Changes

- **CLAUDE.md** — updated the "Current State" intro from "Tasks 0-14 and 19" to "Tasks 0-15.5 and 19"; mention both npm packages (`playwright-snapshot-saver` and `@pagemirror/snapshot-core`) as published; changed the Task 15 paragraph from "in progress on branch `claude/check-task-statuses-C7rh9`" to "complete" with the `packages/snapshot-core/` location; marked Task 15.5 explicitly as complete.
- **docs/Roadmap.md** — same correction in the Context paragraph; updated the Track B / B1 bullet to note B1 shipped (incl. Task 15.5); struck out the completed items (C1a, C1b-d, C2, B1, C3) in the "Suggested Execution Order".

## Test plan

- [ ] Diff is documentation-only — no code, no schemas, no CI files touched.
- [ ] No links or paths broken; all referenced files (`task-15-snapshot-core-extraction.md`, `task-15.5-trace-resource-inlining.md`, `packages/snapshot-core/`) still exist.
- [ ] CI green on this branch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rc7t16je3nSvM8okYe5cg1)_