### PR TITLE
docs: mark Task 15 / 15.5 complete in CLAUDE.md and fix stale paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,10 @@ packages/test-project/
 
 Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
+The table below covers the MVP sequence (tasks 0–9). Tasks 10–20 are
+each documented individually under `docs/tasks/` — see "Current State"
+below for their status and key outputs.
+
 | #  | Task                              | Key Output                        | Depends On |
 |----|-----------------------------------|-----------------------------------|------------|
 | 0  | Dummy Playwright test project     | `.snapshots/` with real data      | Nothing    |
@@ -152,11 +156,13 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` package is published and consumed via semver,
+trace-extracted bundles are fully self-contained, the UI test suite runs
+under a layered Page Object structure, CI aggregates test results into a
+single `claude-summary.{json,md}` bundle, and a Playwright-style trace
+viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -169,28 +175,13 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
-- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** `@pagemirror/snapshot-core@0.1.0` ships as a publishable package under `packages/snapshot-core/`; `playwright-snapshot-saver` consumes it via `^0.1.0` and is itself published at `0.7.0`. Snapshot bundles are on format v2: `screenshot.<ext>` lives under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a clear error message — regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` now owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
+- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `ui/support/FeatureTagListener.kt`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+Tasks 16, 17, 18, and 20 (Python / Selenium / Cypress / JVM-Playwright /
+Appium adapters) are planned future work — see `docs/tasks/` for the
+individual specs. They have not been implemented.
 
 ## Working with the Build
 


### PR DESCRIPTION
## Summary

`CLAUDE.md`'s "Current State" section was out of sync with `main`:

- It claimed **Task 15 (Extract `@pagemirror/snapshot-core`) is in progress on branch `claude/check-task-statuses-C7rh9`**, but the package has shipped: `packages/snapshot-core/package.json` is at `0.1.0`, `playwright-snapshot-saver` (`0.7.0`) consumes it via `^0.1.0`, all `packages/test-project/.snapshots/*/manifest.json` fixtures are on `version: 2`, and the v2 bundle layout (`resources/<sha1>.css` sidecars, `resources/screenshot.*`) is what's actually on disk.
- The lead sentence only listed **"Tasks 0–14 and 19 are complete"**, omitting 15 and 15.5 entirely.
- The Task 19 bullet referenced `FeatureTagListener` as if it lived next to `ui/annotations/Feature.kt`, but the listener is actually at `src/uiTest/.../ui/support/FeatureTagListener.kt`.
- The **Task Sequence** table only covers tasks 0–9, with no pointer to where the rest are documented.

This PR is docs-only:

- Update the lead sentence to `Tasks 0–15, 15.5, and 19 are complete`, mentioning the published `@pagemirror/snapshot-core` and self-contained trace bundles.
- Fold Tasks 15 and 15.5 into the existing per-task bullet list (previously they were standalone paragraphs claiming "in progress" / dangling at the bottom).
- Add a one-line note that tasks 16/17/18/20 (Python / Selenium / Cypress / JVM-Playwright / Appium adapters) are planned future work — they exist in `docs/tasks/` but have not shipped.
- Fix the Task 19 bullet path: `ui/support/FeatureTagListener.kt`.
- Add a sentence above the Task Sequence table directing readers to `docs/tasks/` for tasks 10–20.

No code changes; no behavior changes; no impact on CI.

## Test plan

- [x] `git diff` only touches `CLAUDE.md`.
- [x] Verified `packages/snapshot-core/package.json` is published at `0.1.0` and consumed via semver by `playwright-snapshot-saver`.
- [x] Verified `packages/test-project/.snapshots/*/manifest.json` fixtures are all on `"version": 2`.
- [x] Verified `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/support/FeatureTagListener.kt` exists at the corrected path.
- [x] No new tests required — docs-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WnGJB3X5NF2FgGovkKxfEM)_