### PR TITLE
docs: mark Task 15 + 15.5 complete and refresh stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/                       # external CSS for fixture pages (Task 15.5 resource-inlining tests)
+      reset.css
+      layout.css
+      theme.css
+      components.css
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -152,9 +157,11 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, both
+npm packages (`@pagemirror/snapshot-core` and `playwright-snapshot-saver`)
+are published to the public registry and consumed via semver, the snapshot
+bundle format is on v2, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -162,35 +169,16 @@ auto-generated on PRs tagged `demo`.
   bridge, element picker, gutter validation, polish, JS refactor,
   Highlight All, and the `playwright-snapshot-saver` npm package.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
-- **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
+- **Task 11 (Manifest fixes):** timestamp, change detection, version increment. Note: the version-increment write counter was reverted under Task 15 — `manifest.version` is now a fixed schema version (always `2`). See `docs/migration-v1-to-v2.md`.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
-- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
+- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:114`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** the framework-agnostic core lives in `packages/snapshot-core/` and owns the bundle layout, manifest building, HTML assembly, and the browser-side collector. `packages/playwright-snapshot-saver/` is a thin Playwright adapter on top, consuming `@pagemirror/snapshot-core` via semver. The snapshot bundle format bumped to v2: `screenshot.<ext>` lives under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a clear error message — regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` now also owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, both `@pagemirror/snapshot-core` and `playwright-snapshot-saver` are published to the npm registry, the snapshot bundle format is on v2 (screenshot + CSS sidecars live under `resources/`; the core also owns framework-agnostic trace rendering and full resource inlining), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current IDE-side architecture is still tightly coupled to TypeScript (regex-based locator extraction); language-specific locator extractors (Python/JVM, Tasks 16/18) and additional snapshot-saver adapters built on top of the framework-agnostic core (Selenium/Cypress/Appium, Tasks 17/20) are the remaining roadmap items.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ (complete; `@pagemirror/snapshot-core` published)
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor (now done); B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 

--- a/docs/issues/manifest-timestamp-epoch.md
+++ b/docs/issues/manifest-timestamp-epoch.md
@@ -1,8 +1,9 @@
 # Manifest timestamp shows epoch-zero date
 
 > **Date:** 2026-04-01
-> **Status:** Open
+> **Status:** Resolved
 > **Affects:** `extractSnapshots()`, reporter
+> **Fixed in:** `packages/playwright-snapshot-saver/src/trace/playwright-adapter.ts` — `markerTimestamp` now anchors against `context.wallTime + (action.startTime - context.startTime)`, and `extractFromBackend` (in `packages/snapshot-core/src/trace/extract.ts`) derives `manifest.timestamp` from `marker.wallTime`. The on-disk fixtures in `packages/test-project/.snapshots/` carry real ISO timestamps (e.g. `2026-04-15T21:07:18.357Z`).
 
 ## Symptom
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -119,5 +119,5 @@ initial/
 
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
-- Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
+- Plugin loader: `SnapshotBundle.kt` — version is checked against the `SUPPORTED_BUNDLE_VERSION` constant inside `SnapshotBundle.load()`
 - Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant


### PR DESCRIPTION
## Summary

Audited the docs against the actual code in the main branch. Found four spots where the docs lag the code after Task 15 (snapshot-core extraction) and Task 15.5 (framework-agnostic trace rendering + resource inlining) landed and both npm packages were published. This PR re-aligns them.

## Mismatches found

| File | What the doc said | What the code actually does |
|---|---|---|
| `CLAUDE.md` "Current State" | Task 15 is "in progress on branch `claude/check-task-statuses-C7rh9`" | That branch does not exist; `packages/snapshot-core/` is published and consumed by `packages/playwright-snapshot-saver/` via semver. Task 15.5 (which builds on 15) was already described as complete in the same section. |
| `CLAUDE.md` Task 13a | Cites `build.gradle.kts:112-144` | `register("runIdeForUiTests")` is at `build.gradle.kts:114`. |
| `CLAUDE.md` Test Project Layout | No `fixtures/styles/` directory | `packages/test-project/fixtures/styles/{reset,layout,theme,components}.css` exists (used by Task 15.5 resource-inlining tests). |
| `docs/Roadmap.md` Context | "Tasks 0–14 plus 19 are complete… Task 15 below extracts a framework-agnostic core" | Tasks 0–15, 15.5, and 19 are complete; B1 (extraction) is done. |
| `docs/issues/manifest-timestamp-epoch.md` | Status: Open | Fixed: `markerTimestamp` now anchors against `context.wallTime + (action.startTime - context.startTime)` in `packages/playwright-snapshot-saver/src/trace/playwright-adapter.ts:190-192`, and `manifest.timestamp` is derived from `marker.wallTime` in `packages/snapshot-core/src/trace/extract.ts:222-225`. On-disk fixtures carry real ISO timestamps like `2026-04-15T21:07:18.357Z`. |
| `docs/migration-v1-to-v2.md` | References `SnapshotBundle.kt` → `isSupportedVersion()` method | No such method. The version check uses the `SUPPORTED_BUNDLE_VERSION` constant inside `SnapshotBundle.load()`. |

## Changes

- `CLAUDE.md`: merge Task 15 and 15.5 into the completed list; drop the dead branch reference; note that Task 11's manifest write-counter behavior was reverted under Task 15; fix the `runIdeForUiTests` line number; add `fixtures/styles/` to the test-project layout.
- `docs/Roadmap.md`: update Context paragraph to reflect Tasks 0–15, 15.5, 19 complete; mark B1 done.
- `docs/issues/manifest-timestamp-epoch.md`: mark Resolved and point at the two fix sites.
- `docs/migration-v1-to-v2.md`: replace the bogus `isSupportedVersion()` reference with the actual mechanism (`SUPPORTED_BUNDLE_VERSION` constant inside `SnapshotBundle.load()`).

## Test plan

- [x] No code changes — only Markdown.
- [x] Diff reviewed manually; every claim left in the docs is traceable to a current source location.
- [ ] Optional: confirm CI `test-report` job still passes on this branch (no source change, so no test regressions expected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WQFNKqRDNQ4KmTpWmuQfqE)_