### PR TITLE
docs: mark Task 15/15.5 complete, align Roadmap with v2 bundle layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published, `@pagemirror/snapshot-core` is extracted
+and consumed via semver, the UI test suite runs under a layered Page
+Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,13 +172,17 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** — shipped on `main`.
+`packages/snapshot-core/` (`@pagemirror/snapshot-core@0.1.0`) owns the
+browser-side collector, the Node-side HTML assembler, manifest building,
+and `saveSnapshot` orchestration behind the `PageAdapter` interface.
+`playwright-snapshot-saver@^0.7.0` consumes it via semver as a thin
+Playwright adapter. The snapshot bundle format is now v2:
+`screenshot.<ext>` lives under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` package has been extracted and owns both live-capture assembly and trace rendering behind the `PageAdapter` / `TraceBackend` interfaces, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction). The remaining roadmap layers Selenium / Cypress / Appium / Python / JVM adapters (Tasks 16–18, 20) on top of the extracted core.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk v2 bundle format (`index.html` + `manifest.json` + `resources/`, with `screenshot.<ext>` and `<sha1>.css` sidecars under `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
@@ -21,7 +21,7 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` **(done)** — extended by Task 15.5 (`task-15.5-trace-resource-inlining.md`) which moved trace rendering + resource inlining into the core behind the `TraceBackend` interface.
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+1. ~~**C1a** — unblock UI tests (everything else benefits).~~ **done**
+2. ~~**C1b–d** — reliability, diagnostics, page-object refactor.~~ **done**
+3. ~~**C2** — get the Claude inner loop solid before adding scope.~~ **done**
+4. ~~**B1** — refactor snapshot core (low risk, enables B2/B3).~~ **done** (incl. Task 15.5)
+5. ~~**C3** — demo reporting (depends on C1c trace format + C2 stable).~~ **done**
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

CLAUDE.md and `docs/Roadmap.md` had drifted out of sync with the code:

- **CLAUDE.md** described Task 15 as "in progress on branch `claude/check-task-statuses-C7rh9`", but the work has shipped on `main`. `@pagemirror/snapshot-core@0.1.0` is published, `playwright-snapshot-saver@^0.7.0` consumes it via semver, the v2 bundle layout (`resources/screenshot.<ext>`, `resources/<sha1>.css` sidecars) is what every saver produces, and v1 bundles are refused.
- **`docs/Roadmap.md`** carried the same outdated "Tasks 0–14 plus 19 are complete" lede and still referenced the pre-v2 bundle layout (`index.html + screenshot.webp + manifest.json` at the top level) when describing what the future Python / JVM savers must reproduce.

This PR aligns both files with what's actually on disk and on npm.

## Changes

- `CLAUDE.md` Current State: bump completed range to "Tasks 0–15.5 and 19", note the snapshot-core extraction in the lede.
- `CLAUDE.md` Task 15 block: replace the "in progress on branch …" paragraph with a "shipped on `main`" description that names the published package versions and the `PageAdapter` boundary. The v2 format text is preserved.
- `docs/Roadmap.md` Context: bump completed range, mention the `PageAdapter` / `TraceBackend` interfaces, drop the "Task 15 below extracts …" sentence since it's already done.
- `docs/Roadmap.md` Track A intro: replace the v1 bundle-layout example with the v2 layout (`resources/` directory, sidecar CSS).
- `docs/Roadmap.md` Track B: mark B1 as **done** and note that Task 15.5 extended it.
- `docs/Roadmap.md` Suggested Execution Order: strike through items C1a, C1b–d, C2, B1, and C3 (all complete) and renumber the remaining items.

Nothing else changes — the snapshot bundle spec, migration guide, and package READMEs already describe the v2 layout correctly.

## Test plan

- [ ] CI green on `test-report` (docs-only change, no production code touched)
- [ ] Manually re-read `CLAUDE.md` Current State and confirm it matches `packages/snapshot-core/package.json` (`0.1.0`) and `packages/playwright-snapshot-saver/package.json` (`0.7.0`)
- [ ] Manually re-read `docs/Roadmap.md` and confirm bundle layout matches `docs/snapshot-bundle-spec.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbufPW847VjtKB29dEFopo)_