### PR TITLE
docs: mark Tasks 15 and 15.5 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,11 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` package is extracted and consumed by the
+Playwright saver, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,13 +173,16 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is **complete**. The
+package lives at `packages/snapshot-core/` (published as
+`@pagemirror/snapshot-core`) and `packages/playwright-snapshot-saver/`
+depends on it as a thin Playwright adapter. This task also bumped the
+snapshot bundle format to v2: `screenshot.<ext>` moves under
+`resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced
+by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc`
+iframes can't resolve relative URLs). v1 bundles are refused with a clear
+error message — regenerate via `npx playwright test` in
+`packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` package is extracted and consumed by the Playwright saver (with bundle format bumped to v2 — `resources/` sidecars and self-contained trace rendering), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). With `@pagemirror/snapshot-core` extracted, Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can now layer on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` *(complete)* and `task-15.5-trace-resource-inlining.md` *(complete)*
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 shipped: `@pagemirror/snapshot-core` owns bundle assembly, the v2 bundle layout, and framework-agnostic trace rendering behind a `TraceBackend` interface. B2 and B3 layer new adapters on top by implementing `TraceBackend`.
 
 ---
 
@@ -43,15 +43,12 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
-9. **B3** — mobile/Appium (largest unknowns).
+Completed prerequisites: **C1a–d**, **C2**, **C3**, and **B1** (Tasks 13a–d, 14, 19, 15, 15.5) all shipped on `main`. The remaining order is:
+
+1. **A1** — Python Playwright (highest user demand for language expansion).
+2. **B2** — Selenium/Cypress adapters.
+3. **A2** — Java/Kotlin Playwright.
+4. **B3** — mobile/Appium (largest unknowns).
 
 ---
 


### PR DESCRIPTION
## Summary

`CLAUDE.md` and `docs/Roadmap.md` still described Task 15 (Extract `@pagemirror/snapshot-core`) as an in-progress refactor on a feature branch. In reality the package has shipped — `packages/snapshot-core/` is a published workspace (`@pagemirror/snapshot-core@0.1.0`) consumed by `packages/playwright-snapshot-saver/`, the v2 bundle layout it introduced is live, and Task 15.5 (framework-agnostic trace rendering behind `TraceBackend`) is also already complete on `main`.

This PR aligns the docs to reality. No code changes.

## Changes

- **`CLAUDE.md`** — bump the *Current State* headline to "Tasks 0–15, 15.5, and 19 are complete", and rewrite the Task 15 paragraph to describe the shipped package (location, consumers, v2 bundle layout) instead of an in-progress branch.
- **`docs/Roadmap.md`** —
  - Update the *Context* section to reflect that `@pagemirror/snapshot-core` is extracted and that adapter work (16–18, 20) can now layer on top.
  - Annotate Track B → B1 as *(complete)* and link Task 15.5 alongside Task 15.
  - Trim the *Suggested Execution Order* so it lists only the still-open items (A1, B2, A2, B3); C1a–d, C2, C3, and B1 are called out as completed prerequisites.

## Audit method

Spawned an `Explore` subagent to diff every doc file against the actual repo state (`packages/`, `src/main/kotlin/`, `plugin.xml`, READMEs, CHANGELOGs, per-task `Status:` fields). Everything else aligned — these four mismatches were the only stale claims found. Verified the findings by reading the flagged files and confirming `packages/snapshot-core/package.json` exists at v0.1.0.

## Test plan

- [x] `git diff` confirms only docs touched (no source or build files).
- [x] Reviewed updated text in `CLAUDE.md` "Current State" and `docs/Roadmap.md` (Context, Track B, Suggested Execution Order).
- [ ] CI: docs-only change; the `test-report` job should run unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhosQKLZMATN7S2gUtiidf)_