### PR TITLE
docs: align CLAUDE.md and Roadmap.md with shipped state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/
+      components.css
+      layout.css
+      reset.css
+      theme.css
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -152,11 +157,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published, `@pagemirror/snapshot-core` is extracted
+and powers v2 bundles, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single `claude-summary.{json,md}`
+bundle, and a Playwright-style trace viewer is auto-generated on PRs
+tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -171,13 +177,19 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped in plugin
+v0.5.0. The framework-agnostic core lives in `packages/snapshot-core/`
+(published as `@pagemirror/snapshot-core` v0.1.0) and powers
+`playwright-snapshot-saver`'s live-capture pipeline; trace extraction
+stays in the Playwright package. This bumped the snapshot bundle format
+to v2: `screenshot.<ext>` moves under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative URLs). The plugin refuses v1 bundles
+(`SUPPORTED_BUNDLE_VERSION = 2` in `model/SnapshotBundle.kt`) and
+surfaces an in-tool-window banner pointing users at
+`docs/migration-v1-to-v2.md`; regenerate via `npx playwright test` in
+`packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the extracted framework-agnostic `@pagemirror/snapshot-core` package (v2 bundle format), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction). With the core extracted, Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,12 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` *(complete; `@pagemirror/snapshot-core` shipped in plugin v0.5.0)*
+- **B1.5. Framework-agnostic trace rendering + resource inlining** — `task-15.5-trace-resource-inlining.md` *(complete; `TraceBackend` interface in `packages/snapshot-core/src/trace/`)*
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1/B1.5 were pure refactors and are done; B2 and B3 layer new adapters on top of the extracted core via the same `TraceBackend` surface.
 
 ---
 
@@ -43,14 +44,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+1. ~~**C1a**~~ — unblock UI tests (everything else benefits). *(done)*
+2. ~~**C1b–d**~~ — reliability, diagnostics, page-object refactor. *(done)*
+3. ~~**C2**~~ — get the Claude inner loop solid before adding scope. *(done)*
+4. ~~**B1 / B1.5**~~ — refactor snapshot core, framework-agnostic trace rendering. *(done)*
+5. ~~**C3**~~ — demo reporting (depends on C1c trace format + C2 stable). *(done)*
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

The state notes in `CLAUDE.md` and `docs/Roadmap.md` drifted behind the code: Task 15 (snapshot-core extraction + v2 bundle format) actually shipped in plugin v0.5.0 (see `CHANGELOG.md`), `@pagemirror/snapshot-core` is published at `0.1.0`, and the plugin enforces `SUPPORTED_BUNDLE_VERSION = 2` in `model/SnapshotBundle.kt` — but both docs still described Task 15 as in-progress on a dead branch. The Test Project Layout block in `CLAUDE.md` also omitted the `packages/test-project/fixtures/styles/` directory (four CSS fixtures used by the snapshot tests).

This PR is docs-only — no code changes.

## Changes

- `CLAUDE.md`
  - "Current State" header now reads "Tasks 0–15.5 and 19 are complete" and mentions the extracted `@pagemirror/snapshot-core`.
  - Task 15 bullet rewritten to say it shipped in v0.5.0, points at `packages/snapshot-core/`, `SUPPORTED_BUNDLE_VERSION`, and `docs/migration-v1-to-v2.md`. Removes the stale "in progress on branch `claude/check-task-statuses-C7rh9`" claim.
  - "Test Project Layout" block adds `fixtures/styles/{components,layout,reset,theme}.css`.
- `docs/Roadmap.md`
  - "Context" paragraph: Tasks 0–15.5 + 19 complete; Track B no longer described as future work.
  - Track B list marks B1 and the previously-unmentioned B1.5 (Task 15.5) as complete and links to their task docs.
  - "Suggested Execution Order" strikes through the steps that are done (C1a, C1b–d, C2, B1/B1.5, C3) and leaves the remaining language/adapter work numbered ahead.

## Verification

- `git diff --stat` on `main..claude/loving-carson-69rmvk` is `CLAUDE.md` + `docs/Roadmap.md` only.
- Cross-referenced doc claims against code: `packages/snapshot-core/package.json` (v0.1.0, published), `CHANGELOG.md` (v0.5.0 ⚠️ breaking v2 bundle entry), `src/main/kotlin/.../model/SnapshotBundle.kt` (`SUPPORTED_BUNDLE_VERSION = 2`), `docs/migration-v1-to-v2.md`, `packages/test-project/fixtures/` (styles directory present).
- No code touched, so no test runs needed; CI on this PR will exercise the standard unit / UI / playwright matrix as a sanity check.

---
_Generated by [Claude Code](https://claude.ai/code/session_01De6pJYQtGxD8xN3paVwTaD)_