### PR TITLE
docs: mark Task 15/15.5 complete and refresh bundle layout references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,11 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+`@pagemirror/snapshot-core` + `playwright-snapshot-saver` npm packages
+are published (the saver consumes core via semver), the snapshot bundle
+format is at v2, the UI test suite runs under a layered Page Object
+structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -169,28 +171,32 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped as
+  `packages/snapshot-core/` (`assemble-html.ts`, `manifest.ts`,
+  `save-snapshot.ts`, `browser/collector.ts`, `types.ts`).
+  `playwright-snapshot-saver` is a thin Playwright adapter
+  (`playwright-adapter.ts` + the `index.ts` shim) that depends on
+  `@pagemirror/snapshot-core` via semver (`^0.1.0`). The snapshot bundle
+  format is bumped to v2: `screenshot.<ext>` lives under `resources/`,
+  CSS is written as `resources/<sha1>.css` sidecars referenced by
+  `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc`
+  iframes can't resolve relative URLs). v1 bundles trigger the
+  outdated-bundle banner in the tool window — regenerate via
+  `npx playwright test` in `packages/test-project/`. See
+  `docs/migration-v1-to-v2.md`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` now owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 
@@ -299,9 +305,9 @@ The layout was overhauled in Task 13 — follow these rules.
   do not hide it.
 - **Reference tests.** `tests/ToolWindowUiTest.kt` is the canonical
   Page/Flow example for active tests. `tests/SettingsUiTest.kt` is the
-  canonical example for tests that compose `SettingsChangeFlow`; it is
-  currently `@Disabled` for unrelated reasons (UI DSL component
-  wrapping) but kept as a structural reference.
+  canonical example for tests that compose `SettingsChangeFlow`; it was
+  re-enabled after `PageMirrorConfigurable` was given explicit
+  accessible names on its four testable fields.
 
 ## Report Dashboard Access
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,21 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for
+Playwright + TypeScript; the `@pagemirror/snapshot-core` package owns
+framework-agnostic bundle assembly + trace rendering, and
+`playwright-snapshot-saver` is now a thin Playwright adapter on top of
+it; the snapshot bundle format is at v2 (`index.html` + `manifest.json`
++ `resources/` with `screenshot.<ext>` and sidecar CSS); the settings
+UI is on Kotlin UI DSL v2; the UI test suite runs under a layered Page
+Object structure with polling/retry/trace-bundle diagnostics; CI
+aggregates unit + UI + Playwright results into a single
+`claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`;
+and PRs tagged `demo` auto-render a Playwright-style trace viewer. The
+remaining architectural coupling is to TypeScript (regex-based locator
+extraction) and to Playwright as the only trace backend; the Selenium /
+Cypress / Appium / Python / JVM tasks below layer new adapters on top
+of `snapshot-core` without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +24,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (v2: `index.html` + `manifest.json` + `resources/` holding `screenshot.<ext>` and sidecar CSS) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
@@ -21,11 +35,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` (done — shipped as `packages/snapshot-core/`)
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 is shipped; B2 and B3 layer new adapters on top of the extracted core (and on the `TraceBackend` interface added in Task 15.5).
 
 ---
 


### PR DESCRIPTION
## Summary

Realign `CLAUDE.md` and `docs/Roadmap.md` with the actual state of `main` after an audit against the source tree. Three concrete mismatches were found:

1. **Task 15 status.** `CLAUDE.md` and `Roadmap.md` still described Task 15 (`@pagemirror/snapshot-core` extraction) as in-progress on a stale branch (`claude/check-task-statuses-C7rh9`). On `main` the work has shipped: `packages/snapshot-core/` contains `assemble-html.ts`, `manifest.ts`, `save-snapshot.ts`, `browser/collector.ts`, and `types.ts`; `playwright-snapshot-saver` is now a thin Playwright adapter (`playwright-adapter.ts` + the `index.ts` shim) consuming `@pagemirror/snapshot-core` via semver (`^0.1.0`); and the v0.5.0 changelog entry calls out the v2 bundle bump.

2. **Snapshot bundle layout in Roadmap.md.** The Context and Track A blurbs still referenced the v1 layout `index.html + screenshot.webp + manifest.json`. The bundle has been at v2 since Task 15: `index.html + manifest.json + resources/` with `screenshot.<ext>` and sidecar CSS — confirmed against `packages/test-project/.snapshots/` and `docs/snapshot-bundle-spec.md`.

3. **`SettingsUiTest.kt` is no longer `@Disabled`.** `CLAUDE.md` claimed the test was kept as a `@Disabled` structural reference for UI DSL component wrapping. `grep` against `src/uiTest/.../tests/*.kt` returns no `@Disabled` annotation, and the file's own header comment says it was enabled after `PageMirrorConfigurable` was given explicit accessible names on its four testable fields.

The "Tasks complete" headline on both docs is updated to **0–15, 15.5, and 19**, and the per-task list in `CLAUDE.md` now has Task 15 / 15.5 entries pointing at the real on-disk paths.

No source code changes — docs only.

## Test plan

- [x] Re-grep `src/uiTest/.../tests/` for `@Disabled` — no matches; SettingsUiTest is genuinely enabled.
- [x] Inspect `packages/test-project/.snapshots/dashboard/initial/` — contains `index.html + manifest.json + resources/<sha1>.css` (v2 layout) and `manifest.json` reports `"version": 2`.
- [x] Confirm `packages/snapshot-core/package.json` is at `0.1.0` and `playwright-snapshot-saver/package.json` depends on `@pagemirror/snapshot-core: ^0.1.0`.
- [x] Verify `build.gradle.kts` line refs from `CLAUDE.md` still hit the right blocks (`:112-144` for `runIdeForUiTests`, `:219` and `:261` for `aggregateTestReport` / `testReport`).
- [ ] No CI suites are sensitive to docs-only changes; the standard test-report job is sufficient.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQEiCyCcTJagi7EEChAQk1)_