### PR TITLE
docs: align with current code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/                   # components.css, layout.css, reset.css, theme.css
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -126,12 +127,16 @@ packages/test-project/
     dashboard.spec.ts
   .snapshots/
     login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
+      initial/        {index.html, manifest.json}              # no external CSS
+      error-state/    {index.html, manifest.json}
     dashboard/
-      initial/        {index.html, manifest.json, resources/}
+      initial/        {index.html, manifest.json, resources/}  # CSS sidecars
       ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+`resources/` is only emitted when the page references external assets
+(CSS sidecars, screenshots, fonts). Snapshots that captured a page with
+only inline `<style>` legitimately ship without it.
 
 ## Task Sequence
 
@@ -152,11 +157,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, the framework-agnostic
+`@pagemirror/snapshot-core` engine is extracted, the UI test suite runs
+under a layered Page Object structure, CI aggregates test results into a
+single `claude-summary.{json,md}` bundle, and a Playwright-style trace
+viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -169,28 +175,9 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** `packages/snapshot-core/` ships as `@pagemirror/snapshot-core@0.1.0` (publishable to npm) with the framework-agnostic engine — `assembleHtml`, `buildManifest`, `saveSnapshot`, and the `PageAdapter` surface driver packages implement. `packages/playwright-snapshot-saver` consumes it via semver. The snapshot bundle format is bumped to v2: `screenshot.<ext>` moves under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a clear error message — regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight current locator** — press `Alt+Shift+H` to flash the locator on the line under your cursor.
+- **Highlight All** — click the **Show All** button in the Page Mirror tool window to highlight every locator in the open file at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -224,6 +224,10 @@ The editor gutter shows a badge next to each locator with the number of matching
 - **0** — no match (broken selector)
 - **2+** — multiple matches (ambiguous selector)
 
+### Highlight current locator
+
+Press `Alt+Shift+H` to highlight only the locator on the **current cursor line** — useful for confirming what a single selector targets without dismissing the rest of the file.
+
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror tool window toolbar to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges. The button toggles — click again (it now reads **Show All \***) to clear.

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -120,4 +120,4 @@ initial/
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
 - Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
-- Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant
+- Manifest builder: `packages/snapshot-core/src/manifest.ts` (`MANIFEST_VERSION` constant is defined in `packages/snapshot-core/src/types.ts` and re-exported via `index.ts`)


### PR DESCRIPTION
## Summary

Walked the docs (CLAUDE.md, README.md, USE.md, docs/) against the current code on `main` and fixed the drifted bits.

### CLAUDE.md — Task 15 is no longer "in progress"
- The "Current State" header still claimed Task 15 was in progress on a feature branch, but `packages/snapshot-core/` already ships in main as `@pagemirror/snapshot-core@0.1.0` (publishable, with `publishConfig.access: public`), and `packages/playwright-snapshot-saver` consumes it via semver. Promoted to a completed bullet and updated the leading summary line to read "Tasks 0–15, 15.5, and 19 are complete."
- Folded Task 15.5 into the same ordered bullet list so the list isn't split across "completed" bullets and standalone paragraphs.

### CLAUDE.md — Test Project Layout
- Added the `fixtures/styles/` subdir (real contents: `components.css`, `layout.css`, `reset.css`, `theme.css`) that the listing was missing.
- Corrected the `.snapshots/login/{initial,error-state}/` rows — they ship with `index.html` + `manifest.json` only (no `resources/`), because the login pages have only inline `<style>`. Added a one-line note that `resources/` is only emitted when the captured page references external assets.

### README.md / USE.md — Highlight-All shortcut was wrong
- Both docs claimed `Alt+Shift+H` triggers Highlight All. In the actual plugin, `Alt+Shift+H` is bound to `HighlightCurrentSelectorAction` (highlights only the current cursor line), and the "highlight everything" feature is the **Show All** toolbar button in the Page Mirror tool window (`PageMirrorToolWindowFactory.kt:70`, calls `service.highlightAllLocators(...)`). Updated both docs to describe the button and added a separate entry for what `Alt+Shift+H` actually does.

### docs/migration-v1-to-v2.md
- Reference pointed at `manifest.ts` for the `MANIFEST_VERSION` constant. The constant is defined in `snapshot-core/src/types.ts` and re-exported via `index.ts`; updated to say so.

### Confirmed accurate, no change
- Plugin source layout in CLAUDE.md (`src/main/`)
- `packages/snapshot-core/src/trace/` file list (Task 15.5 description)
- `aggregateTestReport`/`testReport` line references in `build.gradle.kts`
- `docs/release-flow.md`, `docs/release-runbook.md`, `docs/snapshot-bundle-spec.md`
- `packages/playwright-snapshot-saver/README.md`, `packages/snapshot-core/README.md`
- CHANGELOG.md (0.5.0 is current, matches `gradle.properties`)
- `.github/workflows/ci.yml` redlines (upload step still present, no `continue-on-error`)

## Test plan

- [ ] Render `CLAUDE.md`, `README.md`, `USE.md`, and `docs/migration-v1-to-v2.md` in the PR view and confirm Markdown still formats correctly.
- [ ] Spot-check: `Alt+Shift+H` in the running plugin highlights only the cursor-line locator; the "Show All" tool-window button highlights every locator in the open file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01BQZuouAdytt5wfBmvwCsFG)_