### PR TITLE
docs: mark Task 15 + 15.5 as complete and align stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/                       # external CSS served by the dev server
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -126,12 +127,17 @@ packages/test-project/
     dashboard.spec.ts
   .snapshots/
     login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
     dashboard/
       initial/        {index.html, manifest.json, resources/}
       ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+`resources/` is only present when `index.html` references external
+files (CSS sidecars, screenshots, fonts, etc.). Bundles whose captured
+DOM had no external references — e.g. the login fixtures, which carry
+only inline `<style>` — omit it entirely.
 
 ## Task Sequence
 
@@ -152,9 +158,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published on top of the framework-agnostic
+`@pagemirror/snapshot-core` engine, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,13 +178,16 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped the v2 snapshot
+bundle format: `screenshot.<ext>` moved under `resources/`, CSS is now
+written as `resources/<sha1>.css` sidecars referenced by `<link>`, and
+the plugin inlines sidecar CSS on read (since `srcdoc` iframes can't
+resolve relative URLs). v1 bundles are refused with a clear error
+message — regenerate via `npx playwright test` in
+`packages/test-project/`. The framework-agnostic engine lives at
+`packages/snapshot-core/` and the Playwright saver
+(`packages/playwright-snapshot-saver/`) is now a thin adapter on top of
+it.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the framework-agnostic `@pagemirror/snapshot-core` engine (which also owns trace rendering and resource inlining), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The IDE-side architecture is still tightly coupled to TypeScript (regex-based locator extraction), but the snapshot saver is now framework-agnostic so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on `snapshot-core` without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ **Complete** (plus Task 15.5: trace rendering + resource inlining moved into core)
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor (now shipped); B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -119,5 +119,5 @@ initial/
 
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
-- Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
+- Plugin loader: `SnapshotBundle.kt` — `SUPPORTED_BUNDLE_VERSION` constant + `SnapshotBundle.load()`
 - Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant


### PR DESCRIPTION
## Summary

Routine docs-vs-code audit found that several docs still described Task 15 (snapshot-core extraction) as "in progress on branch `claude/check-task-statuses-C7rh9`", but the package and its v2 bundle format are shipped on main (`packages/snapshot-core/` with full trace rendering; the plugin's `SnapshotBundle.load()` refuses anything other than `manifest.version=2`).

### Changes

- **`CLAUDE.md` — Current State.** Update to "Tasks 0–15, 15.5, and 19 are complete." Rewrite the Task 15 paragraph from "in progress on branch …" to a shipped-state description that points at `packages/snapshot-core/` and clarifies the Playwright saver is now a thin adapter on top of it.
- **`CLAUDE.md` — Test Project Layout.** The login `initial/` and `error-state/` bundles do **not** contain a `resources/` directory — their captured DOM only carries inline `<style>`, so there is nothing to sidecar. Show `resources/` only on the dashboard bundles (which actually have it) and add a one-paragraph rule explaining when it is omitted. Also add the existing `fixtures/styles/` directory that backs the dashboard CSS sidecars.
- **`docs/Roadmap.md`.** Same status correction in the "Context" paragraph and a "✅ Complete" marker on Track B1 (Extract framework-agnostic core).
- **`docs/migration-v1-to-v2.md`.** Fix a dangling reference to `SnapshotBundle.kt — isSupportedVersion()`. That method doesn't exist; the actual code exposes the `SUPPORTED_BUNDLE_VERSION` constant and `SnapshotBundle.load()` (which returns a `BundleLoadResult.UnsupportedVersion` case for the wrong version).

### Verification

- `packages/snapshot-core/src/trace/{content-type,extract,inline,renderer,runtime-script,types}.ts` all exist on main.
- `src/main/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundle.kt` defines `const val SUPPORTED_BUNDLE_VERSION = 2` and a public `fun load(dir: Path): BundleLoadResult`; no `isSupportedVersion` symbol exists.
- `packages/test-project/.snapshots/login/{initial,error-state}/` contain only `index.html` + `manifest.json` (no `resources/`); `packages/test-project/.snapshots/dashboard/{initial,ticket-filled}/` each contain `resources/` with `<sha1>.css` sidecars.
- `packages/test-project/fixtures/styles/` contains `components.css`, `layout.css`, `reset.css`, `theme.css`.

No code changes; docs-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_014s15m5RccPaUXsukgZi4Si)_