### PR TITLE
docs: align CLAUDE.md and Roadmap with shipped Task 15 + real layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,11 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/
+      components.css
+      layout.css
+      reset.css
+      theme.css
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -126,8 +131,8 @@ packages/test-project/
     dashboard.spec.ts
   .snapshots/
     login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
     dashboard/
       initial/        {index.html, manifest.json, resources/}
       ticket-filled/  {index.html, manifest.json, resources/}
@@ -152,8 +157,9 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core` is
+extracted and reused by the saver, the UI test suite runs under a layered
 Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
@@ -169,15 +175,17 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
-- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
+- **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `ui/support/FeatureTagListener.kt`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped. The package
+lives at `packages/snapshot-core/` (`@pagemirror/snapshot-core`, v0.1.0)
+and is consumed by `playwright-snapshot-saver` via semver. Task 15 also
+bumped the snapshot bundle format to v2: `screenshot.<ext>` moves under
+`resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced
+by `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc`
+iframes can't resolve relative URLs). v1 bundles are refused with a clear
+error message — regenerate via `npx playwright test` in
+`packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the extracted `@pagemirror/snapshot-core`, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Track B1 (framework-agnostic `@pagemirror/snapshot-core`) shipped so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` **(complete)**
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 shipped as `@pagemirror/snapshot-core`; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 
@@ -43,15 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
-9. **B3** — mobile/Appium (largest unknowns).
+Completed so far: **C1a → C1d**, **C2**, **B1**, **C3**.
+
+Remaining:
+
+1. **A1** — Python Playwright (highest user demand for language expansion).
+2. **B2** — Selenium/Cypress adapters.
+3. **A2** — Java/Kotlin Playwright.
+4. **B3** — mobile/Appium (largest unknowns).
 
 ---
 


### PR DESCRIPTION
## Summary

Audited `CLAUDE.md` and top-level docs against the current `main` branch to
catch drift. Three real mismatches, one minor wording issue — fixed in this
PR. Everything else (plugin source layout table, UI test conventions, gradle
line references, snapshot bundle spec, release flow / runbook) already
matches the code.

## Changes

**`CLAUDE.md` — Current State section**

- Task 15 (Extract `@pagemirror/snapshot-core`) is now shipped on `main`:
  `packages/snapshot-core/` exists with a full `src/`, the package name is
  `@pagemirror/snapshot-core@0.1.0`, and `playwright-snapshot-saver@0.7.0`
  already depends on it via semver. Rewrote the paragraph that still
  claimed it was "in progress on branch claude/check-task-statuses-C7rh9".
- Bumped the "Tasks 0–14 and 19 are complete" summary to
  `0–15, 15.5, and 19`.

**`CLAUDE.md` — Test Project Layout table**

- Added the `fixtures/styles/` subdir (`reset.css`, `theme.css`,
  `layout.css`, `components.css`) that lives on disk but wasn't listed.
- Corrected `.snapshots/login/{initial,error-state}/` — those bundles
  contain only `index.html` + `manifest.json`, not a `resources/` dir.
  Only `.snapshots/dashboard/*` have `resources/`.

**`CLAUDE.md` — Task 19 bullet**

- Point `FeatureTagListener` at its actual path
  (`ui/support/FeatureTagListener.kt`) rather than implicitly grouping it
  with `ui/annotations/Feature.kt`.

**`docs/Roadmap.md`**

- Update the Context paragraph to mark Tasks 0–15, 15.5, and 19 complete
  and note that Track B1 already shipped.
- Mark B1 as **(complete)** and rewrite the trailing sentence.
- Rewrote "Suggested Execution Order" to list what's already done
  (C1a→C1d, C2, B1, C3) separately from the remaining sequence
  (A1 → B2 → A2 → B3).

## Out of scope (flagged for later)

`packages/test-project/.snapshots/{login,dashboard}/*/manifest.json` are
missing the `url` field that `packages/snapshot-core/src/manifest.ts` and
`docs/snapshot-bundle-spec.md` both mark as required. That's stale
committed fixture data, not a docs issue — regenerating it requires
`npx playwright test` inside `packages/test-project/` and is best done in
a follow-up PR alongside verifying the writer.

## Test plan

- [x] Reviewed `git diff` — pure docs changes, no code touched.
- [x] Spot-checked each doc claim against the tree on `main` before
      editing (`packages/snapshot-core/`, `packages/test-project/`,
      `src/uiTest/kotlin/.../ui/support/FeatureTagListener.kt`).

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKfAo4YFxdCr2C1CvB75ju)_