### PR TITLE
docs: align top-level docs with shipped Task 15 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,6 @@
 - Previous release.
 
 [Unreleased]: https://github.com/AnewTranduil/PageObjectPlugin/compare/v0.5.0...HEAD
-[0.5.0]: https://github.com/AnewTranduil/PageObjectPlugin/compare/v0.4.0...v0.5.0
-[0.4.0]: https://github.com/AnewTranduil/PageObjectPlugin/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/AnewTranduil/PageObjectPlugin/commits/v0.3.0
+[0.5.0]: https://github.com/AnewTranduil/PageObjectPlugin/compare/0.4.0...v0.5.0
+[0.4.0]: https://github.com/AnewTranduil/PageObjectPlugin/commits/0.4.0
+[0.3.0]: https://github.com/AnewTranduil/PageObjectPlugin/releases

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,11 +152,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15 (incl. 15.5) and 19 are complete.** All plugin features
+ship, the snapshot saver npm package is published, `@pagemirror/snapshot-core`
+is extracted as an independent semver package, the UI test suite runs
+under a layered Page Object structure, CI aggregates test results into a
+single `claude-summary.{json,md}` bundle, and a Playwright-style trace
+viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -171,13 +172,17 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** is complete.
+`packages/snapshot-core/` ships as `@pagemirror/snapshot-core` (currently
+v0.1.0, `publishConfig.access: public`) and
+`packages/playwright-snapshot-saver` consumes it via semver
+(`"@pagemirror/snapshot-core": "^0.1.0"`), not `workspace:*`. Task 15
+also bumped the snapshot bundle format to v2: `screenshot.<ext>` moves
+under `resources/`, CSS is written as `resources/<sha1>.css` sidecars
+referenced by `<link>`, and the plugin inlines sidecar CSS on read
+(since `srcdoc` iframes can't resolve relative URLs). v1 bundles are
+refused with a clear error message — regenerate via `npx playwright test`
+in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 - **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight All** — click the "Show All" button in the Page Mirror tool window to overlay every locator at once with color-coded highlights and duplicate detection. To highlight only the locator on the current line, use `Alt+Shift+H`.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15 (incl. 15.5) plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, `@pagemirror/snapshot-core` is extracted as an independent semver-versioned package (consumed by the saver via `^0.1.0`) and owns HTML assembly, manifest building, and trace rendering, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The remaining coupling is on the IDE side (regex-based locator extraction is still TypeScript-shaped). With the framework-agnostic core in place, Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can now be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` — **done** (`@pagemirror/snapshot-core` 0.1.0 shipped; trace rendering + resource inlining also moved into core under Task 15.5, see `task-15.5-trace-resource-inlining.md`).
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor (now shipped); B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+1. **C1a** — unblock UI tests (everything else benefits). *(done)*
+2. **C1b–d** — reliability, diagnostics, page-object refactor. *(done)*
+3. **C2** — get the Claude inner loop solid before adding scope. *(done)*
+4. **B1** — refactor snapshot core (low risk, enables B2/B3). *(done)*
+5. **C3** — demo reporting (depends on C1c trace format + C2 stable). *(done)*
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---

--- a/packages/snapshot-core/src/types.ts
+++ b/packages/snapshot-core/src/types.ts
@@ -107,7 +107,7 @@ export interface SaveSnapshotOptions extends CollectorOptions {
   group?: string;
   /**
    * Screenshot options. Pass `false` to disable, omit for default
-   * (`{ format: 'webp', fullPage: false }`), or specify a partial object.
+   * (`{ format: 'png', fullPage: false }`), or specify a partial object.
    */
   screenshot?: Partial<ScreenshotOptions> | false;
   /** Generate `manifest.json`. Default `true`. */


### PR DESCRIPTION
## Summary

Audited `CLAUDE.md`, `README.md`, `docs/Roadmap.md`, `CHANGELOG.md`, and
`packages/snapshot-core/src/types.ts` against the current code on `main`
and fixed the mismatches I found. No runtime code changes — only doc
comments and Markdown.

## Findings and Fixes

- **CLAUDE.md — Task 15 was documented as "in progress on branch
  `claude/check-task-statuses-C7rh9`".** In reality that branch was
  merged: `packages/snapshot-core` ships as `@pagemirror/snapshot-core`
  0.1.0 (`publishConfig.access: public`), `playwright-snapshot-saver`
  consumes it via `"@pagemirror/snapshot-core": "^0.1.0"` (not
  `workspace:*`), and both `@pagemirror/snapshot-core@0.1.0` and
  `playwright-snapshot-saver@0.7.0` are tagged on origin. Updated the
  "Current State" heading to *Tasks 0–15 (incl. 15.5) and 19 complete*
  and rewrote the Task 15 paragraph to describe what shipped.
- **README.md — Highlight All shortcut was wrong.** The bullet said
  Highlight All is triggered by `Alt+Shift+H`, but `plugin.xml` binds
  `alt shift H` to `HighlightCurrentSelectorAction` (single-line
  extraction). The Highlight All / duplicate-detection feature is the
  "Show All" `JButton` in `PageMirrorToolWindowFactory.kt:70` with no
  keyboard shortcut. Reworded the bullet to describe the button and
  keep `Alt+Shift+H` labelled as "highlight the current line's locator".
- **docs/Roadmap.md — described Task 15 / B1 as still future.** The
  Context paragraph, the B1 list entry, and item 4 of the Suggested
  Execution Order all treated the snapshot-core extraction as unshipped.
  Updated the Context to reflect the shipped `@pagemirror/snapshot-core`,
  marked B1 as done (with a pointer to Task 15.5 for the follow-up
  trace-rendering work), and annotated already-completed items in the
  execution order as `*(done)*`.
- **CHANGELOG.md — footer compare links 404'd.** Origin has tag `0.4.0`
  (no `v` prefix) and no `v0.3.0` tag at all, but the reference-style
  links used `v0.4.0` / `v0.3.0`. Repointed the `[0.5.0]` compare and
  `[0.4.0]` link at the actual `0.4.0` tag, and pointed `[0.3.0]` at
  the repository releases page instead of a non-existent tag.
- **packages/snapshot-core/src/types.ts — doc comment was wrong.**
  `SaveSnapshotOptions.screenshot`'s JSDoc said the default was
  `{ format: 'webp', fullPage: false }`, but `save-snapshot.ts:20`
  defines `DEFAULT_SCREENSHOT` as `{ format: 'png', fullPage: false }`
  (and the README / plugin rely on `png`). Updated the comment to
  match the code.

## Test plan

- [x] Every changed doc file rendered locally, no broken headings.
- [x] `git diff` reviewed — no non-doc source changes.
- [x] `packages/snapshot-core/src/types.ts` change is comment-only —
      no TypeScript compile impact.
- [ ] CI green on the `test-report` job.


---
_Generated by [Claude Code](https://claude.ai/code/session_012CgcSytrrSxoXqDMcCTTgq)_