### PR TITLE
docs: mark Task 15 / 15.5 complete in CLAUDE.md and Roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published on top of the framework-agnostic
+`@pagemirror/snapshot-core`, the UI test suite runs under a layered Page
+Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,26 +172,31 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped in plugin
+  `0.5.0` and `playwright-snapshot-saver@0.7.0` (see CHANGELOG). Live
+  capture and manifest building live in `packages/snapshot-core/src/
+  {assemble-html.ts, manifest.ts, save-snapshot.ts, browser/}`;
+  `playwright-snapshot-saver` is now a thin adapter
+  (`src/playwright-adapter.ts`) on top. The snapshot bundle format was
+  bumped to v2: `screenshot.<ext>` lives under `resources/`, CSS is
+  written as `resources/<sha1>.css` sidecars referenced by `<link>`, and
+  the plugin's `SnapshotHtmlResolver` inlines sidecar CSS on read (since
+  `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused
+  with a clear error banner in the tool window — regenerate via `npx
+  playwright test` in `packages/test-project/`.
 
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` now owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript; the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of the framework-agnostic `@pagemirror/snapshot-core` extracted in Task 15 (bundle format bumped to v2 — `resources/` sidecars for CSS/screenshots, trace-extracted bundles fully self-contained after Task 15.5); the settings UI is on Kotlin UI DSL v2; the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics; CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`; and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction). With the snapshot core already extracted, remaining Track B work (Selenium / Cypress / Appium adapters — Tasks 17, 20) and Track A work (Python / JVM locator extractors + saver packages — Tasks 16, 18) can be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the v2 on-disk bundle format (`index.html` + `manifest.json` + `resources/` sidecars) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`


### PR DESCRIPTION
## Summary

Auditing the main branch's docs against the shipped code turned up two stale references to Task 15 (extract `@pagemirror/snapshot-core`) that describe it as future / in-progress work, even though it landed in plugin `0.5.0` (PR #30, `packages/snapshot-core/` on disk, CHANGELOG entry dated 2026-04-16) and Task 15.5 shipped on top of it.

### CLAUDE.md

- "Current State" bullet updated from `Tasks 0–14 and 19 are complete` to `Tasks 0–15, 15.5, and 19 are complete`, with a note that the snapshot saver npm package is now published on top of the framework-agnostic `@pagemirror/snapshot-core`.
- The standalone paragraph beginning `**Task 15 (Extract @pagemirror/snapshot-core)** is **in progress** on branch claude/check-task-statuses-C7rh9` is rewritten as a completed-task bullet in the "Current State" list, pointing at the actual sources (`packages/snapshot-core/src/{assemble-html, manifest, save-snapshot, browser/}`, `playwright-snapshot-saver/src/playwright-adapter.ts`, plugin's `SnapshotHtmlResolver`).
- Task 15.5's body is preserved verbatim but reformatted as a completed-task bullet so the two entries sit alongside the other complete tasks.

### docs/Roadmap.md

- Context paragraph updated to list Tasks 15 and 15.5 as complete, and to frame the remaining Track A / Track B work as layers on top of the already-extracted snapshot core.
- Track A intro's bundle-format description updated from the old v1 layout `index.html + screenshot.webp + manifest.json` to the current v2 layout `index.html + manifest.json + resources/` (matching `docs/snapshot-bundle-spec.md` and the CLAUDE.md "Snapshot Bundle Format (v2)" section).

Docs-only change; no code touched.

## Test plan

- [x] `git diff origin/main` — verify diff is limited to `CLAUDE.md` + `docs/Roadmap.md` and does not touch code
- [x] Cross-check every claim against the state of `origin/main` (worktree at `9d58b4d`): confirmed `packages/snapshot-core/` exists, `SnapshotHtmlResolver.kt` is in the plugin, `CHANGELOG.md` v0.5.0 documents the v2 bundle format, PR #30 (`claude/check-task-statuses-C7rh9`) is merged
- [ ] CI green on the `test-report` job for this branch


---
_Generated by [Claude Code](https://claude.ai/code/session_012ZfQ6pGiuDJFqEoYSs4X1G)_