### PR TITLE
docs: mark Task 15 and 15.5 complete on main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,11 +152,12 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core` owns
+framework-agnostic bundle assembly and trace rendering, the UI test suite
+runs under a layered Page Object structure, CI aggregates test results
+into a single `claude-summary.{json,md}` bundle, and a Playwright-style
+trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -169,28 +170,29 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** the framework-agnostic
+  core lives at `packages/snapshot-core/` and owns bundle assembly,
+  manifest building, and the browser-side collector; the Playwright
+  package (`packages/playwright-snapshot-saver/`) is now a thin adapter on
+  top. This bumped the snapshot bundle format to v2: `screenshot.<ext>`
+  moved under `resources/`, CSS is written as `resources/<sha1>.css`
+  sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on
+  read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles
+  are refused with a clear error message — regenerate via
+  `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` also owns trace rendering behind a
+  `TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
+  renderer, inline, extract, runtime-script, content-type}.ts`). The
+  Playwright package (`packages/playwright-snapshot-saver/src/trace/
+  playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
+  interface; `extractor.ts` delegates to `extractFromBackend`. Trace
+  bundles are fully self-contained — every `<link>`, `<img>`, CSS
+  `url(...)`, `@font-face`, and SVG `<use>` reference points at a real
+  file under `resources/`, and the `<base>` element is stripped.
+  Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
-
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, `@pagemirror/snapshot-core` owns framework-agnostic bundle assembly and trace rendering behind a `TraceBackend` interface, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current IDE-side architecture is still tightly coupled to TypeScript (regex-based locator extraction); Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can now layer on top of the extracted core without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk v2 bundle format (`index.html` + `manifest.json` + `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` *(complete; extended by `task-15.5-trace-resource-inlining.md`)*
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -119,5 +119,5 @@ initial/
 
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
-- Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
+- Plugin loader: `SnapshotBundle.kt` — `SUPPORTED_BUNDLE_VERSION` constant + `SnapshotBundle.load()`
 - Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant


### PR DESCRIPTION
## Summary

Audit of `main` (HEAD `9d58b4d`) turned up three doc/code drifts. This PR touches docs only — no code changes.

### 1. `CLAUDE.md` — "Current State" section

Still described Task 15 as **in progress** on branch `claude/check-task-statuses-C7rh9`, which was merged (PR #30) and deleted. The code has shipped:

- `packages/snapshot-core/` exists with framework-agnostic `saveSnapshot`, browser-side collector, manifest builder, HTML assembler.
- `packages/playwright-snapshot-saver/` is now a thin Playwright adapter (`playwright-adapter.ts`, `trace/playwright-backend.ts`).
- Bundle format is v2 across the board: `SnapshotBundle.kt` has `const val SUPPORTED_BUNDLE_VERSION = 2` and refuses anything else; regenerated snapshots under `packages/test-project/.snapshots/` sit in the `resources/` layout.

Updated the "Tasks 0–14 and 19 are complete" line to `0–15, 15.5, and 19`, moved the Task 15 / 15.5 bullets into the completed list, and dropped the stale in-progress paragraphs.

### 2. `docs/Roadmap.md`

- Context paragraph reframed: Task 15 is done, not "below".
- Track A bundle-format reference changed from the pre-v2 shape (`index.html + screenshot.webp + manifest.json`) to the actual v2 shape (`index.html + manifest.json + resources/`).
- Track B / B1 marked complete with a pointer to Task 15.5.

### 3. `docs/migration-v1-to-v2.md`

Reference section pointed at an `isSupportedVersion()` method on `SnapshotBundle.kt` that never existed. Actual API is the `SUPPORTED_BUNDLE_VERSION` constant + `SnapshotBundle.load()` — updated the reference.

## Test plan

- [x] `git diff` shows docs-only changes (CLAUDE.md, docs/Roadmap.md, docs/migration-v1-to-v2.md).
- [x] All references in the updated docs (file paths, symbols, constants) verified against the tree at `9d58b4d`.
- [ ] CI `test-report` job passes (docs-only PR, so no behavior change expected).

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7jJ7dLMP1VJarhuiuiD5h)_