### PR TITLE
docs: mark Tasks 15 and 15.5 as shipped, refresh Current State

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published alongside a framework-agnostic
+`@pagemirror/snapshot-core` engine, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -164,33 +165,44 @@ auto-generated on PRs tagged `demo`.
 - **Task 10 (Trace extraction & reporter):** `packages/playwright-snapshot-saver/src/{extractor.ts, reporter.ts, snapshot-marker.ts, trace/, sources/}` ship the reporter + extractor API.
 - **Task 11 (Manifest fixes):** timestamp, change detection, version increment.
 - **Task 12 (Settings UI DSL v2):** `PageMirrorConfigurable.kt` rewritten on Kotlin UI DSL v2.
-- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL at `build.gradle.kts:112-144`, which sidesteps the `splitMode` issue entirely.
+- **Task 13a (UI test unblock):** resolved via the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL in `build.gradle.kts`, which sidesteps the `splitMode` issue entirely.
 - **Task 13b (UI test reliability):** `ui/support/Wait.kt` and `RetryOnceExtension.kt` provide polling + retry-once. **Gap:** no `@Quarantine` annotation was created (only tracked as a reporting field in `ClaudeSummaryModel.kt`).
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
-- **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` and `testReport`; `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** shipped as
+  `packages/snapshot-core/` (published to npm as `@pagemirror/snapshot-core`)
+  with `playwright-snapshot-saver` refactored as a thin Playwright adapter
+  on top. Bumped the snapshot bundle format to **v2**: `screenshot.<ext>`
+  moved under `resources/`, CSS is written as `resources/<sha1>.css`
+  sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on
+  read (since `srcdoc` iframes can't resolve relative URLs). v1 bundles
+  are refused with a user-visible banner in the tool window — regenerate
+  via `npx playwright test` in `packages/test-project/` or via any saver
+  `≥ 0.7.0`. Bundle format is frozen in `docs/snapshot-bundle-spec.md`;
+  end-user migration steps live in `docs/migration-v1-to-v2.md`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend`
+  interface (`packages/snapshot-core/src/trace/{types, renderer, inline,
+  extract, runtime-script, content-type}.ts`). The Playwright package
+  (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`)
+  reshapes `TraceLoader.storage()` into that interface; `extractor.ts`
+  delegates to `extractFromBackend`. Trace bundles are fully
+  self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`,
+  and SVG `<use>` reference points at a real file under `resources/`, and
+  the `<base>` element is stripped. Selenium/Cypress/Appium adapters
+  (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same
+  `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 16 (Python Playwright), Task 17 (Selenium + Cypress adapters),
+Task 18 (JVM Playwright), and Task 20 (Appium mobile)** remain open —
+see `docs/Roadmap.md` and the individual task docs.
 
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+Also shipped since the last "Current State" refresh: an outdated-bundle
+banner inside the Page Mirror tool window (`SnapshotService.showOutdatedBanner`
++ `html/js/snapshot.js`), so users who upgrade the plugin against v1
+bundles get an actionable in-IDE prompt instead of silent failure.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15, 15.5, and 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs on top of a framework-agnostic `@pagemirror/snapshot-core` engine (Task 15) that also owns trace rendering + resource inlining (Task 15.5), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The remaining work — Tasks 16–18 and 20 — broadens language and driver support: locator extraction for Python (16) and JVM (18), plus Selenium/Cypress (17) and Appium (20) adapters that layer on top of `@pagemirror/snapshot-core` without duplicating bundle assembly. The IDE side is still TypeScript-only today (regex-based locator extraction).
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (v2: `index.html` + `manifest.json` + `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` *(complete — `@pagemirror/snapshot-core` ships)*
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 
@@ -43,15 +43,12 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
-9. **B3** — mobile/Appium (largest unknowns).
+C1a–d, C2, B1, and C3 are already shipped. Remaining work in order:
+
+1. **A1** — Python Playwright (highest user demand for language expansion).
+2. **B2** — Selenium/Cypress adapters (reuse `@pagemirror/snapshot-core`'s `TraceBackend` from Task 15.5).
+3. **A2** — Java/Kotlin Playwright.
+4. **B3** — mobile/Appium (largest unknowns).
 
 ---
 

--- a/docs/tasks/task-15-snapshot-core-extraction.md
+++ b/docs/tasks/task-15-snapshot-core-extraction.md
@@ -1,5 +1,12 @@
 # Task 15: Extract Framework-Agnostic `snapshot-core`
 
+> **Status: shipped.** `packages/snapshot-core/` is published to npm as
+> `@pagemirror/snapshot-core`, `playwright-snapshot-saver` was refactored
+> into a thin adapter on top of it, and the plugin loads the resulting v2
+> bundles. Trace-side extraction was later brought into the core under
+> **Task 15.5**. The document below is preserved as the historical design
+> record for the extraction.
+>
 > **Goal:** Split `playwright-snapshot-saver` into a framework-agnostic `@pagemirror/snapshot-core` package plus a thin Playwright adapter, enabling future Selenium / Cypress / Appium adapters (Tasks 17, 20) without duplicating bundle assembly, manifest generation, and HTML post-processing.
 > **Depends on:** Task 14 (aggregator) — recommended but not required.
 > **Output:** New `packages/snapshot-core/`, refactored `packages/playwright-snapshot-saver/` depending on it.

--- a/docs/tasks/task-15.5-trace-resource-inlining.md
+++ b/docs/tasks/task-15.5-trace-resource-inlining.md
@@ -1,5 +1,13 @@
 # Task 15.5: Resource Inlining for Trace-Extracted Snapshots
 
+> **Status: shipped.** `@pagemirror/snapshot-core` owns trace rendering
+> behind a framework-agnostic `TraceBackend` interface
+> (`packages/snapshot-core/src/trace/`); the Playwright package's
+> `trace/playwright-backend.ts` implements it against `TraceLoader`, and
+> trace-extracted bundles are fully self-contained under `resources/`.
+> Selenium/Cypress/Appium adapters (Tasks 17, 20) will implement the same
+> `TraceBackend` surface to reuse this pipeline.
+>
 > **Scope expanded 2026-04-15.** The original plan post-processed Playwright's
 > rendered HTML. The implementation instead owns rendering: `snapshot-core`
 > now ports Playwright's `SnapshotRenderer` behind a framework-agnostic


### PR DESCRIPTION
## Summary

Audited `CLAUDE.md`, `docs/Roadmap.md`, and the per-task docs against the current state of the code on `main` and updated the docs where they had drifted.

### What was stale

- `CLAUDE.md` still described **Task 15 (`@pagemirror/snapshot-core` extraction)** as *"in progress on branch `claude/check-task-statuses-C7rh9`"*. That branch merged as PR #30 back in April 2026, and the extraction shipped as part of plugin **v0.5.0** (2026-04-16). The v2 bundle format it introduced is already in production — the test-project's `.snapshots/` fixtures, the `resources/<sha1>.css` sidecar loader, and the `manifest.version: 2` gate are all live.
- **Task 15.5** (framework-agnostic trace rendering + resource inlining) was mentioned in `CLAUDE.md`'s Current State but had no status marker on its own task doc.
- `docs/Roadmap.md` still listed **B1 (Extract framework-agnostic core)** as pending work and included it in the "Suggested Execution Order".
- The Task 13a and Task 14 entries in `CLAUDE.md` pinned specific line numbers in `build.gradle.kts` (`:112-144`, `:219`, `:261`) that either had drifted or are fragile.
- The **outdated-bundle banner** feature added in v0.5.0 (`SnapshotService.showOutdatedBanner` + `html/js/snapshot.js` + `OutdatedBundleBannerUiTest`) was not called out anywhere in `CLAUDE.md`'s Current State.

### Changes

- `CLAUDE.md` — Current State now reads "Tasks 0–15, 15.5, and 19 are complete." Task 15 and 15.5 have full bullets describing what shipped. Dropped fragile line-number refs in the Task 13a and Task 14 bullets. Added a note about the outdated-bundle banner. Called out that Tasks 16, 17, 18, and 20 remain open.
- `docs/Roadmap.md` — Context section reflects Task 15 + 15.5 completion; B1 marked *(complete)*; Suggested Execution Order collapses the already-shipped C-track and B1 into a preamble and lists only the remaining A1/B2/A2/B3 work. Bundle format description updated from the v1 wording (`screenshot.webp` at top level) to v2 (`resources/`).
- `docs/tasks/task-15-snapshot-core-extraction.md` — added a **Status: shipped** callout at the top, preserving the design doc as a historical record.
- `docs/tasks/task-15.5-trace-resource-inlining.md` — added a **Status: shipped** callout at the top, kept alongside the existing "Scope expanded 2026-04-15" note.

### Verification

Docs-only change — no code touched. Confirmed against `main`:

- `packages/snapshot-core/` exists on `main` with the trace + live-capture modules referenced in the updated CLAUDE.md.
- `packages/playwright-snapshot-saver/src/trace/playwright-backend.ts` implements `TraceBackend` and `extractor.ts` delegates via `extractFromBackend`.
- `packages/test-project/.snapshots/*/*/manifest.json` files declare `"version": 2` and (where CSS is present) sit alongside a `resources/` directory.
- `CHANGELOG.md` `[0.5.0]` entry documents the same v2 bundle switch + banner behavior.

## Test plan

- [ ] CI green on `main` after merge (docs-only, so this is a formality — no test surface changed).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AexsMMVvu8BVnx58kJAJ8S)_