### PR TITLE
docs: mark Tasks 15 and 15.5 as complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
+**Tasks 0–15, 15.5, and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published, `@pagemirror/snapshot-core` is
+extracted as a framework-agnostic engine, the UI test suite runs under a
+layered Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
 
@@ -171,26 +172,27 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** the framework-agnostic
+  engine lives at `packages/snapshot-core/` (name `@pagemirror/snapshot-core`,
+  published to npm) and owns the browser-side collector, HTML assembler,
+  manifest builder, and `saveSnapshot` orchestration. `playwright-snapshot-saver`
+  depends on it via `^0.1.0` and is now a thin adapter (`playwright-adapter.ts`).
+  This landed the snapshot bundle format v2: `screenshot.<ext>` moves under
+  `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by
+  `<link>`, and the plugin inlines sidecar CSS on read (since `srcdoc` iframes
+  can't resolve relative URLs). v1 bundles are refused with a clear error
+  message — regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):**
+  `@pagemirror/snapshot-core` now owns trace rendering behind a `TraceBackend`
+  interface (`packages/snapshot-core/src/trace/{types, renderer, inline,
+  extract, runtime-script, content-type}.ts`). The Playwright package
+  (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`)
+  reshapes `TraceLoader.storage()` into that interface; `extractor.ts`
+  delegates to `extractFromBackend`. Trace bundles are fully self-contained —
+  every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>`
+  reference points at a real file under `resources/`, and the `<base>` element
+  is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
+  `extractFromBackend` by implementing the same `TraceBackend` surface.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15 (including 15.5) plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, `@pagemirror/snapshot-core` has been extracted as the framework-agnostic engine (bundle assembly, manifest builder, trace rendering behind a `TraceBackend` interface, resource inlining), the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The IDE-side architecture is still tightly coupled to TypeScript (regex-based locator extraction), but the snapshot pipeline is now framework-agnostic, so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` and `task-15.5-trace-resource-inlining.md` (**done** — `@pagemirror/snapshot-core` ships at `packages/snapshot-core/`).
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B2 and B3 layer new adapters on top of the extracted core (B1).
 
 ---
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
-5. **A1** — Python Playwright (highest user demand for language expansion).
-6. **B2** — Selenium/Cypress adapters.
-7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+1. **C1a** — unblock UI tests (everything else benefits). ✅ done
+2. **C1b–d** — reliability, diagnostics, page-object refactor. ✅ done
+3. **C2** — get the Claude inner loop solid before adding scope. ✅ done
+4. **B1** — refactor snapshot core (low risk, enables B2/B3). ✅ done
+5. **C3** — demo reporting (depends on C1c trace format + C2 stable). ✅ done
+6. **A1** — Python Playwright (highest user demand for language expansion).
+7. **B2** — Selenium/Cypress adapters.
+8. **A2** — Java/Kotlin Playwright.
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

CLAUDE.md's **Current State** block still described Task 15 as _"in progress on branch `claude/check-task-statuses-C7rh9`"_ and treated Task 15.5 as a follow-up on the same in-flight work. On disk the story is different:

- `packages/snapshot-core/` ships as `@pagemirror/snapshot-core@0.1.0` (published to npm, `publishConfig.access: "public"`).
- `packages/playwright-snapshot-saver` depends on it via `^0.1.0` and is now a thin adapter (`playwright-adapter.ts`, `playwright-backend.ts`).
- `packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts` all exist; `extractor.ts` in the saver delegates to `extractFromBackend`.
- The v2 bundle layout (`resources/` sidecars, `<sha1>.css`, `<sha1>.woff2`, etc.) is what the plugin reads and what the test-project fixtures follow.
- The `claude/check-task-statuses-C7rh9` branch referenced from CLAUDE.md no longer exists in `git branch -a`.

This PR aligns the docs with that reality.

### Changes

- **CLAUDE.md** — "Current State":
  - Update the headline from "Tasks 0–14 and 19 are complete" to include 15 and 15.5.
  - Move the Task 15 paragraph out of "in progress" into a completed bullet, and reword Task 15.5 as a completed bullet too. Both entries still list the key files / mechanisms so the section keeps its value as a source-code map.
- **docs/Roadmap.md**:
  - Refresh the **Context** paragraph so it matches the same task-status set and reflects that the snapshot pipeline is framework-agnostic.
  - Mark **B1** as done in Track B and simplify the follow-up sentence to note that B2/B3 layer on top of B1.
  - Annotate the **Suggested Execution Order** with ✅ done markers on C1a–d, C2, B1, and C3, and reorder so the remaining items (A1, B2, A2, B3) sit at the tail.

### Not changed (verified up to date)

- Kotlin source layout in CLAUDE.md matches `src/main/kotlin/…` (audited against `find src/main/kotlin`).
- `src/main/resources/` layout — `META-INF/plugin.xml`, `messages/PageObjectBundle.properties`, `html/js/…`, `demo-viewer/…` — matches the tree.
- Plugin id/name in `plugin.xml` (`com.github.artem.pageobjectplugin`, "Page Object Helper", right-anchored `Page Mirror` tool window, `HighlightCurrentSelectorAction`, status-bar widget).
- Bundle spec (`docs/snapshot-bundle-spec.md`) and `USE.md` v2 layout still match the code paths in `SnapshotHtmlResolver` + `assemble-html.ts` + `inline.ts`.
- Manifest schema in code (`packages/snapshot-core/src/types.ts` — `MANIFEST_VERSION = 2`, `url` required, optional `userAgent`, driver key) matches the docs' example.

## Test plan

- [ ] CI (`test-report` job) stays green on the branch — this is a docs-only diff, so no runtime behavior changes.
- [ ] Read the "Current State" section in the rendered PR view and confirm it now describes Task 15 and 15.5 as complete.
- [ ] Read `docs/Roadmap.md` and confirm B1 is annotated done and the execution order marks the finished work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLrX73NcDQHTsBgqBrWG5W)_