### PR TITLE
docs: align docs with current code state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,9 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the snapshot
+saver npm package is published on top of the extracted framework-agnostic
+`@pagemirror/snapshot-core`, the UI test suite runs under a layered
 Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
@@ -171,13 +172,14 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped the framework-agnostic
+core package at `packages/snapshot-core/` (`@pagemirror/snapshot-core`,
+consumed via semver by `playwright-snapshot-saver`) and bumped the snapshot
+bundle format to v2: `screenshot.<ext>` moved under `resources/`, CSS is
+written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the
+plugin inlines sidecar CSS on read (since `srcdoc` iframes can't resolve
+relative paths). v1 bundles are refused with a clear error message —
+regenerate via `npx playwright test` in `packages/test-project/`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ An IntelliJ plugin that renders Playwright page snapshots inside a docked tool w
 ## Features
 
 - **Page Mirror panel** — displays captured page snapshots in an embedded browser (JCEF), docked to the right side of the IDE.
-- **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot.
+- **Code-to-UI highlight** — move your cursor to a Playwright locator and the corresponding element lights up in the snapshot. Press `Alt+Shift+H` to re-highlight the selector on the current line at any time.
 - **Element picker** — click any element in the snapshot to generate a locator and insert it into your code (`Alt+Shift+I`).
 - **Selector validation** — gutter badges show how many elements match each locator, catching ambiguous or broken selectors before you run tests.
-- **Highlight All** — highlight every locator on the page at once with color-coded overlays and duplicate detection (`Alt+Shift+H`).
+- **Highlight All** — the **Show All** button in the Page Mirror tool window highlights every locator in the current file at once with color-coded overlays and duplicate detection.
 - **Auto-discovery** — snapshots reload automatically when files change on disk.
 - **Configurable** — adjust snapshot search depth, highlight color, auto-reload behavior, and code generation style in Settings > Tools > Page Mirror.
 

--- a/USE.md
+++ b/USE.md
@@ -226,4 +226,6 @@ The editor gutter shows a badge next to each locator with the number of matching
 
 ### Highlight All
 
-Press `Alt+Shift+H` to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges.
+Click the **Show All** button in the Page Mirror tool window toolbar to highlight every locator in the current file on the snapshot at once. Color-coded overlays distinguish different locators. Duplicate and overlapping selectors are flagged with visual badges. Click **Show All** again to clear the overlays.
+
+The separate `Alt+Shift+H` shortcut (Highlight Current Selector) re-runs the caret-driven highlight for the locator on the current line — useful after switching snapshots or tabs.

--- a/docs/tasks/task-16-python-playwright-support.md
+++ b/docs/tasks/task-16-python-playwright-support.md
@@ -76,7 +76,7 @@ The pytest plugin (`pytest_plugin.py`) provides auto-capture on test failure whe
 4. Add `.py` to default `fileExtensions` in settings; update `PageMirrorConfigurable` if the default needs to be surfaced.
 5. Scaffold `packages/playwright-snapshot-saver-python/` with modern `pyproject.toml` (PEP 621) and `hatchling` or `poetry` build.
 6. Port `html-inliner.ts` to Python using `beautifulsoup4` + stdlib `urllib` — produce output matching the TS version for the shared fixture page (verified by golden-file test).
-7. Port `manifest-generator.ts` — emit spec-v1 compliant `manifest.json` per `docs/snapshot-bundle-spec.md`.
+7. Port `manifest-generator.ts` — emit spec-v2 compliant `manifest.json` per `docs/snapshot-bundle-spec.md`.
 8. Implement `save_snapshot` / `save_snapshot_async` for `playwright.sync_api.Page` and `playwright.async_api.Page`.
 9. Implement `pytest_plugin.py` reporter (fixture + hook) analogous to `playwright-snapshot-saver`'s Playwright reporter.
 10. Integration tests: `pytest` suite that launches a headless Chromium, visits a fixture page, calls `save_snapshot`, and asserts bundle layout + manifest contents.

--- a/docs/tasks/task-18-jvm-playwright-support.md
+++ b/docs/tasks/task-18-jvm-playwright-support.md
@@ -1,6 +1,6 @@
 # Task 18: Java/Kotlin Playwright Support
 
-> **Goal:** Recognize Playwright Java API locators in `.java` and `.kt` files (highlight + gutter) AND ship `snapshot-saver-jvm` — a Kotlin JVM library that produces spec-v1 bundles from `com.microsoft.playwright.Page`.
+> **Goal:** Recognize Playwright Java API locators in `.java` and `.kt` files (highlight + gutter) AND ship `snapshot-saver-jvm` — a Kotlin JVM library that produces spec-v2 bundles from `com.microsoft.playwright.Page`.
 > **Depends on:** Task 16 (introduces `LocatorExtractor` interface + registry), `docs/snapshot-bundle-spec.md`.
 > **Output:** `JvmLocatorExtractor.kt`, new Gradle artifact `packages/playwright-snapshot-saver-jvm/`.
 
@@ -57,7 +57,7 @@ SnapshotSaver.save(page, "login/initial", new SaveOptions().setOutputDir(new Fil
 3. Add `.java`, `.kt` to default `fileExtensions` in settings.
 4. Scaffold `packages/playwright-snapshot-saver-jvm/` as a sibling Gradle project, included via root `settings.gradle.kts`. Kotlin JVM, Java 17 target.
 5. Implement `HtmlInliner` in Kotlin using Jsoup (port of TS version, verified against the shared fixture page via golden-file test).
-6. Implement `ManifestGenerator` emitting spec-v1 JSON via `kotlinx.serialization`.
+6. Implement `ManifestGenerator` emitting spec-v2 JSON via `kotlinx.serialization`.
 7. Implement `SnapshotSaver.save()` against `com.microsoft.playwright.Page`. Options class mirrors the TS API.
 8. Implement `SnapshotSaverExtension` as a JUnit 5 `TestWatcher` + `ParameterResolver` — auto-captures on failure when registered.
 9. Integration tests: JUnit 5 suite that launches Playwright Java, visits a fixture page, calls the saver, asserts bundle layout.

--- a/docs/tasks/task-20-appium-mobile-support.md
+++ b/docs/tasks/task-20-appium-mobile-support.md
@@ -1,6 +1,6 @@
 # Task 20: Appium Mobile Snapshot Saver
 
-> **Goal:** Ship `appium-snapshot-saver` — a `PageAdapter` over Appium that captures native mobile page source + screenshot into a spec-v1 bundle, extending the manifest `viewport` with platform + device metadata.
+> **Goal:** Ship `appium-snapshot-saver` — a `PageAdapter` over Appium that captures native mobile page source + screenshot into a spec-v2 bundle, extending the manifest `viewport` with platform + device metadata.
 > **Depends on:** Task 15 (`snapshot-core`), Task 17 (pattern for adapter packages).
 > **Output:** New `packages/appium-snapshot-saver/`, decision on HTML-vs-XML rendering fallback tracked as follow-up.
 
@@ -26,7 +26,7 @@ Appium exposes UI tree dumps as XML, not HTML. Supporting it stretches the snaps
 - Manifest extension:
   ```json
   {
-    "version": 1,
+    "version": 2,
     "viewport": {
       "width": 390,
       "height": 844,
@@ -60,7 +60,7 @@ The plugin's tool window iframe is HTML-only. XML page-source cannot render ther
 
 ## Verification
 
-- Bundles produced by `AppiumAdapter` conform to spec v1 with the additive mobile fields.
+- Bundles produced by `AppiumAdapter` conform to spec v2 with the additive mobile fields.
 - Both `index.html` and `index.xml` present for native snapshots; only `index.html` for webview snapshots.
 - `snapshot-core` tests still pass; no regression for Playwright/Selenium/Cypress bundles.
 - The plugin tool window can list and show screenshots for mobile bundles (full XML rendering waits for the follow-up task).


### PR DESCRIPTION
## Summary

Audit of `main` docs vs the shipped code turned up several stale claims — this PR aligns them with what the codebase actually does today.

### CLAUDE.md — Task 15 was already shipped, not in progress

The "Current State" section still described **Task 15 (Extract `@pagemirror/snapshot-core`)** as "in progress on branch `claude/check-task-statuses-C7rh9`". That work landed in PR #30 (`dac7042 Merge pull request #30 from AnewTranduil/claude/check-task-statuses-C7rh9`):

- `packages/snapshot-core/` ships `@pagemirror/snapshot-core` v0.1.0 (`packages/snapshot-core/package.json`).
- `packages/playwright-snapshot-saver/` depends on the core via semver (`cbc75f1 build: make @pagemirror/snapshot-core publishable, switch consumers to semver`).
- The Task 15.5 paragraph directly below already says the core "now owns trace rendering behind a `TraceBackend` interface", which only makes sense if Task 15 is done.

Fix:

- Bump the summary line from "Tasks 0–14 and 19 are complete" to "Tasks 0–15.5 and 19 are complete" and mention that the saver now sits on top of `@pagemirror/snapshot-core`.
- Rewrite the Task 15 paragraph in past tense, drop the stale in-progress branch reference, and point at `packages/snapshot-core/` as the shipped location.

### README.md & USE.md — `Alt+Shift+H` is Highlight Current Selector, not Highlight All

Both docs claimed `Alt+Shift+H` triggers **Highlight All**. In the shipped code:

- `src/main/resources/META-INF/plugin.xml:46-52` binds `Alt+Shift+H` to `HighlightCurrentSelectorAction`, which highlights only the locator on the caret's current line (`src/main/kotlin/.../actions/HighlightCurrentSelectorAction.kt`).
- **Highlight All** is the **Show All** button in the tool window toolbar (`src/main/kotlin/.../PageMirrorToolWindowFactory.kt:70-84`) — it has no keybinding.

Fix:

- `README.md`: split the two features cleanly. `Alt+Shift+H` is documented on the Code-to-UI highlight bullet; the Highlight All bullet now points at the **Show All** button.
- `USE.md`: rewrite the "Highlight All" section to describe the **Show All** button (including click-again-to-clear), and add a short paragraph documenting the `Alt+Shift+H` re-highlight shortcut separately.

### docs/tasks/task-16, task-18, task-20 — planning docs still targeted spec-v1

The three future-language planning docs (Python, JVM, Appium) told the implementer to emit "spec-v1 compliant" bundles. The bundle spec has been at v2 since Task 15 (see `docs/snapshot-bundle-spec.md`, `docs/migration-v1-to-v2.md`, `CHANGELOG.md [0.5.0]`), and the plugin refuses non-v2 bundles.

Fix: replace every remaining "spec-v1"/`"version": 1` reference in these three planning docs with the current v2 target so a future implementer doesn't ship an already-refused format.

## Test plan

- [x] Reviewed CLAUDE.md, README.md, USE.md, and the three edited task docs after the changes — no other stale references remain in the touched sections.
- [x] Verified against source: `plugin.xml`, `HighlightCurrentSelectorAction.kt`, `PageMirrorToolWindowFactory.kt`, `packages/snapshot-core/package.json`, git log for PR #30.
- [x] Docs-only change — no runtime behavior touched, so unit/UI/Playwright suites are unaffected. CI will still run them via the standard test-report pipeline for confidence.

---
_Generated by [Claude Code](https://claude.ai/code/session_019SP1eDLtpJg5cHRxb7DgXB)_