### PR TITLE
docs: mark Tasks 15 and 15.5 as complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,12 +126,19 @@ packages/test-project/
     dashboard.spec.ts
   .snapshots/
     login/
-      initial/        {index.html, manifest.json, resources/}
-      error-state/    {index.html, manifest.json, resources/}
+      initial/        {index.html, manifest.json}
+      error-state/    {index.html, manifest.json}
     dashboard/
       initial/        {index.html, manifest.json, resources/}
       ticket-filled/  {index.html, manifest.json, resources/}
 ```
+
+`resources/` is only present when the captured page references sidecar
+assets. The `login` fixtures use inline `<style>` blocks, so their
+bundles have no `resources/` directory. The `dashboard` fixtures pull
+in an external stylesheet, so their bundles contain `resources/<sha1>.css`
+sidecars. A missing `resources/` directory is valid — the plugin treats
+it as "no sidecar resources to inline."
 
 ## Task Sequence
 
@@ -150,13 +157,21 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 | 8  | Highlight all + duplicates        | Show All button, overlap detection| 4, 6       |
 | 9  | Snapshot saver npm package        | Standalone `playwright-snapshot-saver`             | 0 |
 
+Tasks 10 onward are each documented in their own file under
+`docs/tasks/` (see `task-10-trace-extraction.md` through
+`task-20-appium-mobile-support.md`). Status per task lives in the
+"Current State" section below and in `docs/Roadmap.md`.
+
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
-Page Object structure, CI aggregates test results into a single
-`claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
-auto-generated on PRs tagged `demo`.
+**Tasks 0–15.5 and 19 are complete** (Task 15.5 shipped in commit
+`7b808a0`; the bundle format v2 announced in `CHANGELOG.md` v0.5.0 is
+live on `main`). All plugin features ship, the framework-agnostic
+`@pagemirror/snapshot-core` package is extracted and published, the
+Playwright saver is a thin adapter on top of it, the UI test suite runs
+under a layered Page Object structure, CI aggregates test results into
+a single `claude-summary.{json,md}` bundle, and a Playwright-style
+trace viewer is auto-generated on PRs tagged `demo`.
 
 - **Tasks 0–9:** Plugin shell, snapshot loading, file watcher, highlight
   bridge, element picker, gutter validation, polish, JS refactor,
@@ -169,28 +184,14 @@ auto-generated on PRs tagged `demo`.
 - **Task 13c (UI test diagnostics):** `ui/support/{TraceBundleExtension, TraceBundle, StepRecorder, TraceIndexGenerator, CdpConsoleCollector}.kt` capture full trace bundles on failure.
 - **Task 13d (Page object refactor):** `ui/{locators, pages, flows, tests}/` provide the layered UI test structure; `ui/tests/ToolWindowUiTest.kt` is the reference example.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
+- **Task 15 (Extract `@pagemirror/snapshot-core`):** `packages/snapshot-core/src/{assemble-html.ts, browser/collector.ts, index.ts, manifest.ts, save-snapshot.ts, trace/, types.ts}` owns bundle assembly, manifest generation, and the browser-side collector behind a framework-agnostic `PageAdapter` interface. `packages/playwright-snapshot-saver/src/playwright-adapter.ts` is now the Playwright-specific `PageAdapter` implementation. Snapshot bundle format bumped to **v2** — `screenshot.<ext>` moves under `resources/`, CSS is written as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin inlines sidecar CSS on read via `services/SnapshotHtmlResolver.kt` (since `srcdoc` iframes can't resolve relative URLs). v1 bundles are refused with a user-visible banner pointing at `docs/migration-v1-to-v2.md` — regenerate via `npx playwright test` in `packages/test-project/`.
+- **Task 15.5 (Framework-agnostic trace rendering + resource inlining):** `@pagemirror/snapshot-core` owns trace rendering behind a `TraceBackend` interface (`packages/snapshot-core/src/trace/{types, renderer, inline, extract, runtime-script, content-type}.ts`). The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`) reshapes `TraceLoader.storage()` into that interface; `extractor.ts` delegates to `extractFromBackend`. Trace bundles are fully self-contained — every `<link>`, `<img>`, CSS `url(...)`, `@font-face`, and SVG `<use>` reference points at a real file under `resources/`, and the `<base>` element is stripped. Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse `extractFromBackend` by implementing the same `TraceBackend` surface.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
-
-**Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
-`@pagemirror/snapshot-core` now owns trace rendering behind a
-`TraceBackend` interface (`packages/snapshot-core/src/trace/{types,
-renderer, inline, extract, runtime-script, content-type}.ts`). The
-Playwright package (`packages/playwright-snapshot-saver/src/trace/
-playwright-backend.ts`) reshapes `TraceLoader.storage()` into that
-interface; `extractor.ts` delegates to `extractFromBackend`. Trace
-bundles are fully self-contained — every `<link>`, `<img>`, CSS
-`url(...)`, `@font-face`, and SVG `<use>` reference points at a real
-file under `resources/`, and the `<base>` element is stripped.
-Selenium/Cypress/Appium adapters (Tasks 17, 20) will reuse
-`extractFromBackend` by implementing the same `TraceBackend` surface.
+Open roadmap items — see `docs/Roadmap.md` and `docs/tasks/`:
+Task 16 (Python Playwright), Task 17 (Selenium/Cypress adapters),
+Task 18 (JVM Playwright), Task 20 (Appium). Task 15.5 delivered the
+`TraceBackend` seam these adapters depend on.
 
 ## Working with the Build
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` package now owns bundle assembly and trace rendering (Tasks 15 + 15.5) with the Playwright saver reduced to a thin `PageAdapter` + `TraceBackend` implementation, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The IDE side is still tightly coupled to TypeScript (regex-based locator extraction); the snapshot saver seam is now framework-agnostic so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,14 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` **(complete)**
+- **B1.5. Framework-agnostic trace rendering + resource inlining** — `task-15.5-trace-resource-inlining.md` **(complete)**
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor and B1.5 layered framework-agnostic trace
+rendering on top of it; B2 and B3 layer new adapters on top of the
+extracted core.
 
 ---
 

--- a/docs/tasks/task-15-snapshot-core-extraction.md
+++ b/docs/tasks/task-15-snapshot-core-extraction.md
@@ -1,5 +1,11 @@
 # Task 15: Extract Framework-Agnostic `snapshot-core`
 
+> **Status:** Complete. `packages/snapshot-core/` ships on `main` with
+> `src/{assemble-html.ts, browser/collector.ts, index.ts, manifest.ts,
+> save-snapshot.ts, trace/, types.ts}`; `packages/playwright-snapshot-saver/`
+> now depends on it. Bundle format v2 is announced in `CHANGELOG.md`
+> v0.5.0 and codified in `docs/snapshot-bundle-spec.md`.
+>
 > **Goal:** Split `playwright-snapshot-saver` into a framework-agnostic `@pagemirror/snapshot-core` package plus a thin Playwright adapter, enabling future Selenium / Cypress / Appium adapters (Tasks 17, 20) without duplicating bundle assembly, manifest generation, and HTML post-processing.
 > **Depends on:** Task 14 (aggregator) — recommended but not required.
 > **Output:** New `packages/snapshot-core/`, refactored `packages/playwright-snapshot-saver/` depending on it.

--- a/docs/tasks/task-15.5-trace-resource-inlining.md
+++ b/docs/tasks/task-15.5-trace-resource-inlining.md
@@ -1,5 +1,13 @@
 # Task 15.5: Resource Inlining for Trace-Extracted Snapshots
 
+> **Status:** Complete (commit `7b808a0`). `packages/snapshot-core/src/trace/`
+> owns rendering + inlining behind `TraceBackend`;
+> `packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`
+> implements the interface and `extractor.ts` delegates to
+> `extractFromBackend`. Test fixtures under
+> `packages/test-project/.snapshots/dashboard/` exercise sidecar CSS
+> resource inlining end-to-end.
+>
 > **Scope expanded 2026-04-15.** The original plan post-processed Playwright's
 > rendered HTML. The implementation instead owns rendering: `snapshot-core`
 > now ports Playwright's `SnapshotRenderer` behind a framework-agnostic


### PR DESCRIPTION
## Summary

Aligns docs to the current state of `main`. `@pagemirror/snapshot-core` has shipped, the Playwright saver is now a thin adapter on it, and the v2 bundle format is live (CHANGELOG.md v0.5.0, commit `7b808a0`) — but `CLAUDE.md`, `docs/Roadmap.md`, and the task 15 / 15.5 docs still described Task 15 as in-progress on a feature branch that no longer exists (`claude/check-task-statuses-C7rh9`). This PR is docs-only.

### Mismatches fixed

- **CLAUDE.md — "Current State"**: Task 15 was labeled *in progress* with a stale branch reference. Folded Tasks 15 and 15.5 into the completed bullet list, dropped the in-progress paragraph and stale branch pointer, updated the rollup from "Tasks 0–14 and 19" to "Tasks 0–15.5 and 19", added a short pointer to the open Track A/B roadmap items (16, 17, 18, 20).
- **CLAUDE.md — "Test Project Layout"**: showed `resources/` under all four fixtures. In reality only the `dashboard/initial/` and `dashboard/ticket-filled/` bundles have a `resources/` directory — the `login` fixtures use inline `<style>` so they have none. Corrected the tree and added a short note explaining that an absent `resources/` directory is valid.
- **CLAUDE.md — "Task Sequence" table**: stopped at Task 9 while the rest of the doc referenced Tasks 10–20. Added a pointer note under the table directing readers to `docs/tasks/task-10-*` … `task-20-*` for later tasks.
- **docs/Roadmap.md**: bumped completion rollup to "0–15.5 plus 19"; marked Track **B1** (task-15) and added **B1.5** (task-15.5) both as **(complete)**.
- **docs/tasks/task-15-snapshot-core-extraction.md** and **docs/tasks/task-15.5-trace-resource-inlining.md**: added an explicit `Status: Complete` block at the top of each so readers don't have to cross-reference CHANGELOG / git log to see whether the task landed.

### Verified accurate — no change needed

- Plugin source layout (`src/main/kotlin/...` and `src/main/resources/{META-INF, html/js, demo-viewer, messages}`) matches CLAUDE.md exactly.
- `docs/snapshot-bundle-spec.md` and `docs/migration-v1-to-v2.md` are consistent with `packages/snapshot-core/src/manifest.ts` (`MANIFEST_VERSION = 2`) and `services/SnapshotHtmlResolver.kt`.
- `packages/snapshot-core/README.md` and `packages/playwright-snapshot-saver/README.md` accurately describe the two-package split.
- CHANGELOG.md v0.5.0 entry matches the shipped v2 behaviour.

## Test plan

Docs-only change; no runtime code touched.

- [ ] CI stays green on `claude/loving-carson-drupp4` (no test or build impact expected)
- [ ] Skim `CLAUDE.md` and `docs/Roadmap.md` in the rendered PR view — the Current State section should list Tasks 15 and 15.5 as complete with no reference to `claude/check-task-statuses-C7rh9`
- [ ] Skim `docs/tasks/task-15-snapshot-core-extraction.md` and `docs/tasks/task-15.5-trace-resource-inlining.md` — each opens with a `Status: Complete` block

---
_Generated by [Claude Code](https://claude.ai/code/session_01PhyAnDUgTKZLYxokt1CewZ)_