### PR TITLE
docs: align docs with current state of main

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,7 @@ spec and v1 → v2 migration notes.
   "url": "https://example.com/login",
   "viewport": { "width": 1280, "height": 720 },
   "timestamp": "2025-01-15T10:30:00Z",
-  "playwright": "1.48.0",
+  "playwright": "1.58.0",
   "userAgent": "Mozilla/5.0 ..."
 }
 ```
@@ -118,6 +118,7 @@ packages/test-project/
   fixtures/
     app.html
     login.html
+    styles/
   page-objects/
     login.page.ts
     dashboard.page.ts
@@ -152,8 +153,9 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package and framework-agnostic `@pagemirror/snapshot-core`
+are published to `packages/`, the UI test suite runs under a layered
 Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
@@ -171,13 +173,16 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped in plugin 0.5.0
+(see `CHANGELOG.md`). `packages/snapshot-core/` publishes as
+`@pagemirror/snapshot-core@0.1.0`; `playwright-snapshot-saver@0.7.0`
+depends on it via semver. This release bumped the snapshot bundle format
+to v2: `screenshot.<ext>` moved under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
 inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
 URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+`npx playwright test` in `packages/test-project/`. See
+`docs/migration-v1-to-v2.md`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15 (+15.5) plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the framework-agnostic `@pagemirror/snapshot-core` package is extracted and consumed via semver, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) on the IDE side. Track A extends to Python / JVM locator support; Tracks B2/B3 add Selenium / Cypress / Appium adapters on top of `@pagemirror/snapshot-core`.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md` ✅ done
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 shipped as `@pagemirror/snapshot-core@0.1.0`; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 

--- a/docs/UI_tests/diagnostic-report.md
+++ b/docs/UI_tests/diagnostic-report.md
@@ -1,7 +1,12 @@
 # UI Tests Diagnostic Report
 
 **Date:** 2025-03-25
-**Status:** BLOCKED — tests cannot run
+**Status:** RESOLVED — see `docs/UI_tests/resolution-report.md` and
+`docs/tasks/task-13a-ui-tests-unblock.md`. UI tests run in CI today via
+the `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL
+at `build.gradle.kts:112-144`; retained for historical reference.
+
+**Original status:** BLOCKED — tests cannot run
 
 ## Overview
 

--- a/docs/UI_tests/plan.md
+++ b/docs/UI_tests/plan.md
@@ -1,5 +1,28 @@
 # Page Mirror — UI Test Development Plan
 
+> **Historical planning doc — captured before implementation.** The UI
+> test suite has shipped (Tasks 13a–13d, 19). Some low-level details
+> here have drifted from the shipped code:
+> - `runIdeForUiTests` is registered via the
+>   `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL,
+>   **not** a `tasks.register<RunIdeTask>` block. See
+>   [`build.gradle.kts:112-144`](../../build.gradle.kts) for the current
+>   wiring.
+> - The `layout.json` sidecar was removed in Task 15 (v2 bundle format);
+>   bundles now contain `index.html + manifest.json + resources/`. Tests
+>   no longer read a layout file.
+> - The `tests/` directory has grown to 11 classes — the file checklist
+>   below covers the original 8; `DashboardV2UiTest`, `DemoSmokeUiTest`,
+>   and `OutdatedBundleBannerUiTest` were added later.
+> - Layered Page Object structure (`ui/{fixtures,locators,pages,flows,tests}/`)
+>   is authoritative — see `docs/tasks/task-13d-ui-tests-page-object-refactor.md`
+>   and `CLAUDE.md` "UI Test Conventions".
+>
+> Retained here for the scenario numbering (UT-01 … UT-30) that other
+> docs reference. Please refresh section 2 (Build Integration) and
+> section 8 (File Checklist) against the current tree before treating
+> them as authoritative.
+
 ## Overview
 
 This document defines the plan for developing UI (end-to-end) tests for the Page Mirror plugin using the JetBrains **intellij-ui-test-robot** framework (Remote Robot). These tests drive a real IDE instance, unlike the existing `BasePlatformTestCase` integration tests which run headlessly without a visible UI.

--- a/docs/UI_tests/resolution-report.md
+++ b/docs/UI_tests/resolution-report.md
@@ -3,6 +3,13 @@
 **Date:** 2026-03-25
 **Status:** RESOLVED — all three blockers from `diagnostic-report.md` are fixed
 
+> **Follow-up (post-report):** The `register<RunIdeTask>("runIdeForUiTests")`
+> workaround described below was later replaced with the newer
+> `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL,
+> which sidesteps `splitMode` and the config-cache incompatibility
+> entirely. See `build.gradle.kts:112-144` for the current wiring and
+> `docs/tasks/task-13a-ui-tests-unblock.md` for the migration.
+
 ## Fixes Applied
 
 ### Blocker 1 (P0): `splitMode` property not configured

--- a/docs/UI_tests/test-run-status.md
+++ b/docs/UI_tests/test-run-status.md
@@ -4,6 +4,14 @@
 **Branch:** `dev`
 **Overall:** 30/30 PASS
 
+> **Historical snapshot** — captured on 2026-03-27 against 8 test classes
+> (UT-01 … UT-30). The suite has since grown to 11 classes with the
+> addition of `DashboardV2UiTest`, `DemoSmokeUiTest`, and
+> `OutdatedBundleBannerUiTest`. For current test results, read
+> `claude-summary.md` from the latest CI run on
+> `reports.artemon.cloud` — see the "Test Loop" section of
+> `CLAUDE.md` for the read commands.
+
 ## Summary
 
 | Test Class | Scenarios | Status |

--- a/docs/issues/manifest-timestamp-epoch.md
+++ b/docs/issues/manifest-timestamp-epoch.md
@@ -1,8 +1,13 @@
 # Manifest timestamp shows epoch-zero date
 
 > **Date:** 2026-04-01
-> **Status:** Open
+> **Status:** Resolved — fix landed in `playwright-snapshot-saver@0.7.0`
 > **Affects:** `extractSnapshots()`, reporter
+> **Fix location:** `packages/playwright-snapshot-saver/src/trace/playwright-adapter.ts:190-192`
+> (falls back to `context.wallTime + (action.startTime - context.startTime)`
+> when `action.wallTime` is missing or below the 1e10 epoch-ms sanity floor).
+> The value flows into `extractor.ts:127-128` as both `timestamp` and
+> `wallTime` on the `TraceSnapshotMarker`.
 
 ## Symptom
 

--- a/docs/migration-v1-to-v2.md
+++ b/docs/migration-v1-to-v2.md
@@ -119,5 +119,5 @@ initial/
 
 - Bundle spec: [`docs/snapshot-bundle-spec.md`](snapshot-bundle-spec.md)
 - Core package: [`packages/snapshot-core/`](../packages/snapshot-core/)
-- Plugin loader: `SnapshotBundle.kt` — `isSupportedVersion()` method
-- Manifest builder: `packages/snapshot-core/src/manifest.ts` — `MANIFEST_VERSION` constant
+- Plugin loader: `src/main/kotlin/com/github/artem/pageobjectplugin/model/SnapshotBundle.kt` — `SUPPORTED_BUNDLE_VERSION` constant + `readDeclaredVersion()` helper (both checked in `BundleLoadResult.load`)
+- Manifest schema version: `packages/snapshot-core/src/types.ts` — `MANIFEST_VERSION` constant (consumed by `packages/snapshot-core/src/manifest.ts`)

--- a/docs/research/playwright-snapshot-internals.md
+++ b/docs/research/playwright-snapshot-internals.md
@@ -2,6 +2,20 @@
 
 > **Date:** 2026-03-30
 > **Purpose:** Understand how Playwright captures DOM snapshots in traces, evaluate reuse potential for `playwright-snapshot-saver`.
+>
+> **Historical snapshot.** Captured pre-Task 15/15.5. Some references
+> are now out of date:
+> - `save-state.ts` (referenced under "Comparison with
+>   `playwright-snapshot-saver`") no longer exists; its logic was folded
+>   into `packages/snapshot-core/src/{assemble-html.ts,save-snapshot.ts}`
+>   during Task 15.
+> - The `layout.json` output was removed in Task 15 — bundles now ship
+>   `index.html + manifest.json + resources/` (v2 layout).
+> - Trace rendering + resource inlining live behind the framework-agnostic
+>   `TraceBackend` interface in `packages/snapshot-core/src/trace/` (Task 15.5).
+>
+> Retained for the internals write-up — trace-capture mechanics and the
+> Playwright client-side rendering pipeline are still accurate.
 
 ---
 

--- a/docs/research/playwright-snapshot-rendering.md
+++ b/docs/research/playwright-snapshot-rendering.md
@@ -68,7 +68,11 @@ const cleanHtml = rendered.html.replace(/ __playwright_target__="[^"]*"/g, '');
 
 The `querySelectorAll` reference inside the bootstrap script is left intact — it simply matches nothing since all target attributes are removed.
 
-Applied in `extractor.ts`, which is called by both the `extractSnapshots()` API and the Playwright reporter.
+Applied inside the emulated Playwright bootstrap in
+`packages/snapshot-core/src/trace/runtime-script.ts` (see the block near
+line 95). Task 15.5 moved this from `extractor.ts` into the framework-agnostic
+runtime script so every trace backend gets the same fix. The reporter and
+`extractSnapshots()` inherit it via `extractFromBackend`.
 
 ---
 

--- a/docs/superpowers/plans/2026-03-30-trace-extraction.md
+++ b/docs/superpowers/plans/2026-03-30-trace-extraction.md
@@ -1,5 +1,18 @@
 # Trace Extraction & Reporter Implementation Plan
 
+> **Historical — superseded by the Task 15 refactor.** This plan was
+> written against a `packages/snapshot-saver/` layout with
+> `layout.json`, `html-inliner.ts`, and `manifest-generator.ts`. What
+> actually shipped is `packages/playwright-snapshot-saver/` plus a
+> separate `packages/snapshot-core/` (Task 15), with trace rendering
+> owned by `snapshot-core` behind the `TraceBackend` interface (Task
+> 15.5). `manifest.version` is `2` (see `MANIFEST_VERSION` in
+> `packages/snapshot-core/src/types.ts`), the `screenshot` default is
+> `false` (`ExtractOptions` in
+> `packages/playwright-snapshot-saver/src/types.ts`), and none of
+> `layout.json`, `html-inliner.ts`, or `manifest-generator.ts` exist
+> today. Kept as a design record.
+>
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Extend `playwright-snapshot-saver` to extract snapshots from Playwright traces via a reporter and CLI extractor.

--- a/docs/superpowers/specs/2026-04-09-task-19-feature-demo-trace-viewer-design.md
+++ b/docs/superpowers/specs/2026-04-09-task-19-feature-demo-trace-viewer-design.md
@@ -4,6 +4,16 @@
 **Date:** 2026-04-09
 **Shape:** Three sequential PRs.
 
+> **Historical execution design.** The three-PR plumbing shipped; the
+> file paths quoted below drop the `ui/` subpackage that the layout
+> ultimately used. Shipped locations:
+> `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/annotations/Feature.kt`,
+> `.../ui/support/FeatureTagListener.kt`,
+> `.../ui/support/TraceBundleExtension.kt`. CI wiring also diverged:
+> `demo.yml` triggers on the `demo` label alone (no `[demo:tag]` PR-title
+> prefix) and uploads to `reports.artemon.cloud` instead of using
+> `actions/upload-artifact` + a PR comment.
+
 ## Goal
 
 Ship the `@Feature` → `demoReport` → CI-on-`demo`-label pipeline in three reviewable PRs, reusing Task 13c trace bundles. Reviewers click an artifact link on a labeled PR and walk every UI scenario covering the feature.

--- a/docs/tasks/task-0-playwright-test-project.md
+++ b/docs/tasks/task-0-playwright-test-project.md
@@ -1,8 +1,18 @@
 # Task 0: Dummy Playwright Test Project
 
+> **Status:** DONE — the test project shipped and has since moved and
+> changed shape:
+> - Location is `packages/test-project/` (moved under npm workspaces in
+>   Task 9), not `test-project/` at the repo root.
+> - Snapshot bundles now use the v2 layout (`index.html + manifest.json + resources/`);
+>   the `layout.json` sidecar referenced below was removed in Task 15.
+> - The `utils/save-state.ts` helper was superseded by the
+>   `playwright-snapshot-saver` npm package (Task 9) and its reporter
+>   (Task 10).
+>
 > **Goal:** Create a minimal Playwright project that produces real snapshot bundles for testing all IDE features.
 > **Depends on:** Nothing
-> **Output:** `test-project/` with `.snapshots/login/initial/` and `.snapshots/login/error-state/`
+> **Output:** `packages/test-project/` with `.snapshots/login/initial/` and `.snapshots/login/error-state/`
 
 ## Prompt
 

--- a/docs/tasks/task-10-trace-extraction.md
+++ b/docs/tasks/task-10-trace-extraction.md
@@ -1,5 +1,13 @@
 # Task 10 — Trace Extraction & Reporter Integration
 
+> **Status:** DONE — the package path referenced below
+> (`packages/snapshot-saver/`) is stale; the shipped package is
+> `packages/playwright-snapshot-saver/`. `html-inliner.ts` and
+> `manifest-generator.ts` were extracted into
+> `packages/snapshot-core/src/{assemble-html.ts,manifest.ts}` in
+> Task 15; the trace pipeline moved behind a framework-agnostic
+> `TraceBackend` interface in Task 15.5.
+
 ## Overview
 
 Extend `playwright-snapshot-saver` to extract snapshots from Playwright traces. Two new capabilities:

--- a/docs/tasks/task-13a-ui-tests-unblock.md
+++ b/docs/tasks/task-13a-ui-tests-unblock.md
@@ -1,5 +1,11 @@
 # Task 13a: UI Tests — Unblock Runner
 
+> **Status:** DONE — resolved via the newer
+> `intellijPlatformTesting.runIde.register("runIdeForUiTests")` DSL,
+> which sidesteps the `splitMode` / config-cache issues entirely rather
+> than working around them on a `RunIdeTask` registration. See
+> `build.gradle.kts:112-144` for the current wiring.
+>
 > **Goal:** Restore the ability to run `./gradlew runIdeForUiTests` so the existing 30 UI scenarios execute again.
 > **Depends on:** nothing (prerequisite for 13b–d, 14, 19)
 > **Output:** Updated `build.gradle.kts` and `BaseUiTest.kt`; all existing UI scenarios runnable.
@@ -12,9 +18,11 @@ Until this is fixed, no further UI-test work (13b–d), CI reporting (14), or de
 
 ## Key Files
 
-- `build.gradle.kts:109-156` — `runIdeForUiTests` task registration.
-- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/BaseUiTest.kt:40-104` — `waitForIde()` + 2-minute blind timeout.
-- `docs/UI_tests/diagnostic-report.md` — full symptom trace and proposed fix outline.
+- `build.gradle.kts:112-144` — `runIdeForUiTests` task registration
+  (now via `intellijPlatformTesting.runIde.register("runIdeForUiTests")`).
+- `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/BaseUiTest.kt` — `waitForIde()` health check.
+- `docs/UI_tests/diagnostic-report.md` — full symptom trace and original fix outline.
+- `docs/UI_tests/resolution-report.md` — the interim `register<RunIdeTask>` fix that was later replaced by the DSL above.
 
 ## Steps
 

--- a/docs/tasks/task-13b-ui-tests-reliability.md
+++ b/docs/tasks/task-13b-ui-tests-reliability.md
@@ -1,8 +1,16 @@
 # Task 13b: UI Tests — Reliability (polling, retry, quarantine)
 
+> **Status:** DONE (partial). `ui/support/Wait.kt` (`pollUntil`,
+> `pollUntilTrue`) and `ui/support/RetryOnceExtension.kt` ship. **Gap:**
+> the `@Quarantine` annotation was never created — quarantine remains a
+> field in `ClaudeSummaryModel.kt` only, tracked as follow-up. Paths in
+> "Key Files" and "Steps" below reference the pre-13d layout (before
+> the `ui/` subpackage move); actual files live under
+> `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/…`.
+>
 > **Goal:** Eliminate `Thread.sleep`/fixed timeouts, make transient failures retry once with visibility, and allow known-flaky tests to be quarantined without deletion.
 > **Depends on:** Task 13a
-> **Output:** `support/Wait.kt`, a retry-once JUnit 5 extension, a `@Quarantine` annotation + condition, all fixtures migrated off `Thread.sleep`.
+> **Output:** `ui/support/Wait.kt`, a retry-once JUnit 5 extension (`ui/support/RetryOnceExtension.kt`), a `@Quarantine` annotation + condition (never shipped), all fixtures migrated off `Thread.sleep`.
 
 ## Motivation
 

--- a/docs/tasks/task-13c-ui-tests-diagnostics.md
+++ b/docs/tasks/task-13c-ui-tests-diagnostics.md
@@ -1,8 +1,19 @@
 # Task 13c: UI Tests — Per-Test Diagnostics Trace Bundle
 
+> **Status:** DONE — `ui/support/TraceBundleExtension.kt`,
+> `TraceBundle.kt`, `StepRecorder.kt`, `TraceIndexGenerator.kt`, and
+> `CdpConsoleCollector.kt` capture per-test bundles. `trace.json` is
+> emitted on failure (and on success when `-PcaptureAllTraces=true`).
+> The planned `ScreenshotOnFailureExtension` was never checked in — the
+> replacement shipped without a preceding version, so the "delete
+> `ScreenshotOnFailureExtension`" step below never had a file to delete.
+> Paths in "Key Files" and "Steps" below reference the pre-13d layout;
+> actual files live under
+> `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/…`.
+>
 > **Goal:** On UI test failure, capture a structured bundle of artifacts (IDE log, tool-window DOM, JCEF console, screenshot timeline, thread dump) with a machine-readable `trace.json` manifest. This bundle is the direct input to the Task 19 (C3) Playwright-style trace viewer.
 > **Depends on:** Task 13a (unblock), Task 13b (polling — for step recording)
-> **Output:** `TraceBundleExtension` replacing `ScreenshotOnFailureExtension`; one bundle per failing test under `build/reports/uiTest/traces/<test>/`.
+> **Output:** `TraceBundleExtension` — one bundle per failing test under `build/reports/uiTest/traces/<test>/`.
 
 ## Motivation
 

--- a/docs/tasks/task-13d-ui-tests-page-object-refactor.md
+++ b/docs/tasks/task-13d-ui-tests-page-object-refactor.md
@@ -1,8 +1,17 @@
 # Task 13d: UI Tests — Page Object Pattern Refactor
 
+> **Status:** DONE. All fixtures, pages, flows, locators, and tests
+> shipped under the `ui/` subpackage
+> (`src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/{locators,
+> pages, flows, fixtures, tests}/`). Paths in "Key Files" and "Steps"
+> below reflect the pre-refactor layout — the shipped tree adds a `ui/`
+> segment to every path. `ui/tests/ToolWindowUiTest.kt` is the
+> reference test; `ui/tests/SettingsUiTest.kt` is `@Disabled` for
+> unrelated UI-DSL reasons but kept as a structural reference.
+>
 > **Goal:** Refactor the flat Remote Robot fixture layer into a layered structure (`locators/` + `pages/` + `flows/`) so UI tests read as high-level scenarios, XPaths live in exactly one place, and `BaseUiTest` shrinks to pure lifecycle code.
 > **Depends on:** Task 13a (unblock), Task 13b (polling helpers), Task 13c (trace bundle — `step()` integration)
-> **Output:** New `locators/`, `pages/`, `flows/` packages under `src/uiTest/kotlin/…`; `ToolWindowUiTest` and `SettingsUiTest` rewritten as reference examples; `CLAUDE.md` layering rule documented.
+> **Output:** New `ui/locators/`, `ui/pages/`, `ui/flows/` packages under `src/uiTest/kotlin/…`; `ToolWindowUiTest` and `SettingsUiTest` rewritten as reference examples; `CLAUDE.md` layering rule documented.
 
 ## Motivation
 

--- a/docs/tasks/task-15.5-trace-resource-inlining.md
+++ b/docs/tasks/task-15.5-trace-resource-inlining.md
@@ -1,11 +1,29 @@
 # Task 15.5: Resource Inlining for Trace-Extracted Snapshots
 
+> **Status:** DONE. `snapshot-core` ports Playwright's `SnapshotRenderer`
+> behind a framework-agnostic `TraceBackend` interface; resource
+> inlining lives at
+> `packages/snapshot-core/src/trace/{types,renderer,inline,extract,runtime-script,content-type}.ts`.
+> The Playwright package (`packages/playwright-snapshot-saver/src/trace/playwright-backend.ts`)
+> reshapes `TraceLoader.storage()` into that interface and
+> `packages/playwright-snapshot-saver/src/extractor.ts` delegates to
+> `extractFromBackend`. Every `<link>`, `<img>`, CSS `url(...)`,
+> `@font-face`, and SVG `<use>` reference resolves to a file under
+> `resources/`, and `<base>` is stripped. See CLAUDE.md's "Task 15.5"
+> paragraph.
+>
+> **File-reference note.** Steps below reference the pre-implementation
+> plan — `inline-resources.ts`, `resolveTraceResource`, `renderSnapshotAtMarker`,
+> and the `__playwright_target__` strip at `extractor.ts:142` — none of
+> which shipped in that shape. Read the paragraph above for the shipped
+> file layout; the steps are retained to document what was actually
+> executed against the earlier plan.
+>
 > **Scope expanded 2026-04-15.** The original plan post-processed Playwright's
 > rendered HTML. The implementation instead owns rendering: `snapshot-core`
 > now ports Playwright's `SnapshotRenderer` behind a framework-agnostic
 > `TraceBackend` interface. Seven-category inlining still applies — only the
-> mechanism changed. See `C:\Users\Artem\.claude\plans\delegated-dancing-valley.md`
-> for the expanded plan that was executed.
+> mechanism changed.
 >
 > **Goal:** Make trace-extracted snapshots self-contained by walking the
 > rendered HTML, resolving every external reference through the snapshot's

--- a/docs/tasks/task-16-python-playwright-support.md
+++ b/docs/tasks/task-16-python-playwright-support.md
@@ -1,5 +1,7 @@
 # Task 16: Python Playwright Support
 
+> **Status:** PLANNED — not yet started.
+>
 > **Goal:** Make the plugin recognize Python Playwright locators in `.py` files (highlight + gutter) AND ship a `playwright-snapshot-saver-python` package so Python users can produce snapshot bundles.
 > **Depends on:** Task 15 (snapshot-core — for the bundle spec contract), `docs/snapshot-bundle-spec.md` frozen.
 > **Output:** `PythonLocatorExtractor.kt`, `LocatorExtractorRegistry`, new PyPI package `packages/playwright-snapshot-saver-python/`.
@@ -75,8 +77,8 @@ The pytest plugin (`pytest_plugin.py`) provides auto-capture on test failure whe
 3. Wire `SelectorValidationAnnotator` to look up the extractor via the registry by file extension.
 4. Add `.py` to default `fileExtensions` in settings; update `PageMirrorConfigurable` if the default needs to be surfaced.
 5. Scaffold `packages/playwright-snapshot-saver-python/` with modern `pyproject.toml` (PEP 621) and `hatchling` or `poetry` build.
-6. Port `html-inliner.ts` to Python using `beautifulsoup4` + stdlib `urllib` — produce output matching the TS version for the shared fixture page (verified by golden-file test).
-7. Port `manifest-generator.ts` — emit spec-v1 compliant `manifest.json` per `docs/snapshot-bundle-spec.md`.
+6. Port `packages/snapshot-core/src/assemble-html.ts` to Python using `beautifulsoup4` + stdlib `urllib` — produce output matching the TS version for the shared fixture page (verified by golden-file test).
+7. Port `packages/snapshot-core/src/manifest.ts` — emit spec-v2 compliant `manifest.json` per `docs/snapshot-bundle-spec.md` (`MANIFEST_VERSION = 2`; source of truth in `packages/snapshot-core/src/types.ts`).
 8. Implement `save_snapshot` / `save_snapshot_async` for `playwright.sync_api.Page` and `playwright.async_api.Page`.
 9. Implement `pytest_plugin.py` reporter (fixture + hook) analogous to `playwright-snapshot-saver`'s Playwright reporter.
 10. Integration tests: `pytest` suite that launches a headless Chromium, visits a fixture page, calls `save_snapshot`, and asserts bundle layout + manifest contents.

--- a/docs/tasks/task-17-selenium-cypress-adapters.md
+++ b/docs/tasks/task-17-selenium-cypress-adapters.md
@@ -1,7 +1,9 @@
 # Task 17: Selenium + Cypress Snapshot Saver Adapters
 
+> **Status:** PLANNED — not yet started.
+>
 > **Goal:** Ship two new npm packages, `selenium-snapshot-saver` and `cypress-snapshot-saver`, each a thin `PageAdapter` implementation over `snapshot-core` (Task 15). Enables Selenium/Cypress users to produce identical snapshot bundles.
-> **Depends on:** Task 15 (`snapshot-core` extracted).
+> **Depends on:** Task 15 (`snapshot-core` extracted — done).
 > **Output:** Two new packages under `packages/`, each with integration tests against a fixture page.
 
 ## Motivation
@@ -10,7 +12,7 @@ Task 15 built the `PageAdapter` abstraction specifically so new driver adapters 
 
 ## Key Files
 
-- `packages/snapshot-core/src/page-adapter.ts` — interface to implement.
+- `PageAdapter` interface — defined in `packages/snapshot-core/src/types.ts` (see also the "Writing a new driver adapter" section of `packages/snapshot-core/README.md`). There is no dedicated `page-adapter.ts` file.
 - New: `packages/selenium-snapshot-saver/`
   - `src/index.ts` — `SeleniumAdapter implements PageAdapter`
   - `src/save.ts` — re-export `saveSnapshot` bound to the adapter

--- a/docs/tasks/task-18-jvm-playwright-support.md
+++ b/docs/tasks/task-18-jvm-playwright-support.md
@@ -1,6 +1,10 @@
 # Task 18: Java/Kotlin Playwright Support
 
-> **Goal:** Recognize Playwright Java API locators in `.java` and `.kt` files (highlight + gutter) AND ship `snapshot-saver-jvm` — a Kotlin JVM library that produces spec-v1 bundles from `com.microsoft.playwright.Page`.
+> **Status:** PLANNED — not yet started. The bundle format is now v2
+> (`MANIFEST_VERSION = 2` in `packages/snapshot-core/src/types.ts`); the
+> "spec-v1" wording in step 6 below is stale.
+>
+> **Goal:** Recognize Playwright Java API locators in `.java` and `.kt` files (highlight + gutter) AND ship `snapshot-saver-jvm` — a Kotlin JVM library that produces spec-v2 bundles from `com.microsoft.playwright.Page`.
 > **Depends on:** Task 16 (introduces `LocatorExtractor` interface + registry), `docs/snapshot-bundle-spec.md`.
 > **Output:** `JvmLocatorExtractor.kt`, new Gradle artifact `packages/playwright-snapshot-saver-jvm/`.
 
@@ -57,7 +61,7 @@ SnapshotSaver.save(page, "login/initial", new SaveOptions().setOutputDir(new Fil
 3. Add `.java`, `.kt` to default `fileExtensions` in settings.
 4. Scaffold `packages/playwright-snapshot-saver-jvm/` as a sibling Gradle project, included via root `settings.gradle.kts`. Kotlin JVM, Java 17 target.
 5. Implement `HtmlInliner` in Kotlin using Jsoup (port of TS version, verified against the shared fixture page via golden-file test).
-6. Implement `ManifestGenerator` emitting spec-v1 JSON via `kotlinx.serialization`.
+6. Implement `ManifestGenerator` emitting spec-v2 JSON via `kotlinx.serialization` (`"version": 2`).
 7. Implement `SnapshotSaver.save()` against `com.microsoft.playwright.Page`. Options class mirrors the TS API.
 8. Implement `SnapshotSaverExtension` as a JUnit 5 `TestWatcher` + `ParameterResolver` — auto-captures on failure when registered.
 9. Integration tests: JUnit 5 suite that launches Playwright Java, visits a fixture page, calls the saver, asserts bundle layout.

--- a/docs/tasks/task-19-feature-demo-trace-viewer.md
+++ b/docs/tasks/task-19-feature-demo-trace-viewer.md
@@ -1,5 +1,20 @@
 # Task 19: Feature Demo — Playwright-Style Trace Viewer
 
+> **Status:** DONE. Shipped files (paths adjusted from the plan):
+> - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/annotations/Feature.kt`
+> - `src/uiTest/kotlin/com/github/artem/pageobjectplugin/ui/support/FeatureTagListener.kt`
+>   (a JUnit-Jupiter `BeforeEachCallback`, not a `TestExecutionListener`)
+> - `buildSrc/src/main/kotlin/com/github/artem/pageobjectplugin/buildtools/DemoReportRenderer.kt`
+>   and `DemoTestSelector.kt`
+> - `src/main/resources/demo-viewer/{index.html,app.js,styles.css}`
+> - `.github/workflows/demo.yml`
+>
+> Reviewers receive the demo bundle via the `reports.artemon.cloud`
+> dashboard (see `CLAUDE.md` "Report Dashboard Access"). demo.yml
+> uploads the report zip with `curl` — there is no `actions/upload-artifact`
+> step or PR-comment step. `demoReport` is invoked with `-PfeatureName=all`.
+> Xvfb (`:99`) is installed and started before the IDE launches.
+>
 > **Goal:** Produce a self-contained HTML trace viewer (Playwright-style) per PR that lets reviewers step through every UI test exercising a changed or added feature — timeline, action log, before/after DOM snapshots, screenshots — triggered by adding a `demo` label on a PR.
 > **Depends on:** Task 13c (trace bundle + `trace.json` schema), Task 14 (CI reporting, artifact upload).
 > **Output:** `./gradlew demoReport -PfeatureName=<tag>` Gradle task, `@Feature("name")` annotation, CI workflow triggered by `demo` label, `build/reports/demo/<feature>/index.html` artifact.

--- a/docs/tasks/task-19-test-plan.md
+++ b/docs/tasks/task-19-test-plan.md
@@ -1,5 +1,26 @@
 # Task 19 — Test Plan: Demo Report & CI Integration
 
+> **Historical planning doc.** The shipped `demo.yml`
+> (`.github/workflows/demo.yml`) diverges from what Check 2 describes:
+> - Trigger is `pull_request: types: [labeled]` with a job-level
+>   `if: github.event.label.name == 'demo'` — no `[demo:tag]` PR-title
+>   parsing.
+> - The workflow always runs `./gradlew demoReport -PfeatureName=all`
+>   (no per-label feature routing).
+> - Reports are uploaded via `curl` to `reports.artemon.cloud`
+>   (`/api/v1/upload?suite=demo&...`) rather than
+>   `actions/upload-artifact` + a PR comment.
+> - Xvfb + display packages *are* installed before the IDE launches
+>   (see steps "Install Xvfb and display dependencies" / "Start Xvfb");
+>   the "Known risk: demo.yml missing Xvfb" callout below is stale.
+> - `build.gradle.kts` line ranges cited in Check 1 have drifted by a
+>   few lines as `demoReport` and related tasks were edited — treat
+>   them as approximate.
+>
+> Kept for reference on the pass criteria (Check 1's `test -f` / `grep`
+> assertions on the produced `index.html`) and for Check 3's CI test-loop
+> workflow.
+
 Three verification checks that together prove the feature-demo pipeline works
 end-to-end in CI.
 

--- a/docs/tasks/task-2-snapshot-loading.md
+++ b/docs/tasks/task-2-snapshot-loading.md
@@ -1,5 +1,17 @@
 # Task 2: Snapshot Loading via CefQueryRouter
 
+> **Status:** DONE — bundle model has since evolved:
+> - `SnapshotBundle` (`src/main/kotlin/.../model/SnapshotBundle.kt`)
+>   drops `layoutPath` and adds `dir` + `resourcesDir`; the shipped
+>   fields are `name`, `dir`, `htmlPath`, `resourcesDir`,
+>   `screenshotPath`, `manifestPath`.
+> - `layout.json` was removed in Task 15 (v2 bundle format); loading
+>   now inlines sidecar CSS via `SnapshotHtmlResolver` rather than
+>   passing a JSON string to JS.
+> - Bundle version validation runs against `SUPPORTED_BUNDLE_VERSION = 2`
+>   (top-level `const val` in `SnapshotBundle.kt`); unknown versions
+>   are refused via `BundleLoadResult`.
+>
 > **Goal:** Establish the Kotlin-to-JCEF communication bridge. Push snapshot data into the browser and render it.
 > **Depends on:** Task 0 (for test data), Task 1 (for plugin shell)
 > **Output:** Menu action that loads a snapshot folder and renders it in the Tool Window

--- a/docs/tasks/task-20-appium-mobile-support.md
+++ b/docs/tasks/task-20-appium-mobile-support.md
@@ -1,7 +1,12 @@
 # Task 20: Appium Mobile Snapshot Saver
 
-> **Goal:** Ship `appium-snapshot-saver` — a `PageAdapter` over Appium that captures native mobile page source + screenshot into a spec-v1 bundle, extending the manifest `viewport` with platform + device metadata.
-> **Depends on:** Task 15 (`snapshot-core`), Task 17 (pattern for adapter packages).
+> **Status:** PLANNED — not yet started. The bundle spec is already v2
+> (`MANIFEST_VERSION = 2`); the "spec-v1" wording and the
+> `"version": 1` manifest example below are stale and must be rebased
+> onto v2 before starting.
+>
+> **Goal:** Ship `appium-snapshot-saver` — a `PageAdapter` over Appium that captures native mobile page source + screenshot into a spec-v2 bundle, extending the manifest `viewport` with platform + device metadata.
+> **Depends on:** Task 15 (`snapshot-core` — done), Task 17 (pattern for adapter packages — planned).
 > **Output:** New `packages/appium-snapshot-saver/`, decision on HTML-vs-XML rendering fallback tracked as follow-up.
 
 ## Motivation
@@ -10,7 +15,7 @@ Appium exposes UI tree dumps as XML, not HTML. Supporting it stretches the snaps
 
 ## Key Files
 
-- `packages/snapshot-core/src/page-adapter.ts` — may need a `sourceFormat: "html" | "xml"` field on the adapter result.
+- `PageAdapter` interface — defined in `packages/snapshot-core/src/types.ts`. May need a `sourceFormat: "html" | "xml"` field on the adapter result.
 - New: `packages/appium-snapshot-saver/`
   - `src/index.ts` — `AppiumAdapter implements PageAdapter`
   - `tests/` — integration test against Appium's demo app or a stubbed driver
@@ -26,7 +31,7 @@ Appium exposes UI tree dumps as XML, not HTML. Supporting it stretches the snaps
 - Manifest extension:
   ```json
   {
-    "version": 1,
+    "version": 2,
     "viewport": {
       "width": 390,
       "height": 844,
@@ -37,7 +42,7 @@ Appium exposes UI tree dumps as XML, not HTML. Supporting it stretches the snaps
     "appium": "2.5.4"
   }
   ```
-  This is an **additive** manifest change — does not bump `spec.version`.
+  This is an **additive** manifest change against the v2 schema — does not bump `manifest.version`.
 
 ## Open Question: Plugin-side Rendering of XML
 
@@ -60,7 +65,7 @@ The plugin's tool window iframe is HTML-only. XML page-source cannot render ther
 
 ## Verification
 
-- Bundles produced by `AppiumAdapter` conform to spec v1 with the additive mobile fields.
+- Bundles produced by `AppiumAdapter` conform to spec v2 with the additive mobile fields.
 - Both `index.html` and `index.xml` present for native snapshots; only `index.html` for webview snapshots.
 - `snapshot-core` tests still pass; no regression for Playwright/Selenium/Cypress bundles.
 - The plugin tool window can list and show screenshots for mobile bundles (full XML rendering waits for the follow-up task).

--- a/docs/tasks/task-5-element-picker.md
+++ b/docs/tasks/task-5-element-picker.md
@@ -1,5 +1,13 @@
 # Task 5: Element Picker + Code Generation
 
+> **Status:** DONE — implementation collapsed a few files:
+> - No `InsertLocatorAction.kt` or `InsertLocatorPopup` class shipped.
+>   Insertion lives inside
+>   `src/main/kotlin/.../locators/PickerResultHandler.kt` (`insertAtCaret`,
+>   `insertLocatorForTest`).
+> - Element metadata is read from the DOM via JS in the snapshot iframe,
+>   not from `layout.json` (which was removed in Task 15).
+>
 > **Goal:** Click an element in Page Mirror to generate a Playwright locator and insert it into the editor.
 > **Depends on:** Task 4
 > **Output:** Inspect mode → click element → popup offers locator code → inserts at caret

--- a/docs/tasks/task-8-highlight-all-locators.md
+++ b/docs/tasks/task-8-highlight-all-locators.md
@@ -1,5 +1,10 @@
 # Task 8: Highlight All Locators + Duplicate Detection
 
+> **Status:** DONE — no dedicated `actions/HighlightAllAction.kt` file
+> shipped. The "Show All" button, its click handler, and locator
+> collection all live inline inside
+> `src/main/kotlin/.../PageMirrorToolWindowFactory.kt`.
+>
 > **Goal:** A toolbar button that highlights every Playwright locator found in the current editor file on the snapshot, with visual indicators for overlapping or duplicate selectors.
 > **Depends on:** Tasks 4, 6
 > **Output:** "Show All" button -> all locators highlighted simultaneously with overlap/duplicate badges

--- a/docs/tasks/task-9-snapshot-package.md
+++ b/docs/tasks/task-9-snapshot-package.md
@@ -1,8 +1,16 @@
 # Task 9: Snapshot Saver npm Package
 
+> **Status:** DONE — the shipped package is
+> `packages/playwright-snapshot-saver/` (not `packages/snapshot-saver/`),
+> published as `playwright-snapshot-saver` on npm. The test project
+> moved to `packages/test-project/` when npm workspaces were adopted.
+> Task 15 later extracted framework-agnostic pieces into
+> `packages/snapshot-core/` (`@pagemirror/snapshot-core`); Playwright
+> stays in `playwright-snapshot-saver`.
+>
 > **Goal:** Extract snapshot-saving logic from `test-project/utils/save-state.ts` into a standalone, publishable npm package with a configurable API.
 > **Depends on:** Task 0
-> **Output:** `packages/snapshot-saver/` — a self-contained npm package consumable by any Playwright project
+> **Output:** `packages/playwright-snapshot-saver/` — a self-contained npm package consumable by any Playwright project
 
 ## Motivation
 


### PR DESCRIPTION
## Summary

Docs-only pass to align every doc under `docs/` (plus root
`README.md` / `CHANGELOG.md` / `USE.md` / `CLAUDE.md`) with the shipped
code on `main`. Three parallel audit passes surfaced ~30 mismatches;
this PR fixes each one in place. No code changes.

## What changed

- **`CLAUDE.md`, `docs/Roadmap.md`, `docs/migration-v1-to-v2.md`,
  `docs/issues/manifest-timestamp-epoch.md`** — the most user-facing docs
  had *materially wrong* claims (Task 15 marked "in progress" on a
  work branch, `SnapshotBundle.isSupportedVersion()` referenced by
  name, `MANIFEST_VERSION` pointed at the wrong file, the epoch
  timestamp issue marked "Open"). All corrected against the shipped
  code.
- **`docs/tasks/task-13*.md`, `docs/tasks/task-15.5-*.md`,
  `docs/tasks/task-19-*.md`, `docs/UI_tests/*.md`** — described the
  pre-`ui/` subpackage tree and an older `register<RunIdeTask>` DSL.
  Added a "Status: DONE" banner at the top of each with the actual
  shipped file paths and the newer
  `intellijPlatformTesting.runIde.register(...)` wiring.
- **`docs/tasks/task-0/2/5/8/9/10-*.md`** — historical task cards
  referenced `layout.json`, `InsertLocatorAction.kt`,
  `HighlightAllAction.kt`, `packages/snapshot-saver/`, and other files
  that were renamed or folded during Task 9/15. Added a "Status: DONE"
  banner pointing at the current locations rather than rewriting the
  step-by-step prompts.
- **`docs/tasks/task-16/17/18/20-*.md`** — planned-task docs still
  said "spec-v1" and pointed at a `page-adapter.ts` file that never
  shipped. Bumped wording to spec-v2 (`MANIFEST_VERSION = 2`) and
  redirected the file references at
  `packages/snapshot-core/src/{types,assemble-html,manifest}.ts`.
  Added explicit "PLANNED — not yet started" markers.
- **`docs/research/*.md`, `docs/superpowers/plans/*.md`,
  `docs/superpowers/specs/*.md`** — pinned to pre-Task-15 file names
  (`save-state.ts`, `html-inliner.ts`, `manifest-generator.ts`). Added
  historical banners so readers land on the shipped file layout.
- **Cosmetic:** CLAUDE.md manifest example uses `"playwright": "1.58.0"`
  (matches USE.md / snapshot-bundle-spec.md / README); the
  test-project fixtures tree in CLAUDE.md now lists `styles/`.

29 files, +286 / −38.

## Test plan

- [ ] Docs-only change — CI's `test-report` job runs to confirm no
      accidental breakage in files it consumes (e.g. workflow YAMLs
      untouched by this diff).
- [ ] Manual review of the top-of-doc status banners on
      `CLAUDE.md`, `docs/migration-v1-to-v2.md`, and the task-13/15.5/19
      docs to confirm the wording matches the current code.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UBFy961drabo4ZNDGpLtM2)_