### PR TITLE
docs: mark Task 15/15.5 shipped, refresh v1→v2 bundle references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,8 +152,10 @@ Tasks MUST be completed in order. Each task is in `docs/tasks/`.
 
 ## Current State
 
-**Tasks 0–14 and 19 are complete.** All plugin features ship, the snapshot
-saver npm package is published, the UI test suite runs under a layered
+**Tasks 0–15.5 and 19 are complete.** All plugin features ship, the
+snapshot saver npm package is published (as a thin adapter on top of
+`@pagemirror/snapshot-core`), bundles are on the v2 format with a
+`resources/` sidecar directory, the UI test suite runs under a layered
 Page Object structure, CI aggregates test results into a single
 `claude-summary.{json,md}` bundle, and a Playwright-style trace viewer is
 auto-generated on PRs tagged `demo`.
@@ -171,13 +173,20 @@ auto-generated on PRs tagged `demo`.
 - **Task 14 (CI test reporting):** `build.gradle.kts` registers `aggregateTestReport` (`:219`) and `testReport` (`:261`); `buildSrc/.../buildtools/` contains `ClaudeSummaryGenerator`, `JUnitXmlParser`, `PlaywrightJsonParser`, `MarkdownEmitter`, `TraceJsonAugmenter` with unit tests.
 - **Task 19 (Feature demo trace viewer):** `ui/annotations/Feature.kt`, `FeatureTagListener`, `buildSrc/.../DemoReportRenderer.kt` + `DemoTestSelector.kt`, `src/main/resources/demo-viewer/`, and `.github/workflows/demo.yml` together render a self-contained trace viewer per PR.
 
-**Task 15 (Extract `@pagemirror/snapshot-core`)** is **in progress** on
-branch `claude/check-task-statuses-C7rh9`. This bumps the snapshot bundle
-format to v2: `screenshot.<ext>` moves under `resources/`, CSS is written
-as `resources/<sha1>.css` sidecars referenced by `<link>`, and the plugin
-inlines sidecar CSS on read (since `srcdoc` iframes can't resolve relative
-URLs). v1 bundles are refused with a clear error message — regenerate via
-`npx playwright test` in `packages/test-project/`.
+**Task 15 (Extract `@pagemirror/snapshot-core`)** shipped in
+`packages/snapshot-core/`. The framework-agnostic core owns HTML
+assembly (`assemble-html.ts`), manifest building (`manifest.ts`), and
+the `saveSnapshot(adapter, options)` orchestrator; `playwright-snapshot-saver`
+is a thin adapter that implements `PageAdapter` in
+`playwright-adapter.ts`. This bumped the bundle format to v2:
+`screenshot.<ext>` moves under `resources/`, CSS is written as
+`resources/<sha1>.css` sidecars referenced by `<link>` (16-hex-char
+prefix for the live saver, full-length sha1 for trace-extracted
+bundles), and the plugin inlines sidecar CSS on read (since `srcdoc`
+iframes can't resolve relative URLs). v1 bundles are refused with a
+user-visible outdated-bundle banner in the tool window — regenerate via
+`npx playwright test` in `packages/test-project/`. See
+`docs/migration-v1-to-v2.md`.
 
 **Task 15.5 (Framework-agnostic trace rendering + resource inlining)** —
 `@pagemirror/snapshot-core` now owns trace rendering behind a

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-Tasks 0–14 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright (snapshot saver imports `@playwright/test`). Task 15 below extracts a framework-agnostic `@pagemirror/snapshot-core` package so Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can be layered on top without duplicating bundle assembly.
+Tasks 0–15.5 plus 19 are complete: the plugin works end-to-end for Playwright + TypeScript, the `playwright-snapshot-saver` npm package ships snapshots from real Playwright runs as a thin adapter on top of the framework-agnostic `@pagemirror/snapshot-core` engine (Task 15) that owns HTML assembly, manifest building, and trace rendering (Task 15.5), bundles are on the v2 layout with `resources/` sidecars, the settings UI is on Kotlin UI DSL v2, the UI test suite runs under a layered Page Object structure with polling/retry/trace-bundle diagnostics, CI aggregates unit + UI + Playwright results into a single `claude-summary.{json,md}` bundle consumed via `reports.artemon.cloud`, and PRs tagged `demo` auto-render a Playwright-style trace viewer. The current architecture is still tightly coupled to TypeScript (regex-based locator extraction) and Playwright as the only driver. Selenium / Cypress / Appium / Python / JVM adapters (16–18, 20) can now be layered on top of `@pagemirror/snapshot-core` without duplicating bundle assembly.
 
 This roadmap broadens language/framework reach and tightens the inner dev loop so future work scales. It is organized into three tracks (A, B, C) that can progress semi-independently. Each roadmap item corresponds to one or more task docs under `docs/tasks/`.
 
@@ -10,7 +10,7 @@ This roadmap broadens language/framework reach and tightens the inner dev loop s
 
 ## Track A — Language Support
 
-Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same on-disk bundle format (`index.html` + `screenshot.webp` + `manifest.json`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
+Each language task has **two halves**: (1) IDE-side locator extraction so highlight/gutter work, and (2) a snapshot-saver sibling package in the target language so users can actually produce `.snapshots/` bundles from their non-TS test runs. The existing npm package cannot be consumed from Python/Java/Kotlin, so we ship native packages that reuse the same v2 on-disk bundle format (`index.html` + `manifest.json` + `resources/`) defined in `CLAUDE.md` and frozen in `docs/snapshot-bundle-spec.md`.
 
 - **A1. Python Playwright support** — `task-16-python-playwright-support.md`
 - **A2. Java/Kotlin Playwright support** — `task-18-jvm-playwright-support.md`
@@ -21,11 +21,11 @@ Shared prerequisite: freeze `docs/snapshot-bundle-spec.md` before A1/A2 implemen
 
 ## Track B — Snapshot Saver Consolidation & Multi-Framework
 
-- **B1. Extract framework-agnostic core** — `task-15-snapshot-core-extraction.md`
+- **B1. Extract framework-agnostic core — DONE** — `task-15-snapshot-core-extraction.md` (shipped as `packages/snapshot-core/`, with framework-agnostic trace rendering added in `task-15.5-trace-resource-inlining.md`).
 - **B2. Selenium + Cypress adapters** — `task-17-selenium-cypress-adapters.md`
 - **B3. Mobile environment support (Appium)** — `task-20-appium-mobile-support.md`
 
-B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
+B1 was a pure refactor; B2 and B3 layer new adapters on top of the extracted core.
 
 ---
 
@@ -43,14 +43,14 @@ B1 is a pure refactor; B2 and B3 layer new adapters on top of the extracted core
 
 ## Suggested Execution Order
 
-1. **C1a** — unblock UI tests (everything else benefits).
-2. **C1b–d** — reliability, diagnostics, page-object refactor.
-3. **C2** — get the Claude inner loop solid before adding scope.
-4. **B1** — refactor snapshot core (low risk, enables B2/B3).
+1. ~~**C1a** — unblock UI tests (everything else benefits).~~ Done.
+2. ~~**C1b–d** — reliability, diagnostics, page-object refactor.~~ Done.
+3. ~~**C2** — get the Claude inner loop solid before adding scope.~~ Done.
+4. ~~**B1** — refactor snapshot core (low risk, enables B2/B3).~~ Done (Tasks 15 & 15.5 shipped).
 5. **A1** — Python Playwright (highest user demand for language expansion).
 6. **B2** — Selenium/Cypress adapters.
 7. **A2** — Java/Kotlin Playwright.
-8. **C3** — demo reporting (depends on C1c trace format + C2 stable).
+8. ~~**C3** — demo reporting (depends on C1c trace format + C2 stable).~~ Done (Task 19).
 9. **B3** — mobile/Appium (largest unknowns).
 
 ---


### PR DESCRIPTION
## Summary

Realigns `CLAUDE.md` and `docs/Roadmap.md` with the current state of the code on `main`. Task 15 (extract `@pagemirror/snapshot-core`) and Task 15.5 (framework-agnostic trace rendering + resource inlining) both merged in April, but the summary docs still described Task 15 as in-progress on a feature branch and referenced the pre-Task-15 v1 bundle shape (`index.html` + top-level `screenshot.webp` + `manifest.json`). No code changes.

### Findings

- `packages/snapshot-core/` ships (owns `assemble-html.ts`, `manifest.ts`, `save-snapshot.ts`, and the `trace/{types,renderer,inline,extract,runtime-script,content-type}.ts` pipeline).
- `packages/playwright-snapshot-saver/` is a thin adapter on top of it (`playwright-adapter.ts` + `trace/playwright-backend.ts`).
- Test-project fixtures under `packages/test-project/.snapshots/` are in the v2 layout (`resources/<sha1>.css`, `resources/screenshot.*`, `manifest.json` with `"version": 2`).
- The plugin refuses v1 bundles via a user-visible outdated-bundle banner in the tool window (Task 15 + CHANGELOG 0.5.0).
- All other places I spot-checked already track the current code — `README.md`, `USE.md`, `docs/snapshot-bundle-spec.md`, `docs/migration-v1-to-v2.md`, `packages/*/README.md`, and CHANGELOG entries are consistent with what ships.

### Changes

**`CLAUDE.md`**
- Bump the completed-tasks summary from "0–14 and 19" to "0–15.5 and 19"; call out that bundles are on v2 and that the snapshot-saver is a thin adapter on top of `@pagemirror/snapshot-core`.
- Rewrite the Task 15 paragraph from "in progress on branch `claude/check-task-statuses-C7rh9`" to a shipped-state summary that names the key files (`assemble-html.ts`, `manifest.ts`, `playwright-adapter.ts`), explains the 16-hex-char CSS sidecar prefix used by the live saver vs the full-length sha1 used by trace-extracted bundles, mentions the outdated-bundle banner, and cross-links `docs/migration-v1-to-v2.md`.

**`docs/Roadmap.md`**
- Bump the completed-tasks range in the Context section and drop the "Task 15 below extracts…" future-tense framing.
- Fix the Track A bundle-format aside to reference the v2 layout (`index.html` + `manifest.json` + `resources/`) instead of the v1 shape.
- Mark **B1** as `DONE` with a pointer to Task 15.5, and past-tense the B1-is-a-refactor sentence.
- Strike through the finished items in the Suggested Execution Order (C1a, C1b–d, C2, B1, C3).

## Test plan

- [ ] `git diff main..HEAD -- CLAUDE.md docs/Roadmap.md` reads cleanly.
- [ ] No code changes → CI unit/UI/Playwright suites should be unaffected; watch the `test-report` job on this PR complete green anyway.

---
_Generated by [Claude Code](https://claude.ai/code/session_018qqXy5jAst5RGLuVAJbeFE)_